### PR TITLE
fix(tailwind): propagate hidden state to descendant elements

### DIFF
--- a/packages/mdream/src/plugin-processor.ts
+++ b/packages/mdream/src/plugin-processor.ts
@@ -19,6 +19,18 @@ export function processPluginsForEvent(
 ): boolean {
   // Process plugins with full state access
   if (plugins?.length) {
+    // Run processAttributes BEFORE beforeNodeProcess so that
+    // ancestor context (e.g. tailwind hidden state) is available
+    // when descendant nodes check their ancestors in beforeNodeProcess.
+    if (event.node.type === ELEMENT_NODE && event.type === NodeEventEnter) {
+      const element = event.node as ElementNode
+      for (const plugin of plugins) {
+        if (plugin.processAttributes) {
+          plugin.processAttributes(element, state)
+        }
+      }
+    }
+
     let shouldSkip = false
     for (const plugin of plugins) {
       const res = plugin.beforeNodeProcess?.(event, state)
@@ -34,15 +46,6 @@ export function processPluginsForEvent(
     // Run plugin hooks
     if (event.node.type === ELEMENT_NODE) {
       const element = event.node as ElementNode
-
-      // Run processAttributes hook on element enter
-      if (event.type === NodeEventEnter) {
-        for (const plugin of plugins) {
-          if (plugin.processAttributes) {
-            plugin.processAttributes(element, state)
-          }
-        }
-      }
 
       // Collect plugin hook outputs
       const fn = event.type === NodeEventEnter ? 'onNodeEnter' : 'onNodeExit'

--- a/packages/mdream/src/plugins/tailwind.ts
+++ b/packages/mdream/src/plugins/tailwind.ts
@@ -308,13 +308,18 @@ export function tailwindPlugin(): Plugin {
       return { content, skip: false }
     },
 
-    // Filter out hidden elements
+    // Filter out hidden elements (including descendants of hidden ancestors)
     beforeNodeProcess({ node }) {
+      let parent = node.parent as ElementNode | null
+      while (parent) {
+        if (parent.context?.tailwind?.hidden) {
+          return { skip: true }
+        }
+        parent = parent.parent as ElementNode | null
+      }
       if (node.type === ELEMENT_NODE) {
         const elementNode = node as ElementNode
-        // Check if element should be hidden based on plugin data
-        const tailwindData = elementNode.context?.tailwind
-        if (tailwindData?.hidden) {
+        if (elementNode.context?.tailwind?.hidden) {
           return { skip: true }
         }
       }

--- a/packages/mdream/test/unit/plugins/tailwind.test.ts
+++ b/packages/mdream/test/unit/plugins/tailwind.test.ts
@@ -165,4 +165,59 @@ describe('tailwind addon', () => {
     expect(markdown).toContain('Regular content')
     expect(markdown).toContain('More regular content')
   })
+
+  it('hides child elements inside a fixed parent', () => {
+    const html = `
+      <div>
+        <div class="fixed">
+          <h5>Sidebar Title</h5>
+          <ul><li><a href="/">Link</a></li></ul>
+        </div>
+        <p>Visible content</p>
+      </div>
+    `
+    const markdown = htmlToMarkdown(html, {
+      plugins: [tailwindPlugin()],
+    })
+
+    expect(markdown).not.toContain('Sidebar Title')
+    expect(markdown).not.toContain('Link')
+    expect(markdown).toContain('Visible content')
+  })
+
+  it('hides deeply nested elements inside a hidden parent', () => {
+    const html = `
+      <div>
+        <div class="hidden">
+          <div>
+            <p>Deeply nested hidden text</p>
+          </div>
+        </div>
+        <p>Visible text</p>
+      </div>
+    `
+    const markdown = htmlToMarkdown(html, {
+      plugins: [tailwindPlugin()],
+    })
+
+    expect(markdown).not.toContain('Deeply nested hidden text')
+    expect(markdown).toContain('Visible text')
+  })
+
+  it('hides text nodes inside a fixed parent', () => {
+    const html = `
+      <div>
+        <div class="absolute">
+          <span>Hidden span text</span>
+        </div>
+        <p>Normal content</p>
+      </div>
+    `
+    const markdown = htmlToMarkdown(html, {
+      plugins: [tailwindPlugin()],
+    })
+
+    expect(markdown).not.toContain('Hidden span text')
+    expect(markdown).toContain('Normal content')
+  })
 })


### PR DESCRIPTION
Run `processAttributes` before `beforeNodeProcess` so that ancestor context (e.g. tailwind hidden state) is available when descendant nodes check their ancestors in `beforeNodeProcess`.

<img width="1576" height="760" alt="2026-03-15-215833-WezTerm" src="https://github.com/user-attachments/assets/af7a7699-d982-449d-866a-6ba781376a48" />