### PR TITLE
fix(crawl): handle wmic.exe ENOENT on Windows 11+

### DIFF
--- a/packages/crawl/src/cli.ts
+++ b/packages/crawl/src/cli.ts
@@ -628,6 +628,17 @@ async function main() {
 
 // Run the CLI
 main().catch((error) => {
-  p.log.error(`Unexpected error: ${error}`)
+  const msg = error instanceof Error ? error.message : String(error)
+  // Surface a clear hint when the error is the Windows wmic.exe removal
+  if (msg.includes('wmic') || (msg.includes('ENOENT') && process.platform === 'win32')) {
+    p.log.error(
+      'Crawlee failed because wmic.exe is not available on this system. '
+      + 'Windows 11 removed wmic.exe, which older crawlee versions depend on for memory monitoring.\n'
+      + 'Fix: upgrade crawlee to >=3.16.0 or switch to the HTTP driver (--driver http).',
+    )
+  }
+  else {
+    p.log.error(`Unexpected error: ${msg}`)
+  }
   process.exit(1)
 })

--- a/packages/crawl/src/crawl.ts
+++ b/packages/crawl/src/crawl.ts
@@ -581,8 +581,17 @@ export async function crawlAndGenerate(options: CrawlOptions, onProgress?: (prog
       await crawler.run(initialRequests)
     }
     catch (error) {
+      const msg = error instanceof Error ? error.message : ''
+      // wmic.exe was removed in Windows 11; older crawlee versions spawn it for memory monitoring
+      if (msg.includes('wmic') || msg.includes('ENOENT')) {
+        throw new Error(
+          `Crawlee failed to spawn a system process (${msg}). `
+          + 'On Windows 11+, wmic.exe is no longer available. '
+          + 'Upgrade crawlee to >=3.16.0 or use the HTTP driver instead (--driver http).',
+        )
+      }
       if (verbose) {
-        console.error(`[CRAWLER ERROR] ${error instanceof Error ? error.message : 'Unknown error'}`)
+        console.error(`[CRAWLER ERROR] ${msg || 'Unknown error'}`)
         console.error(`[CRAWLER ERROR] Stack trace:`, error instanceof Error ? error.stack : 'No stack trace')
       }
       throw error


### PR DESCRIPTION
### 🔗 Linked issue

Closes #13

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Windows 11 removed `wmic.exe`, which older crawlee versions spawn via `@apify/ps-tree` for memory monitoring. The reporter hit this on v0.10.3 where crawlee was imported statically for all drivers. The current codebase already resolved the root cause by making crawlee a dynamic import only for the Playwright driver path, but the Playwright path could still surface a confusing error on Windows 11+ with older crawlee versions.

This adds targeted error handling in both the Playwright crawler path and the top-level CLI catch handler to detect the `wmic.exe ENOENT` error and surface a clear message directing users to upgrade crawlee to >=3.16.0 (which uses PowerShell instead) or switch to the HTTP driver.