### PR TITLE
fix(napi): prevent silent u32-to-u8 truncation in splitter options

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -221,11 +221,11 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "mdream"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 
 [[package]]
 name = "mdream-edge"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "js-sys",
  "mdream",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "mdream-node"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "mdream",
  "napi",

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -265,19 +265,20 @@ pub struct SplitterOptionsNapi {
     pub chunk_overlap: Option<u32>,
 }
 
-fn to_core_splitter_opts(options: Option<SplitterOptionsNapi>) -> mdream::splitter::SplitterOptions {
+fn to_core_splitter_opts(options: Option<SplitterOptionsNapi>) -> Result<mdream::splitter::SplitterOptions> {
     let defaults = mdream::splitter::SplitterOptions::default();
     match options {
-        None => defaults,
-        Some(opts) => mdream::splitter::SplitterOptions {
+        None => Ok(defaults),
+        Some(opts) => Ok(mdream::splitter::SplitterOptions {
             headers_to_split_on: opts.headers_to_split_on
-                .map(|v| v.into_iter().map(|x| x as u8).collect())
+                .map(|v| v.into_iter().map(|x| u8::try_from(x).map_err(|_| napi::Error::new(napi::Status::InvalidArg, format!("headersToSplitOn value {x} exceeds u8 range (0-255)")))).collect::<Result<Vec<u8>>>())
+                .transpose()?
                 .unwrap_or(defaults.headers_to_split_on),
             return_each_line: opts.return_each_line.unwrap_or(defaults.return_each_line),
             strip_headers: opts.strip_headers.unwrap_or(defaults.strip_headers),
             chunk_size: opts.chunk_size.map(|v| v as usize).unwrap_or(defaults.chunk_size),
             chunk_overlap: opts.chunk_overlap.map(|v| v as usize).unwrap_or(defaults.chunk_overlap),
-        },
+        }),
     }
 }
 
@@ -297,7 +298,7 @@ fn chunk_to_napi(chunk: mdream::splitter::MarkdownChunk) -> MarkdownChunkNapi {
 
 #[napi(js_name = "splitMarkdown")]
 pub fn split_markdown(markdown: String, options: Option<SplitterOptionsNapi>) -> Result<Vec<MarkdownChunkNapi>> {
-    let opts = to_core_splitter_opts(options);
+    let opts = to_core_splitter_opts(options)?;
     let chunks = mdream::splitter::split_markdown(&markdown, &opts);
     Ok(chunks.into_iter().map(chunk_to_napi).collect())
 }
@@ -309,7 +310,7 @@ pub fn html_to_markdown_chunks(
     splitter_options: Option<SplitterOptionsNapi>,
 ) -> Result<Vec<MarkdownChunkNapi>> {
     let md_opts = to_core_opts(options);
-    let split_opts = to_core_splitter_opts(splitter_options);
+    let split_opts = to_core_splitter_opts(splitter_options)?;
     let chunks = mdream::splitter::html_to_markdown_chunks(&html, md_opts, &split_opts);
     Ok(chunks.into_iter().map(chunk_to_napi).collect())
 }


### PR DESCRIPTION
### 🔗 Linked issue

Closes #51

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`to_core_splitter_opts` used a bare `x as u8` cast when converting `headersToSplitOn` values from `u32` to `u8`, silently truncating any value above 255. Replaced with `u8::try_from(x)` that returns a descriptive NAPI `InvalidArg` error when a value exceeds the valid range.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for markdown splitting operations with enhanced validation of configuration parameters, preventing invalid values from being silently accepted and ensuring clearer error reporting when out-of-range values are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->