### PR TITLE
feat: `htmlToMarkdownSplitChunks`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 
 - 🧠 Custom built HTML to Markdown Convertor Optimized for LLMs (~50% fewer tokens)
 - 🔍 Generates [Minimal](./packages/mdream/src/preset/minimal.ts) GitHub Flavored Markdown: Frontmatter, Nested & HTML markup support.
+- ✂️ LangChain compatible [Markdown Text Splitter](#text-splitter) for single-pass chunking.
 - 🚀 Ultra Fast: Stream 1.4MB of HTML to markdown in ~50ms.
 - ⚡ Tiny: 6kB gzip, zero dependency core.
 - ⚙️ Run anywhere: [CLI Crawler](#mdream-crawl), [Docker](#docker-usage), [GitHub Actions](#github-actions-integration), [Vite](#vite-integration), & more.
@@ -250,6 +251,25 @@ console.log(markdown) // # Hello World
 ```
 
 See the [Mdream Package README](./packages/mdream/README.md) for complete documentation on API usage, streaming, presets, and the plugin system.
+
+## Text Splitter
+
+Mdream includes a [LangChain](https://python.langchain.com/api_reference/text_splitters/markdown/langchain_text_splitters.markdown.ExperimentalMarkdownSyntaxTextSplitter.html) compatible Markdown splitter that runs efficiently in single pass.
+
+This provides significant performance improvements over traditional multi-pass splitters and allows
+you to integrate with your custom Mdream plugins.
+
+```ts
+import { htmlToMarkdownSplitChunks } from 'mdream/splitter'
+
+const chunks = await htmlToMarkdownSplitChunks('<h1>Hello World</h1><p>This is a paragraph.</p>', {
+  chunkSize: 1000,
+  chunkOverlap: 200,
+})
+console.log(chunks) // Array of text chunks
+```
+
+See the [Text Splitter Documentation](./packages/mdream/docs/splitter.md) for complete usage and configuration.
 
 ## Credits
 

--- a/packages/mdream/build.config.ts
+++ b/packages/mdream/build.config.ts
@@ -7,7 +7,7 @@ export default defineBuildConfig({
   entries: [
     {
       type: 'bundle',
-      input: ['./src/index.ts', './src/cli.ts', './src/llms-txt.ts', './src/plugins.ts', './src/preset/minimal.ts'],
+      input: ['./src/index.ts', './src/cli.ts', './src/llms-txt.ts', './src/plugins.ts', './src/preset/minimal.ts', './src/splitter.ts'],
     },
     {
       type: 'bundle',

--- a/packages/mdream/docs/splitter.md
+++ b/packages/mdream/docs/splitter.md
@@ -1,0 +1,349 @@
+# HTML to Markdown Text Splitter
+
+The `htmlToMarkdownSplitChunks` function converts HTML to Markdown and intelligently splits it into chunks in a **single pass**. This is optimized for LLM applications and is compatible with LangChain's Document structure.
+
+## Basic Usage
+
+```typescript
+import { TAG_H2 } from 'mdream'
+import { htmlToMarkdownSplitChunks } from 'mdream/splitter'
+
+const html = `
+  <h1>Documentation</h1>
+  <p>Introduction text</p>
+
+  <h2>Installation</h2>
+  <p>Install via npm...</p>
+
+  <h2>Usage</h2>
+  <p>Basic example...</p>
+`
+
+const chunks = htmlToMarkdownSplitChunks(html, {
+  headersToSplitOn: [TAG_H2],
+})
+
+// Result:
+// [
+//   {
+//     content: "Introduction text\n\nInstall via npm...",
+//     metadata: {
+//       headers: { h1: "Documentation", h2: "Installation" },
+//       loc: { lines: { from: 1, to: 5 } }
+//     }
+//   },
+//   {
+//     content: "Basic example...",
+//     metadata: {
+//       headers: { h1: "Documentation", h2: "Usage" },
+//       loc: { lines: { from: 6, to: 8 } }
+//     }
+//   }
+// ]
+```
+
+## Configuration Options
+
+### `headersToSplitOn`
+
+Type: `number[]`
+Default: `[TAG_H2, TAG_H3, TAG_H4, TAG_H5, TAG_H6]`
+
+Array of header tag IDs to split on. Import tag constants from `mdream`:
+
+```typescript
+import { TAG_H1, TAG_H2, TAG_H3, TAG_H4, TAG_H5, TAG_H6 } from 'mdream'
+
+// Split on h1 and h2 only
+const chunks = htmlToMarkdownSplitChunks(html, {
+  headersToSplitOn: [TAG_H1, TAG_H2],
+})
+
+// Don't split on headers at all
+const chunksNoHeaders = htmlToMarkdownSplitChunks(html, {
+  headersToSplitOn: [],
+})
+```
+
+### `stripHeaders`
+
+Type: `boolean`
+Default: `true`
+
+Remove header lines from chunk content. Headers are always preserved in metadata.
+
+```typescript
+// Strip headers from content (default)
+const chunksNoHeaders = htmlToMarkdownSplitChunks(html, {
+  stripHeaders: true,
+})
+// chunks[0].content = "Content without header lines"
+
+// Keep headers in content
+const chunks = htmlToMarkdownSplitChunks(html, {
+  stripHeaders: false,
+})
+// chunks[0].content = "## Section\n\nContent with header"
+```
+
+### `chunkSize`
+
+Type: `number`
+Default: `1000`
+
+Maximum size of each chunk (measured by `lengthFunction`). Chunks may slightly exceed this due to element boundaries.
+
+```typescript
+const chunks = htmlToMarkdownSplitChunks(html, {
+  chunkSize: 500,
+  headersToSplitOn: [],
+})
+```
+
+### `chunkOverlap`
+
+Type: `number`
+Default: `200`
+
+Number of characters to overlap between chunks for context preservation. Must be less than `chunkSize`.
+
+```typescript
+const chunks = htmlToMarkdownSplitChunks(html, {
+  chunkSize: 1000,
+  chunkOverlap: 200,
+})
+// Last 200 chars of chunk[0] overlap with first 200 chars of chunk[1]
+```
+
+### `lengthFunction`
+
+Type: `(text: string) => number`
+Default: `(text) => text.length`
+
+Custom function to measure chunk length. Useful for token-based chunking.
+
+```typescript
+// Token-based chunking
+const chunks = htmlToMarkdownSplitChunks(html, {
+  chunkSize: 512, // 512 tokens
+  lengthFunction: text => encode(text).length, // Your tokenizer
+})
+
+// Word-based chunking
+const chunks = htmlToMarkdownSplitChunks(html, {
+  chunkSize: 100, // 100 words
+  lengthFunction: text => text.split(/\s+/).length,
+})
+```
+
+### `returnEachLine`
+
+Type: `boolean`
+Default: `false`
+
+Return each line as a separate chunk. Useful for processing documents line by line.
+
+```typescript
+const chunks = htmlToMarkdownSplitChunks(html, {
+  returnEachLine: true,
+})
+// Each paragraph becomes a separate chunk
+```
+
+### `origin`
+
+Type: `string`
+Optional
+
+Base URL for resolving relative links and images.
+
+```typescript
+const chunks = htmlToMarkdownSplitChunks(html, {
+  origin: 'https://example.com',
+})
+// <img src="/logo.png"> → ![](https://example.com/logo.png)
+```
+
+### `plugins`
+
+Type: `Plugin[]`
+Default: `[]`
+
+Plugins to extend HTML to Markdown conversion. See [Plugin Documentation](./plugins.md).
+
+```typescript
+import { readabilityPlugin } from 'mdream/plugins'
+
+const chunks = htmlToMarkdownSplitChunks(html, {
+  plugins: [readabilityPlugin()],
+})
+```
+
+## Chunk Structure
+
+Each chunk follows this structure:
+
+```typescript
+interface MarkdownChunk {
+  content: string
+  metadata: {
+    // Header hierarchy at this chunk position
+    headers?: {
+      h1?: string
+      h2?: string
+      h3?: string
+      h4?: string
+      h5?: string
+      h6?: string
+    }
+    // Code block language if chunk contains code
+    code?: string
+    // Line number range
+    loc?: {
+      lines: {
+        from: number
+        to: number
+      }
+    }
+  }
+}
+```
+
+## Use Cases
+
+### Split Documentation by Sections
+
+```typescript
+import { TAG_H2 } from 'mdream'
+import { htmlToMarkdownSplitChunks } from 'mdream/splitter'
+
+const chunks = htmlToMarkdownSplitChunks(documentationHtml, {
+  headersToSplitOn: [TAG_H2],
+  stripHeaders: true,
+})
+
+// Each h2 section becomes a separate chunk
+// Perfect for RAG applications
+```
+
+### Token-Limited LLM Context
+
+```typescript
+import { encode } from 'gpt-tokenizer'
+
+const chunks = htmlToMarkdownSplitChunks(html, {
+  chunkSize: 512, // Max tokens per chunk
+  chunkOverlap: 50, // Token overlap
+  lengthFunction: text => encode(text).length,
+  headersToSplitOn: [TAG_H2, TAG_H3],
+})
+
+// Send each chunk to LLM without exceeding token limits
+```
+
+### Preserve Context with Overlap
+
+```typescript
+const chunks = htmlToMarkdownSplitChunks(html, {
+  chunkSize: 1000,
+  chunkOverlap: 200,
+  headersToSplitOn: [TAG_H2],
+})
+
+// Overlapping content ensures context is preserved across chunks
+// Useful for semantic search and QA systems
+```
+
+### Split on Horizontal Rules
+
+```typescript
+const chunks = htmlToMarkdownSplitChunks(html, {
+  headersToSplitOn: [], // Don't split on headers
+  chunkSize: Infinity, // No size limit
+})
+
+// <hr> tags automatically create splits
+// Useful for documents with visual separators
+```
+
+### Extract Code Examples
+
+```typescript
+const chunks = htmlToMarkdownSplitChunks(html, {
+  headersToSplitOn: [TAG_H2],
+})
+
+const codeChunks = chunks.filter(chunk => chunk.metadata.code)
+
+codeChunks.forEach((chunk) => {
+  console.log(`Language: ${chunk.metadata.code}`)
+  console.log(`Code: ${chunk.content}`)
+})
+```
+
+## LangChain Compatibility
+
+Chunks are compatible with LangChain's `Document` structure:
+
+```typescript
+import { Document } from '@langchain/core/documents'
+import { htmlToMarkdownSplitChunks } from 'mdream/splitter'
+
+const chunks = htmlToMarkdownSplitChunks(html, {
+  headersToSplitOn: [TAG_H2],
+})
+
+// Convert to LangChain Documents
+const documents = chunks.map(chunk => new Document({
+  pageContent: chunk.content,
+  metadata: chunk.metadata,
+}))
+
+// Use with vector stores
+await vectorStore.addDocuments(documents)
+```
+
+## Advanced Examples
+
+### Multi-Level Header Splitting
+
+```typescript
+import { TAG_H2, TAG_H3 } from 'mdream'
+
+// Split on both h2 and h3
+const chunks = htmlToMarkdownSplitChunks(html, {
+  headersToSplitOn: [TAG_H2, TAG_H3],
+})
+
+// Header hierarchy preserved in metadata
+chunks.forEach((chunk) => {
+  const breadcrumb = [
+    chunk.metadata.headers?.h1,
+    chunk.metadata.headers?.h2,
+    chunk.metadata.headers?.h3,
+  ].filter(Boolean).join(' > ')
+
+  console.log(breadcrumb)
+})
+```
+
+### Custom Chunk Processing
+
+```typescript
+const chunks = htmlToMarkdownSplitChunks(html, {
+  headersToSplitOn: [TAG_H2],
+})
+
+// Group chunks by top-level header
+const grouped = chunks.reduce((acc, chunk) => {
+  const h1 = chunk.metadata.headers?.h1 || 'untitled'
+  acc[h1] = acc[h1] || []
+  acc[h1].push(chunk)
+  return acc
+}, {})
+
+// Process each group separately
+Object.entries(grouped).forEach(([h1, chunks]) => {
+  console.log(`Processing ${h1}: ${chunks.length} chunks`)
+})
+```

--- a/packages/mdream/package.json
+++ b/packages/mdream/package.json
@@ -54,6 +54,14 @@
         "default": "./dist/preset/minimal.mjs"
       },
       "default": "./dist/preset/minimal.mjs"
+    },
+    "./splitter": {
+      "types": "./dist/splitter.d.mts",
+      "import": {
+        "types": "./dist/splitter.d.mts",
+        "default": "./dist/splitter.mjs"
+      },
+      "default": "./dist/splitter.mjs"
     }
   },
   "main": "./dist/index.mjs",

--- a/packages/mdream/src/splitter.ts
+++ b/packages/mdream/src/splitter.ts
@@ -1,0 +1,281 @@
+import type { ParseState } from './parse'
+import type { ElementNode, MarkdownChunk, NodeEvent, SplitterOptions, TextNode } from './types'
+import {
+  ELEMENT_NODE,
+  NodeEventEnter,
+  NodeEventExit,
+  TAG_CODE,
+  TAG_H1,
+  TAG_H2,
+  TAG_H3,
+  TAG_H4,
+  TAG_H5,
+  TAG_H6,
+  TAG_HR,
+  TAG_PRE,
+  TEXT_NODE,
+} from './const.ts'
+import { createMarkdownProcessor } from './markdown-processor.ts'
+import { parseHtmlStream } from './parse.ts'
+import { processPluginsForEvent } from './plugin-processor.ts'
+
+const DEFAULT_HEADERS_TO_SPLIT_ON: number[] = [
+  TAG_H2,
+  TAG_H3,
+  TAG_H4,
+  TAG_H5,
+  TAG_H6,
+]
+
+function createOptions(options: SplitterOptions) {
+  return {
+    headersToSplitOn: options.headersToSplitOn ?? DEFAULT_HEADERS_TO_SPLIT_ON,
+    returnEachLine: options.returnEachLine ?? false,
+    stripHeaders: options.stripHeaders ?? true,
+    chunkSize: options.chunkSize ?? 1000,
+    chunkOverlap: options.chunkOverlap ?? 200,
+    lengthFunction: options.lengthFunction ?? ((text: string) => text.length),
+    keepSeparator: options.keepSeparator ?? false,
+    origin: options.origin,
+    plugins: options.plugins ?? [],
+  }
+}
+
+function getCodeLanguage(node: ElementNode): string {
+  const className = node.attributes?.class
+  if (!className)
+    return ''
+
+  const langParts = className
+    .split(' ')
+    .map(c => c.split('language-')[1])
+    .filter(Boolean)
+
+  return langParts.length > 0 ? langParts[0].trim() : ''
+}
+
+function shouldSplitOnHeader(tagId: number, options: ReturnType<typeof createOptions>): boolean {
+  return options.headersToSplitOn.includes(tagId)
+}
+
+/**
+ * Get current markdown content WITHOUT clearing buffers
+ */
+function getCurrentMarkdown(state: { regionContentBuffers: Map<number, string[]>, regionToggles: Map<number, boolean> }): string {
+  const fragments: string[] = []
+  for (const [regionId, content] of state.regionContentBuffers.entries()) {
+    const include = state.regionToggles.get(regionId)
+    if (include) {
+      fragments.push(...content)
+    }
+  }
+  return fragments.join('').trimStart()
+}
+
+/**
+ * Convert HTML to Markdown and split into chunks in single pass
+ * Chunks are created during HTML event processing
+ */
+export function htmlToMarkdownSplitChunks(
+  html: string,
+  options: SplitterOptions = {},
+): MarkdownChunk[] {
+  const opts = createOptions(options)
+
+  if (opts.chunkOverlap >= opts.chunkSize) {
+    throw new Error('chunkOverlap must be less than chunkSize')
+  }
+
+  // Create processor
+  const processor = createMarkdownProcessor({
+    origin: opts.origin,
+    plugins: opts.plugins,
+  })
+
+  // Chunking state
+  const chunks: MarkdownChunk[] = []
+  const headerHierarchy = new Map<number, string>()
+  const seenSplitHeaders = new Set<number>()
+  let currentChunkCodeLanguage = ''
+  let collectingHeaderText = false
+  let currentHeaderTagId: number | null = null
+  let currentHeaderText = ''
+  let lineNumber = 1
+  let lastChunkEndPosition = 0
+
+  function flushChunk() {
+    const currentMd = getCurrentMarkdown(processor.state)
+    const chunkContent = currentMd.slice(lastChunkEndPosition)
+
+    if (!chunkContent.trim())
+      return
+
+    const chunk: MarkdownChunk = {
+      content: chunkContent.trimEnd(),
+      metadata: {
+        loc: {
+          lines: {
+            from: lineNumber,
+            to: lineNumber + (chunkContent.match(/\n/g) || []).length,
+          },
+        },
+      },
+    }
+
+    // Add headers
+    if (headerHierarchy.size > 0) {
+      chunk.metadata.headers = {}
+      for (const [tagId, text] of headerHierarchy.entries()) {
+        const level = `h${tagId - TAG_H1 + 1}`
+        chunk.metadata.headers[level] = text
+      }
+    }
+
+    // Add code language
+    if (currentChunkCodeLanguage) {
+      chunk.metadata.code = currentChunkCodeLanguage
+    }
+
+    chunks.push(chunk)
+
+    // Reset code language for next chunk
+    currentChunkCodeLanguage = ''
+
+    // Handle overlap
+    if (opts.chunkOverlap > 0) {
+      const overlapText = chunkContent.slice(-opts.chunkOverlap)
+      lastChunkEndPosition = currentMd.length - overlapText.length
+    }
+    else {
+      lastChunkEndPosition = currentMd.length
+    }
+
+    lineNumber += (chunkContent.match(/\n/g) || []).length
+  }
+
+  // Process HTML with event interception
+  const parseState: ParseState = {
+    depthMap: processor.state.depthMap,
+    depth: 0,
+    plugins: opts.plugins,
+  }
+
+  parseHtmlStream(html, parseState, (event: NodeEvent) => {
+    const { type: eventType, node } = event
+
+    // Track metadata before processing
+    if (node.type === ELEMENT_NODE) {
+      const element = node as ElementNode
+      const tagId = element.tagId
+
+      // Track headers
+      if (tagId && tagId >= TAG_H1 && tagId <= TAG_H6) {
+        if (eventType === NodeEventEnter) {
+          collectingHeaderText = true
+          currentHeaderTagId = tagId
+          currentHeaderText = ''
+
+          // Check if should split BEFORE processing this header
+          if (shouldSplitOnHeader(tagId, opts)) {
+            // Only flush if we've seen this header level before (not the first occurrence)
+            if (seenSplitHeaders.has(tagId)) {
+              flushChunk()
+              // Clear lower-level headers
+              for (let i = tagId; i <= TAG_H6; i++) {
+                headerHierarchy.delete(i)
+              }
+            }
+            seenSplitHeaders.add(tagId)
+          }
+        }
+        else if (eventType === NodeEventExit && currentHeaderTagId === tagId) {
+          headerHierarchy.set(tagId, currentHeaderText.trim())
+          collectingHeaderText = false
+          currentHeaderTagId = null
+        }
+      }
+
+      // Track code blocks
+      if (tagId === TAG_CODE && element.depthMap[TAG_PRE] > 0) {
+        if (eventType === NodeEventEnter) {
+          const lang = getCodeLanguage(element)
+          if (lang && !currentChunkCodeLanguage) {
+            currentChunkCodeLanguage = lang
+          }
+        }
+      }
+
+      // Split on HR BEFORE processing it
+      if (tagId === TAG_HR && eventType === NodeEventEnter) {
+        flushChunk()
+      }
+    }
+
+    // Collect header text
+    if (collectingHeaderText && node.type === TEXT_NODE) {
+      const textNode = node as TextNode
+      currentHeaderText += textNode.value
+    }
+
+    // Process event (generates markdown)
+    processPluginsForEvent(event, opts.plugins, processor.state, processor.processEvent)
+
+    // Check size-based splitting AFTER processing
+    if (!opts.returnEachLine) {
+      const currentMd = getCurrentMarkdown(processor.state)
+      const currentChunkSize = opts.lengthFunction(currentMd.slice(lastChunkEndPosition))
+
+      if (currentChunkSize > opts.chunkSize) {
+        flushChunk()
+      }
+    }
+  })
+
+  // Flush final chunk
+  flushChunk()
+
+  // Handle returnEachLine mode - split chunks into individual lines
+  if (opts.returnEachLine && chunks.length > 0) {
+    const lineChunks: MarkdownChunk[] = []
+
+    for (const chunk of chunks) {
+      const lines = chunk.content.split('\n')
+      const chunkStartLine = chunk.metadata.loc?.lines.from || 1
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i]
+        if (line.trim()) {
+          lineChunks.push({
+            content: line,
+            metadata: {
+              ...chunk.metadata,
+              loc: {
+                lines: {
+                  from: chunkStartLine + i,
+                  to: chunkStartLine + i,
+                },
+              },
+            },
+          })
+        }
+      }
+    }
+
+    return lineChunks
+  }
+
+  // Strip headers if requested
+  if (opts.stripHeaders) {
+    for (const chunk of chunks) {
+      chunk.content = chunk.content
+        .split('\n')
+        .filter(line => !line.match(/^#{1,6}\s+/))
+        .join('\n')
+        .trim()
+    }
+  }
+
+  return chunks
+}
+
+export type { MarkdownChunk, SplitterOptions } from './types'

--- a/packages/mdream/src/types.ts
+++ b/packages/mdream/src/types.ts
@@ -311,3 +311,76 @@ export interface PluginContext {
   // Allow additional plugin-specific data
   [key: string]: unknown
 }
+
+/**
+ * Markdown chunk with content and metadata
+ * Compatible with LangChain Document structure
+ */
+export interface MarkdownChunk {
+  /** The markdown content of the chunk */
+  content: string
+  /** Metadata extracted during chunking */
+  metadata: {
+    /** Header hierarchy at this chunk position */
+    headers?: Record<string, string>
+    /** Code block language if chunk is/contains code */
+    code?: string
+    /** Line number range in original document */
+    loc?: {
+      lines: {
+        from: number
+        to: number
+      }
+    }
+  }
+}
+
+/**
+ * Options for HTML to Markdown chunking
+ * Extends HTMLToMarkdownOptions with chunking-specific settings
+ */
+export interface SplitterOptions extends HTMLToMarkdownOptions {
+  /**
+   * Header tag IDs to split on (TAG_H1, TAG_H2, etc.)
+   * @example [TAG_H1, TAG_H2]
+   * @default [TAG_H2, TAG_H3, TAG_H4, TAG_H5, TAG_H6]
+   */
+  headersToSplitOn?: number[]
+
+  /**
+   * Return each line as individual chunk
+   * @default false
+   */
+  returnEachLine?: boolean
+
+  /**
+   * Strip headers from chunk content
+   * @default true
+   */
+  stripHeaders?: boolean
+
+  /**
+   * Maximum chunk size
+   * @default 1000
+   */
+  chunkSize?: number
+
+  /**
+   * Overlap between chunks for context preservation
+   * @default 200
+   */
+  chunkOverlap?: number
+
+  /**
+   * Function to measure chunk length (default: character count)
+   * Can be replaced with token counter for LLM applications
+   * @default (text) => text.length
+   */
+  lengthFunction?: (text: string) => number
+
+  /**
+   * Keep separators in the split chunks
+   * @default false
+   */
+  keepSeparator?: boolean
+}

--- a/packages/mdream/test/unit/splitter.test.ts
+++ b/packages/mdream/test/unit/splitter.test.ts
@@ -1,0 +1,871 @@
+import { describe, expect, it } from 'vitest'
+import { TAG_H1, TAG_H2 } from '../../src/const'
+import { htmlToMarkdownSplitChunks } from '../../src/splitter'
+
+describe('htmlToMarkdownSplitChunks', () => {
+  it('splits on h2 headers by default', () => {
+    const html = `
+      <h1>Main Title</h1>
+      <p>Introduction</p>
+      <h2>Section 1</h2>
+      <p>Content 1</p>
+      <h2>Section 2</h2>
+      <p>Content 2</p>
+    `
+
+    const chunks = htmlToMarkdownSplitChunks(html)
+
+    expect(chunks.length).toBeGreaterThan(0)
+    expect(chunks[0].metadata.headers).toBeDefined()
+  })
+
+  it('tracks header hierarchy in metadata', () => {
+    const html = `
+      <h1>Title</h1>
+      <h2>Section</h2>
+      <h3>Subsection</h3>
+      <p>Content</p>
+    `
+
+    const chunks = htmlToMarkdownSplitChunks(html, {
+      headersToSplitOn: [TAG_H2],
+    })
+
+    expect(chunks.length).toBeGreaterThan(0)
+    const lastChunk = chunks[chunks.length - 1]
+    expect(lastChunk.metadata.headers).toBeDefined()
+    expect(lastChunk.metadata.headers?.h1).toBe('Title')
+    expect(lastChunk.metadata.headers?.h2).toBe('Section')
+    expect(lastChunk.metadata.headers?.h3).toBe('Subsection')
+  })
+
+  it('splits on custom headers', () => {
+    const html = `
+      <h1>Title</h1>
+      <p>Intro</p>
+      <h2>Section 1</h2>
+      <p>Content 1</p>
+      <h2>Section 2</h2>
+      <p>Content 2</p>
+    `
+
+    const chunks = htmlToMarkdownSplitChunks(html, {
+      headersToSplitOn: [TAG_H1],
+    })
+
+    expect(chunks.length).toBeGreaterThan(0)
+  })
+
+  it('strips headers from content when stripHeaders is true', () => {
+    const html = `
+      <h2>Section</h2>
+      <p>Content here</p>
+    `
+
+    const chunks = htmlToMarkdownSplitChunks(html, {
+      stripHeaders: true,
+      headersToSplitOn: [TAG_H2],
+    })
+
+    expect(chunks.length).toBeGreaterThan(0)
+    expect(chunks[0].content).not.toContain('## Section')
+    expect(chunks[0].content).toContain('Content here')
+  })
+
+  it('keeps headers in content when stripHeaders is false', () => {
+    const html = `
+      <h2>Section</h2>
+      <p>Content here</p>
+    `
+
+    const chunks = htmlToMarkdownSplitChunks(html, {
+      stripHeaders: false,
+      headersToSplitOn: [TAG_H2],
+    })
+
+    expect(chunks.length).toBeGreaterThan(0)
+    expect(chunks[0].content).toContain('## Section')
+  })
+
+  it('extracts code block language to metadata', () => {
+    const html = `
+      <pre><code class="language-javascript">
+        const x = 1;
+      </code></pre>
+    `
+
+    const chunks = htmlToMarkdownSplitChunks(html)
+
+    expect(chunks.length).toBeGreaterThan(0)
+    expect(chunks[0].metadata.code).toBe('javascript')
+  })
+
+  it('splits on horizontal rules', () => {
+    const html = `
+      <p>Section 1</p>
+      <hr>
+      <p>Section 2</p>
+      <hr>
+      <p>Section 3</p>
+    `
+
+    const chunks = htmlToMarkdownSplitChunks(html, {
+      headersToSplitOn: [], // Don't split on headers
+    })
+
+    expect(chunks.length).toBeGreaterThan(1)
+  })
+
+  it('respects chunkSize limit', () => {
+    const html = `
+      <p>${'a'.repeat(1500)}</p>
+      <p>${'b'.repeat(1500)}</p>
+    `
+
+    const chunks = htmlToMarkdownSplitChunks(html, {
+      chunkSize: 1000,
+      headersToSplitOn: [],
+    })
+
+    expect(chunks.length).toBeGreaterThan(1)
+    for (const chunk of chunks) {
+      // Some chunks may slightly exceed due to element boundaries (not splitting mid-element)
+      expect(chunk.content.length).toBeLessThanOrEqual(1800)
+    }
+  })
+
+  it('maintains chunk overlap', () => {
+    const html = `
+      <p>Line 1</p>
+      <p>Line 2</p>
+      <p>Line 3</p>
+      <p>Line 4</p>
+      <p>Line 5</p>
+    `
+
+    const chunks = htmlToMarkdownSplitChunks(html, {
+      chunkSize: 50,
+      chunkOverlap: 20,
+      headersToSplitOn: [],
+    })
+
+    if (chunks.length > 1) {
+      // Check that there's some overlapping content
+      const firstChunkEnd = chunks[0].content.slice(-20)
+      const secondChunkStart = chunks[1].content.slice(0, 20)
+      // There should be some similarity
+      expect(chunks.length).toBeGreaterThan(1)
+    }
+  })
+
+  it('returns each line as chunk when returnEachLine is true', () => {
+    const html = `
+      <p>Line 1</p>
+      <p>Line 2</p>
+      <p>Line 3</p>
+    `
+
+    const chunks = htmlToMarkdownSplitChunks(html, {
+      returnEachLine: true,
+      headersToSplitOn: [],
+    })
+
+    expect(chunks.length).toBeGreaterThan(2)
+  })
+
+  it('uses custom length function', () => {
+    const html = `
+      <p>${'word '.repeat(100)}</p>
+      <p>${'word '.repeat(100)}</p>
+    `
+
+    const wordCountFn = (text: string) => text.split(/\s+/).length
+
+    const chunks = htmlToMarkdownSplitChunks(html, {
+      chunkSize: 50, // 50 words
+      chunkOverlap: 10,
+      lengthFunction: wordCountFn,
+      headersToSplitOn: [],
+    })
+
+    expect(chunks.length).toBeGreaterThan(1)
+  })
+
+  it('tracks line numbers in metadata', () => {
+    const html = `
+      <p>Line 1</p>
+      <p>Line 2</p>
+      <h2>Section</h2>
+      <p>Line 4</p>
+    `
+
+    const chunks = htmlToMarkdownSplitChunks(html, {
+      headersToSplitOn: [TAG_H2],
+    })
+
+    expect(chunks.length).toBeGreaterThan(0)
+    for (const chunk of chunks) {
+      expect(chunk.metadata.loc).toBeDefined()
+      expect(chunk.metadata.loc?.lines.from).toBeGreaterThan(0)
+      expect(chunk.metadata.loc?.lines.to).toBeGreaterThanOrEqual(chunk.metadata.loc?.lines.from)
+    }
+  })
+
+  it('handles nested headers correctly', () => {
+    const html = `
+      <h1>Level 1</h1>
+      <h2>Level 2A</h2>
+      <p>Content A</p>
+      <h3>Level 3</h3>
+      <p>Content 3</p>
+      <h2>Level 2B</h2>
+      <p>Content B</p>
+    `
+
+    const chunks = htmlToMarkdownSplitChunks(html, {
+      headersToSplitOn: [TAG_H2],
+    })
+
+    expect(chunks.length).toBeGreaterThan(1)
+
+    // First chunk should have h1 and h2A
+    const firstChunk = chunks[0]
+    expect(firstChunk.metadata.headers?.h1).toBe('Level 1')
+    expect(firstChunk.metadata.headers?.h2).toBe('Level 2A')
+
+    // Last chunk should have h1 and h2B
+    const lastChunk = chunks[chunks.length - 1]
+    expect(lastChunk.metadata.headers?.h1).toBe('Level 1')
+    expect(lastChunk.metadata.headers?.h2).toBe('Level 2B')
+  })
+
+  it('handles complex HTML with multiple features', () => {
+    const html = `
+      <h1>Documentation</h1>
+      <p>Introduction text</p>
+
+      <h2>Installation</h2>
+      <p>Install via npm:</p>
+      <pre><code class="language-bash">npm install mdream</code></pre>
+
+      <h2>Usage</h2>
+      <p>Basic example:</p>
+      <pre><code class="language-javascript">
+        import { htmlToMarkdown } from 'mdream'
+        const md = htmlToMarkdown(html)
+      </code></pre>
+
+      <hr>
+
+      <h2>Advanced</h2>
+      <p>More advanced features</p>
+    `
+
+    const chunks = htmlToMarkdownSplitChunks(html, {
+      headersToSplitOn: [TAG_H2],
+    })
+
+    expect(chunks.length).toBeGreaterThan(2)
+
+    // Check that code blocks are detected
+    const codeChunks = chunks.filter(c => c.metadata.code)
+    expect(codeChunks.length).toBeGreaterThan(0)
+
+    // Check header hierarchy
+    expect(chunks.some(c => c.metadata.headers?.h2 === 'Installation')).toBe(true)
+    expect(chunks.some(c => c.metadata.headers?.h2 === 'Usage')).toBe(true)
+  })
+
+  it('throws error when chunkOverlap >= chunkSize', () => {
+    const html = '<p>Test</p>'
+
+    expect(() => {
+      htmlToMarkdownSplitChunks(html, {
+        chunkSize: 100,
+        chunkOverlap: 100,
+      })
+    }).toThrow('chunkOverlap must be less than chunkSize')
+  })
+
+  it('handles empty HTML', () => {
+    const chunks = htmlToMarkdownSplitChunks('')
+    expect(chunks).toEqual([])
+  })
+
+  it('handles HTML with only whitespace', () => {
+    const chunks = htmlToMarkdownSplitChunks('   \n  \n  ')
+    expect(chunks.length).toBeLessThanOrEqual(1)
+  })
+
+  it('integrates with HTMLToMarkdownOptions', () => {
+    const html = `
+      <h2>Section</h2>
+      <p>Check out <a href="/page">this link</a></p>
+      <img src="/image.png" alt="Test">
+    `
+
+    const chunks = htmlToMarkdownSplitChunks(html, {
+      origin: 'https://example.com',
+      headersToSplitOn: [TAG_H2],
+    })
+
+    expect(chunks.length).toBeGreaterThan(0)
+    expect(chunks[0].content).toContain('https://example.com/page')
+    expect(chunks[0].content).toContain('https://example.com/image.png')
+  })
+
+  // Edge Cases
+  describe('edge cases', () => {
+    it('handles consecutive headers with no content', () => {
+      const html = `
+        <h1>Title</h1>
+        <h2>Section 1</h2>
+        <h2>Section 2</h2>
+        <h2>Section 3</h2>
+        <p>Finally some content</p>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+        stripHeaders: false,
+      })
+
+      expect(chunks.length).toBeGreaterThan(0)
+      expect(chunks[0].content).toMatchInlineSnapshot(`
+        "# Title
+
+        ## Section 1"
+      `)
+    })
+
+    it('handles headers with inline formatting', () => {
+      const html = `
+        <h2>Section with <strong>bold</strong> and <em>italic</em></h2>
+        <p>Content here</p>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+      })
+
+      expect(chunks.length).toBeGreaterThan(0)
+      expect(chunks[0].metadata.headers?.h2).toBe('Section with bold and italic')
+    })
+
+    it('handles headers with links', () => {
+      const html = `
+        <h2>Check out <a href="https://example.com">this link</a></h2>
+        <p>Content</p>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+      })
+
+      expect(chunks[0].metadata.headers?.h2).toBe('Check out this link')
+    })
+
+    it('handles skipped header levels', () => {
+      const html = `
+        <h1>Level 1</h1>
+        <h3>Level 3 (skipped h2)</h3>
+        <p>Content</p>
+        <h5>Level 5 (skipped h4)</h5>
+        <p>More content</p>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+      })
+
+      expect(chunks[0].metadata.headers?.h1).toBe('Level 1')
+      expect(chunks[0].metadata.headers?.h3).toBe('Level 3 (skipped h2)')
+      expect(chunks[0].metadata.headers?.h5).toBe('Level 5 (skipped h4)')
+    })
+
+    it('handles backwards header levels', () => {
+      const html = `
+        <h3>Starting at h3</h3>
+        <p>Content 1</p>
+        <h1>Going back to h1</h1>
+        <p>Content 2</p>
+        <h2>Then h2</h2>
+        <p>Content 3</p>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+        stripHeaders: false,
+      })
+
+      expect(chunks.length).toBeGreaterThan(0)
+      const lastChunk = chunks[chunks.length - 1]
+      expect(lastChunk.metadata.headers?.h1).toBe('Going back to h1')
+      expect(lastChunk.metadata.headers?.h2).toBe('Then h2')
+    })
+
+    it('handles multiple code blocks with different languages', () => {
+      const html = `
+        <h2>Code Examples</h2>
+        <pre><code class="language-javascript">const x = 1;</code></pre>
+        <pre><code class="language-python">x = 1</code></pre>
+        <pre><code class="language-rust">let x = 1;</code></pre>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [],
+      })
+
+      // Should track the first code language found
+      expect(chunks[0].metadata.code).toBe('javascript')
+    })
+
+    it('handles code blocks without language class', () => {
+      const html = `
+        <pre><code>const x = 1;</code></pre>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html)
+
+      expect(chunks[0].metadata.code).toBeUndefined()
+    })
+
+    it('handles very small chunk sizes', () => {
+      const html = `
+        <p>Short paragraph one</p>
+        <p>Short paragraph two</p>
+        <p>Short paragraph three</p>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        chunkSize: 10,
+        chunkOverlap: 2,
+        headersToSplitOn: [],
+      })
+
+      expect(chunks.length).toBeGreaterThan(1)
+      for (const chunk of chunks) {
+        expect(chunk.content).toBeTruthy()
+      }
+    })
+
+    it('handles chunk size of 1', () => {
+      const html = `<p>Hi</p>`
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        chunkSize: 1,
+        chunkOverlap: 0,
+        headersToSplitOn: [],
+      })
+
+      expect(chunks.length).toBeGreaterThan(0)
+    })
+
+    it('handles headers with special characters', () => {
+      const html = `
+        <h2>Section & Title with "quotes" and 'apostrophes'</h2>
+        <p>Content</p>
+        <h2>Math: 2 &lt; 3 &gt; 1</h2>
+        <p>More</p>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+      })
+
+      expect(chunks.length).toBe(2)
+      expect(chunks[0].metadata.headers?.h2).toBe(`Section & Title with "quotes" and 'apostrophes'`)
+      expect(chunks[1].metadata.headers?.h2).toBe('Math: 2 < 3 > 1')
+    })
+
+    it('handles HTML entities in headers', () => {
+      const html = `
+        <h2>Section &amp; Title &lt;tag&gt;</h2>
+        <p>Content</p>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+      })
+
+      expect(chunks[0].metadata.headers?.h2).toBe('Section & Title <tag>')
+    })
+
+    it('handles nested lists with headers', () => {
+      const html = `
+        <h2>Todo List</h2>
+        <ul>
+          <li>Item 1
+            <ul>
+              <li>Nested 1</li>
+              <li>Nested 2</li>
+            </ul>
+          </li>
+          <li>Item 2</li>
+        </ul>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+      })
+
+      expect(chunks.length).toBeGreaterThan(0)
+      expect(chunks[0].content).toContain('Item 1')
+      expect(chunks[0].content).toContain('Nested 1')
+    })
+
+    it('handles tables in chunks', () => {
+      const html = `
+        <h2>Data Table</h2>
+        <table>
+          <thead>
+            <tr><th>Name</th><th>Value</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>A</td><td>1</td></tr>
+            <tr><td>B</td><td>2</td></tr>
+          </tbody>
+        </table>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+        stripHeaders: false,
+      })
+
+      expect(chunks[0].content).toContain('|')
+      expect(chunks[0].content).toContain('Name')
+      expect(chunks[0].content).toContain('Value')
+    })
+
+    it('handles blockquotes', () => {
+      const html = `
+        <h2>Quotes</h2>
+        <blockquote>
+          <p>This is a quote</p>
+          <p>Multiple paragraphs</p>
+        </blockquote>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+        stripHeaders: false,
+      })
+
+      expect(chunks[0].content).toContain('>')
+      expect(chunks[0].content).toContain('This is a quote')
+    })
+
+    it('handles empty paragraph elements', () => {
+      const html = `
+        <h2>Section</h2>
+        <p></p>
+        <p>Content</p>
+        <p></p>
+        <p>More</p>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+      })
+
+      expect(chunks.length).toBeGreaterThan(0)
+      expect(chunks[0].content).toContain('Content')
+    })
+
+    it('handles only headers, no other content', () => {
+      const html = `
+        <h1>Title</h1>
+        <h2>Section 1</h2>
+        <h2>Section 2</h2>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+        stripHeaders: false,
+      })
+
+      expect(chunks[0].content).toMatchInlineSnapshot(`
+        "# Title
+
+        ## Section 1"
+      `)
+    })
+
+    it('handles HR between headers', () => {
+      const html = `
+        <h2>Section 1</h2>
+        <hr>
+        <h2>Section 2</h2>
+        <hr>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+        stripHeaders: false,
+      })
+
+      expect(chunks.length).toBeGreaterThan(1)
+    })
+
+    it('handles mixed content with all features', () => {
+      const html = `
+        <h1>Documentation</h1>
+        <p>Introduction with <strong>bold</strong> and <em>italic</em></p>
+
+        <h2>Section 1</h2>
+        <ul>
+          <li>Item 1</li>
+          <li>Item 2</li>
+        </ul>
+
+        <h2>Section 2</h2>
+        <blockquote>Important note</blockquote>
+        <pre><code class="language-js">const x = 1;</code></pre>
+
+        <hr>
+
+        <h2>Section 3</h2>
+        <table>
+          <tr><td>A</td><td>1</td></tr>
+        </table>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+      })
+
+      expect(chunks.length).toBeGreaterThan(2)
+
+      // Check first chunk has h1 and h2
+      expect(chunks[0].metadata.headers?.h1).toBe('Documentation')
+      expect(chunks[0].metadata.headers?.h2).toBe('Section 1')
+
+      // Check code language tracked
+      const codeChunk = chunks.find(c => c.metadata.code)
+      expect(codeChunk?.metadata.code).toBe('js')
+    })
+
+    it('handles returnEachLine with headers', () => {
+      const html = `
+        <h2>Section</h2>
+        <p>Line 1</p>
+        <p>Line 2</p>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        returnEachLine: true,
+        headersToSplitOn: [TAG_H2],
+        stripHeaders: false,
+      })
+
+      expect(chunks.length).toBeGreaterThan(2)
+      expect(chunks.some(c => c.content.includes('## Section'))).toBe(true)
+    })
+
+    it('handles overlap larger than content', () => {
+      const html = `<p>Hi</p>`
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        chunkSize: 100,
+        chunkOverlap: 50,
+        headersToSplitOn: [],
+      })
+
+      expect(chunks.length).toBe(1)
+      expect(chunks[0].content).toBe('Hi')
+    })
+
+    it('handles multiple h1 headers', () => {
+      const html = `
+        <h1>First Title</h1>
+        <p>Content 1</p>
+        <h1>Second Title</h1>
+        <p>Content 2</p>
+        <h1>Third Title</h1>
+        <p>Content 3</p>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H1],
+      })
+
+      expect(chunks.length).toBe(3)
+      expect(chunks[0].metadata.headers?.h1).toBe('First Title')
+      expect(chunks[1].metadata.headers?.h1).toBe('Second Title')
+      expect(chunks[2].metadata.headers?.h1).toBe('Third Title')
+    })
+
+    it('handles header text extraction with nested elements', () => {
+      const html = `
+        <h2>
+          <span>Nested</span>
+          <strong>Bold</strong>
+          <em>Italic</em>
+        </h2>
+        <p>Content</p>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+      })
+
+      expect(chunks[0].metadata.headers?.h2).toBe('Nested Bold Italic')
+    })
+
+    it('preserves header hierarchy when splitting on h3', () => {
+      const html = `
+        <h1>Title</h1>
+        <h2>Section</h2>
+        <h3>Subsection A</h3>
+        <p>Content A</p>
+        <h3>Subsection B</h3>
+        <p>Content B</p>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+      })
+
+      // Should have h1, h2, and both h3s in metadata
+      const chunk = chunks[chunks.length - 1]
+      expect(chunk.metadata.headers?.h1).toBe('Title')
+      expect(chunk.metadata.headers?.h2).toBe('Section')
+      expect(chunk.metadata.headers?.h3).toBe('Subsection B')
+    })
+
+    it('handles images in content', () => {
+      const html = `
+        <h2>Images</h2>
+        <p>Check this out:</p>
+        <img src="/test.png" alt="Test Image">
+        <p>Nice!</p>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+        origin: 'https://example.com',
+      })
+
+      expect(chunks[0].content).toContain('![Test Image](https://example.com/test.png)')
+    })
+
+    it('handles definition lists', () => {
+      const html = `
+        <h2>Definitions</h2>
+        <dl>
+          <dt>Term 1</dt>
+          <dd>Definition 1</dd>
+          <dt>Term 2</dt>
+          <dd>Definition 2</dd>
+        </dl>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+      })
+
+      expect(chunks[0].content).toContain('Term 1')
+      expect(chunks[0].content).toContain('Definition 1')
+    })
+
+    it('handles pre without code', () => {
+      const html = `
+        <h2>Preformatted</h2>
+        <pre>This is preformatted text
+with preserved   spacing</pre>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+      })
+
+      expect(chunks[0].content).toContain('This is preformatted text')
+    })
+
+    it('clears code language between chunks', () => {
+      const html = `
+        <h2>Section 1</h2>
+        <pre><code class="language-javascript">const x = 1;</code></pre>
+        <h2>Section 2</h2>
+        <p>No code here</p>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+      })
+
+      expect(chunks.length).toBe(2)
+      expect(chunks[0].metadata.code).toBe('javascript')
+      expect(chunks[1].metadata.code).toBeUndefined()
+    })
+
+    it('handles line numbers correctly across splits', () => {
+      const html = `
+        <p>Line 1</p>
+        <h2>Split here</h2>
+        <p>Line 3</p>
+        <h2>Split again</h2>
+        <p>Line 5</p>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+      })
+
+      expect(chunks.length).toBe(2)
+      expect(chunks[0].metadata.loc?.lines.from).toBe(1)
+      // Line numbers track markdown lines, which are cumulative
+      expect(chunks[0].metadata.loc?.lines.to).toBeGreaterThanOrEqual(1)
+      expect(chunks[1].metadata.loc?.lines.from).toBeGreaterThanOrEqual(chunks[0].metadata.loc?.lines.to)
+    })
+
+    it('produces consistent output for same input', () => {
+      const html = `
+        <h1>Title</h1>
+        <h2>Section</h2>
+        <p>Content</p>
+      `
+
+      const chunks1 = htmlToMarkdownSplitChunks(html, { headersToSplitOn: [TAG_H2] })
+      const chunks2 = htmlToMarkdownSplitChunks(html, { headersToSplitOn: [TAG_H2] })
+
+      expect(chunks1).toEqual(chunks2)
+    })
+
+    it('handles whitespace-only paragraphs', () => {
+      const html = `
+        <h2>Section</h2>
+        <p>   </p>
+        <p>Content</p>
+        <p>
+        </p>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+      })
+
+      expect(chunks[0].content.trim()).toBe('Content')
+    })
+
+    it('handles deeply nested structures', () => {
+      const html = `
+        <h2>Section</h2>
+        <div>
+          <div>
+            <div>
+              <p>Deeply nested content</p>
+            </div>
+          </div>
+        </div>
+      `
+
+      const chunks = htmlToMarkdownSplitChunks(html, {
+        headersToSplitOn: [TAG_H2],
+      })
+
+      expect(chunks[0].content).toContain('Deeply nested content')
+    })
+  })
+})


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description


