### PR TITLE
fix: block spacing inside span elements

### DIFF
--- a/packages/mdream/src/markdown-processor.ts
+++ b/packages/mdream/src/markdown-processor.ts
@@ -9,8 +9,13 @@ import {
   NodeEventEnter,
   NodeEventExit,
   TAG_BLOCKQUOTE,
+  TAG_DIV,
+  TAG_H1,
+  TAG_H6,
   TAG_LI,
+  TAG_P,
   TAG_PRE,
+  TAG_SPAN,
   TAG_TABLE,
   TEXT_NODE,
 } from './const.ts'
@@ -100,9 +105,17 @@ function calculateNewLineConfig(node: ElementNode): readonly [number, number] {
   }
 
   // Adjust for inline elements
+  // Block elements preserve spacing even inside span elements (presentational containers)
+  // because spans shouldn't affect block-level semantics of their children
+  const isBlockElement = tagId !== undefined && ((tagId >= TAG_H1 && tagId <= TAG_H6) || tagId === TAG_P || tagId === TAG_DIV)
   let currParent = node.parent
   while (currParent) {
     if (currParent.tagHandler?.collapsesInnerWhiteSpace) {
+      // Exception: preserve block spacing when inside span (presentational wrapper)
+      if (isBlockElement && currParent.tagId === TAG_SPAN) {
+        currParent = currParent.parent
+        continue
+      }
       return NO_SPACING
     }
     currParent = currParent.parent

--- a/packages/mdream/test/unit/nodes/spacing.test.ts
+++ b/packages/mdream/test/unit/nodes/spacing.test.ts
@@ -40,4 +40,14 @@ describe('spacing', () => {
     const markdown = htmlToMarkdown(html)
     expect(markdown).toMatchInlineSnapshot(`"[a](b) [b](a)"`)
   })
+
+  it('block elements inside inline elements should have proper spacing', () => {
+    const html = '<span><h4>Heading</h4><p>This is a paragraph with <strong>bold</strong> text.</p></span>'
+    const markdown = htmlToMarkdown(html)
+    expect(markdown).toMatchInlineSnapshot(`
+      "#### Heading
+
+      This is a paragraph with **bold** text."
+    `)
+  })
 })


### PR DESCRIPTION
## Problem

When converting HTML to Markdown, block-level elements (h1-h6, p, div) inside `<span>` elements were not getting proper newline spacing. They were being collapsed into inline content.

**Real-world example:**

The HTML from https://thehub.io/jobs/68e7a5960c688c2ac659be70 contains:

```html
<span><h4>Our Journey 🎯</h4><p>At Quiver...</p></span>
```

**Before this fix:**
```markdown
#### Our Journey 🎯 At Quiver...
```

**After this fix:**
```markdown
#### Heading

This is a paragraph with **bold** text.
```

## Root Cause

The `calculateNewLineConfig` function was indiscriminately returning `NO_SPACING` when any parent element had the `collapsesInnerWhiteSpace` property, preventing block elements from maintaining their spacing.

## Solution

Added an exception specifically for block elements (h1-h6, p, div) inside `<span>` elements to preserve their block-level spacing. This is because `<span>` is a presentational wrapper that shouldn't affect the block-level semantics of its children, unlike semantic inline elements like `<a>`.

## Changes

- Modified `calculateNewLineConfig` in `markdown-processor.ts` to preserve block spacing inside span elements
- Added regression test for block elements inside inline elements
- All existing tests pass

## Testing

```bash
curl -s "https://thehub.io/jobs/68e7a5960c688c2ac659be70" | node ./packages/mdream/bin/mdream.mjs --origin https://thehub.io
```

Now correctly shows newlines after the "Our Journey 🎯" heading.