### PR TITLE
fix(crawl): validate sitemap XML response before parsing

### DIFF
--- a/packages/crawl/src/crawl.ts
+++ b/packages/crawl/src/crawl.ts
@@ -10,7 +10,7 @@ import { generateLlmsTxtArtifacts } from 'mdream/llms-txt'
 import { withMinimalPreset } from 'mdream/preset/minimal'
 import { dirname, join, normalize, resolve } from 'pathe'
 import { withHttps } from 'ufo'
-import { getStartingUrl, isUrlExcluded, matchesGlobPattern, parseUrlPattern } from './glob-utils.ts'
+import { getStartingUrl, isUrlExcluded, isValidSitemapXml, matchesGlobPattern, parseUrlPattern } from './glob-utils.ts'
 import { extractMetadata } from './metadata-extractor.ts'
 
 const SITEMAP_INDEX_LOC_RE = /<sitemap[^>]*>.*?<loc>(.*?)<\/loc>.*?<\/sitemap>/gs
@@ -41,6 +41,12 @@ async function loadSitemapWithoutRetries(sitemapUrl: string): Promise<string[]> 
     }
 
     const xmlContent = await response.text()
+
+    // Validate that the response is actually a sitemap XML, not an HTML page
+    // (e.g., when a server redirects sitemap.xml to another HTML page)
+    if (!isValidSitemapXml(xmlContent)) {
+      throw new Error('Response is not a valid sitemap XML')
+    }
 
     // Check if this is a sitemap index (contains <sitemapindex>)
     if (xmlContent.includes('<sitemapindex')) {

--- a/packages/crawl/src/glob-utils.ts
+++ b/packages/crawl/src/glob-utils.ts
@@ -154,6 +154,13 @@ export function isUrlExcluded(url: string, excludePatterns: string[]): boolean {
 }
 
 /**
+ * Check if a string is valid sitemap XML content (not an HTML page or other non-sitemap response)
+ */
+export function isValidSitemapXml(content: string): boolean {
+  return content.includes('<urlset') || content.includes('<sitemapindex')
+}
+
+/**
  * Validate glob pattern syntax
  */
 export function validateGlobPattern(pattern: string): string | undefined {

--- a/packages/crawl/test/unit/glob-utils.test.ts
+++ b/packages/crawl/test/unit/glob-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isUrlExcluded } from '../../src/glob-utils.ts'
+import { isUrlExcluded, isValidSitemapXml } from '../../src/glob-utils.ts'
 
 describe('isUrlExcluded', () => {
   it('returns false when no exclude patterns provided', () => {
@@ -58,5 +58,23 @@ describe('isUrlExcluded', () => {
     expect(isUrlExcluded('https://example.com/admin/users/123', excludePatterns)).toBe(true)
     expect(isUrlExcluded('https://example.com/admin/settings/profile', excludePatterns)).toBe(true)
     expect(isUrlExcluded('https://example.com/public/page', excludePatterns)).toBe(false)
+  })
+})
+
+describe('isValidSitemapXml', () => {
+  it('accepts valid sitemap with urlset', () => {
+    expect(isValidSitemapXml('<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://example.com/</loc></url></urlset>')).toBe(true)
+  })
+
+  it('accepts valid sitemap index', () => {
+    expect(isValidSitemapXml('<?xml version="1.0"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><sitemap><loc>https://example.com/sitemap1.xml</loc></sitemap></sitemapindex>')).toBe(true)
+  })
+
+  it('rejects HTML pages (e.g. from redirect)', () => {
+    expect(isValidSitemapXml('<!DOCTYPE html><html><head><title>Product Page</title></head><body></body></html>')).toBe(false)
+  })
+
+  it('rejects empty content', () => {
+    expect(isValidSitemapXml('')).toBe(false)
   })
 })


### PR DESCRIPTION
Prevents parsing HTML pages as sitemaps when servers redirect `sitemap.xml` to another HTML page.

### Description

When crawling sites like `https://code.claude.com/docs/en/**`, the server responds to `sitemap.xml` with a 302 redirect to an HTML page. The crawler was treating this HTML response as valid sitemap XML and attempting to parse it. Since no `<url><loc>` entries were found in the HTML, the sitemap returned an empty URL list and the crawler finished with 0 pages instead of falling back to link-based discovery.

This PR adds a validation step in `loadSitemapWithoutRetries` that checks whether the response body actually contains `<urlset` or `<sitemapindex` before parsing. If neither is found, it throws an error so the retry/fallback logic can kick in and use link following instead.

```sh
mkdir -p /tmp/crawl
CRAWLEE_STORAGE_DIR="/tmp/crawl/storage" crawl -o "/tmp/crawl/output" -u "https://code.claude.com/docs/en/**" --artifacts markdown
```

<img width="1920" height="1080" alt="2026-03-15-213119-WezTerm" src="https://github.com/user-attachments/assets/5918b067-819f-4fd9-a05b-4c0cd953f66a" />

### Additional context

The validation is intentionally lightweight (substring check rather than full XML parsing) to avoid performance overhead. It covers the two top-level elements defined by the [Sitemaps protocol](https://www.sitemaps.org/protocol.html): `<urlset>` for standard sitemaps and `<sitemapindex>` for sitemap index files.