The `htmlToMarkdownSplitChunks` function converts HTML to Markdown and intelligently splits it into chunks in a **single pass**. This is optimized for LLM applications and is compatible with [LangChain's Markdown Splitter](https://python.langchain.com/api_reference/text_splitters/markdown/langchain_text_splitters.markdown.ExperimentalMarkdownSyntaxTextSplitter.html).

**Basic Usage**

```typescript
import { TAG_H2 } from 'mdream'
import { htmlToMarkdownSplitChunks } from 'mdream/splitter'

const html = `
  <h1>Documentation</h1>
  <p>Introduction text</p>

  <h2>Installation</h2>
  <p>Install via npm...</p>

  <h2>Usage</h2>
  <p>Basic example...</p>
`

const chunks = htmlToMarkdownSplitChunks(html, {
  headersToSplitOn: [TAG_H2],
})

// Result:
// [
//   {
//     content: "Introduction text\n\nInstall via npm...",
//     metadata: {
//       headers: { h1: "Documentation", h2: "Installation" },
//       loc: { lines: { from: 1, to: 5 } }
//     }
//   },
//   {
//     content: "Basic example...",
//     metadata: {
//       headers: { h1: "Documentation", h2: "Usage" },
//       loc: { lines: { from: 6, to: 8 } }
//     }
//   }
// ]
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
