### PR TITLE
fix: preserve paragraph breaks inside blockquotes

### DIFF
--- a/packages/mdream/src/tags.ts
+++ b/packages/mdream/src/tags.ts
@@ -502,7 +502,20 @@ export const tagHandlers: Record<number, TagHandler> = {
     collapsesInnerWhiteSpace: true,
     spacing: NO_SPACING,
   },
-  [TAG_P]: {},
+  [TAG_P]: {
+    enter: ({ node, state }) => {
+      const bqDepth = node.depthMap[TAG_BLOCKQUOTE]
+      if (bqDepth > 0) {
+        const lastEntry = state.buffer.at(-1)
+        const lastChar = lastEntry?.charAt(lastEntry.length - 1) || ''
+        // Only add separator if there's preceding text content (not the first <p> in the blockquote)
+        if (lastChar && lastChar !== '\n' && lastChar !== ' ' && lastChar !== '>') {
+          const prefix = '> '.repeat(bqDepth)
+          return `\n${prefix.trimEnd()}\n${prefix}`
+        }
+      }
+    },
+  },
   [TAG_DIV]: {},
   [TAG_SPAN]: {
     collapsesInnerWhiteSpace: true,

--- a/packages/mdream/test/unit/__snapshots__/splitter.test.ts.snap
+++ b/packages/mdream/test/unit/__snapshots__/splitter.test.ts.snap
@@ -3,7 +3,9 @@
 exports[`htmlToMarkdownSplitChunks > edge cases > handles blockquotes 1`] = `
 "## Quotes
 
-> This is a quote Multiple paragraphs"
+> This is a quote
+>
+> Multiple paragraphs"
 `;
 
 exports[`htmlToMarkdownSplitChunks > edge cases > handles images in content 1`] = `

--- a/packages/mdream/test/unit/nodes/blockquote.test.ts
+++ b/packages/mdream/test/unit/nodes/blockquote.test.ts
@@ -14,10 +14,10 @@ describe('blockquotes', () => {
     expect(markdown).toBe('> Outer quote\n> > Inner quote')
   })
 
-  it.skip('handles blockquotes with paragraphs', () => {
+  it('handles blockquotes with paragraphs', () => {
     const html = '<blockquote><p>First paragraph</p><p>Second paragraph</p></blockquote>'
     const markdown = htmlToMarkdown(html)
-    expect(markdown).toBe('> First paragraph\n> Second paragraph')
+    expect(markdown).toBe('> First paragraph\n>\n> Second paragraph')
   })
 
   it('handles complex nested blockquotes', () => {

--- a/packages/mdream/test/unit/nodes/html-to-markdown-parity.test.ts
+++ b/packages/mdream/test/unit/nodes/html-to-markdown-parity.test.ts
@@ -58,7 +58,9 @@ describe('html-to-markdown parity', () => {
     </blockquote>
 </blockquote>`)).toMatchInlineSnapshot(`
   "> ## Heading 1. List 2. List
-  > > Another Quote by someone"
+  > > Another Quote
+  > >
+  > > by someone"
 `)
   })
   it ('inline Code & Code Block: Correctly handles backticks and multi-line code blocks, preserving code structure.', () => {


### PR DESCRIPTION
### Description

When parsing epubs I ran into an issue parsing multiple `<p>` tags within a single `<blockquote>`, e.g.

`<blockquote><p>A</p><p>B</p><p>C</p></blockquote>`

Running a test like this across compared libraries leads to:

```
mdream result: > A B C
Turndown result: > A
>
> B
>
> C
node-html-markdown result: > A
>
> B
>
> C
```

<details>
<summary>Test Code</summary>

```
import { htmlToMarkdown } from 'mdream';
import { NodeHtmlMarkdown } from 'node-html-markdown';
import TurndownService from 'turndown';

const mdreamMarkdown = htmlToMarkdown(
  '<blockquote><p>A</p><p>B</p><p>C</p></blockquote>'
);
console.log('mdream result:', mdreamMarkdown);

const turndownService = new TurndownService();
const turndownMarkdown = turndownService.turndown(
  '<blockquote><p>A</p><p>B</p><p>C</p></blockquote>'
);
console.log('Turndown result:', turndownMarkdown);

const nodeHtmlMarkdown = NodeHtmlMarkdown.translate(
  '<blockquote><p>A</p><p>B</p><p>C</p></blockquote>'
);
console.log('node-html-markdown result:', nodeHtmlMarkdown);
```
</details>

I understand this library is designed to produce Markdown from HTML that is optimized for LLMs, and this difference may be expected as result. I would argue splitting these paragraphs out into multiple lines increases readability, both for LLMs and for humans, and aligns with other competitive markdown libraries. It also helps with aligning the markdown output with similarly structured HTML e.g. `<blockquote><p>A</p></blockquote><blockquote><p>B</p></blockquote><blockquote><p>C</p></blockquote>`. 

There's also a whole skipped test (!) which simply gets unskipped if this PR lands - it was already covered and expected, but chosen to be skipped in ffe7fa2c439530b0eb41590c9d4bea1b9e710ea7 ( for some reason ? performance ? )

### Additional context

This pull was created with (by?) Claude after running into, debugging, and fixing this issue within a separate codebase and then pulling in the fix upstream.

The PR body itself you're reading right now was created by a human :) 