### PR TITLE
feat(crawl): add config file support and hookable hooks

### DIFF
--- a/packages/crawl/README.md
+++ b/packages/crawl/README.md
@@ -135,7 +135,8 @@ const results = await crawlAndGenerate({
 | `useChrome` | `boolean` | `false` | Use system Chrome instead of Playwright's bundled browser (Playwright driver only) |
 | `chunkSize` | `number` | | Chunk size passed to mdream for markdown conversion |
 | `verbose` | `boolean` | `false` | Enable verbose error logging |
-| `onPage` | `(page: PageData) => Promise<void> \| void` | | Callback invoked for each successfully crawled page |
+| `hooks` | `Partial<CrawlHooks>` | | Hook functions for the crawl pipeline (see [Hooks](#hooks)) |
+| `onPage` | `(page: PageData) => Promise<void> \| void` | | **Deprecated.** Use `hooks['crawl:page']` instead. Still works for backwards compatibility |
 
 ### `CrawlResult`
 
@@ -258,6 +259,132 @@ await crawlAndGenerate({
   urls: ['https://example.com/pricing', 'https://example.com/about'],
   outputDir: './output',
   maxDepth: 0,
+})
+```
+
+## Config File
+
+Create a `mdream.config.ts` (or `.js`, `.mjs`) in your project root to set defaults and register hooks. Loaded via [c12](https://github.com/unjs/c12).
+
+```typescript
+import { defineConfig } from '@mdream/crawl'
+
+export default defineConfig({
+  exclude: ['*/admin/*', '*/internal/*'],
+  driver: 'http',
+  maxDepth: 3,
+  hooks: {
+    'crawl:page': (page) => {
+      // Strip branding from all page titles
+      page.title = page.title.replace(/ \| My Brand$/, '')
+    },
+  },
+})
+```
+
+CLI arguments override config file values. Array options like `exclude` are concatenated (config + CLI).
+
+### Config Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `exclude` | `string[]` | Glob patterns for URLs to exclude |
+| `driver` | `'http' \| 'playwright'` | Crawler driver |
+| `maxDepth` | `number` | Maximum crawl depth |
+| `maxPages` | `number` | Maximum pages to crawl |
+| `crawlDelay` | `number` | Delay between requests (seconds) |
+| `skipSitemap` | `boolean` | Skip sitemap discovery |
+| `allowSubdomains` | `boolean` | Crawl across subdomains |
+| `verbose` | `boolean` | Enable verbose logging |
+| `artifacts` | `string[]` | Output formats: `llms.txt`, `llms-full.txt`, `markdown` |
+| `hooks` | `object` | Hook functions (see below) |
+
+## Hooks
+
+Four hooks let you intercept and transform data at each stage of the crawl pipeline. Hooks receive mutable objects. Mutate in-place to transform output.
+
+### `crawl:url`
+
+Called before fetching a URL. Set `ctx.skip = true` to skip it entirely (saves the network request).
+
+```typescript
+defineConfig({
+  hooks: {
+    'crawl:url': (ctx) => {
+      // Skip large asset pages
+      if (ctx.url.includes('/assets/') || ctx.url.includes('/downloads/'))
+        ctx.skip = true
+    },
+  },
+})
+```
+
+### `crawl:page`
+
+Called after HTML-to-Markdown conversion, before storage. Mutate `page.title` or other fields. This replaces the `onPage` callback (which still works for backwards compatibility).
+
+```typescript
+defineConfig({
+  hooks: {
+    'crawl:page': (page) => {
+      // page.url, page.html, page.title, page.metadata, page.origin
+      page.title = page.title.replace(/ - Docs$/, '')
+    },
+  },
+})
+```
+
+### `crawl:content`
+
+Called before markdown is written to disk. Transform the final output content or change the file path.
+
+```typescript
+defineConfig({
+  hooks: {
+    'crawl:content': (ctx) => {
+      // ctx.url, ctx.title, ctx.content, ctx.filePath
+      ctx.content = ctx.content.replace(/CONFIDENTIAL/g, '[REDACTED]')
+      ctx.filePath = ctx.filePath.replace('.md', '.mdx')
+    },
+  },
+})
+```
+
+### `crawl:done`
+
+Called after all pages are crawled, before `llms.txt` generation. Filter or reorder results.
+
+```typescript
+defineConfig({
+  hooks: {
+    'crawl:done': (ctx) => {
+      // Remove short pages from the final output
+      const filtered = ctx.results.filter(r => r.content.length > 100)
+      ctx.results.length = 0
+      ctx.results.push(...filtered)
+    },
+  },
+})
+```
+
+### Programmatic Hooks
+
+Hooks can also be passed directly to `crawlAndGenerate`:
+
+```typescript
+import { crawlAndGenerate } from '@mdream/crawl'
+
+await crawlAndGenerate({
+  urls: ['https://example.com'],
+  outputDir: './output',
+  hooks: {
+    'crawl:page': (page) => {
+      page.title = page.title.replace(/ \| Brand$/, '')
+    },
+    'crawl:done': (ctx) => {
+      ctx.results.sort((a, b) => a.url.localeCompare(b.url))
+    },
+  },
 })
 ```
 

--- a/packages/crawl/package.json
+++ b/packages/crawl/package.json
@@ -64,12 +64,14 @@
   "dependencies": {
     "@clack/prompts": "catalog:",
     "@mdream/js": "workspace:*",
+    "c12": "catalog:",
+    "hookable": "catalog:",
     "mdream": "workspace:*",
     "nypm": "catalog:",
     "ofetch": "catalog:",
     "pathe": "catalog:",
     "picomatch": "catalog:",
-    "tldts": "^7.0.26",
+    "tldts": "catalog:",
     "ufo": "catalog:"
   },
   "devDependencies": {

--- a/packages/crawl/src/cli.ts
+++ b/packages/crawl/src/cli.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url'
 import * as p from '@clack/prompts'
 import { dirname, join, resolve } from 'pathe'
 import { withHttps } from 'ufo'
+import { loadMdreamConfig } from './config.js'
 import { crawlAndGenerate } from './crawl.js'
 import { parseUrlPattern, validateGlobPattern } from './glob-utils.js'
 // playwright-utils is dynamically imported only when Playwright driver is used
@@ -477,11 +478,28 @@ async function main() {
   // Try to parse CLI arguments first
   const cliOptions = parseCliArgs()
 
+  // Load config file (mdream.config.ts)
+  const fileConfig = await loadMdreamConfig()
+
   let options: CrawlOptions | null
 
   if (cliOptions) {
-    // Use CLI arguments - validation already done in parseCliArgs
-    options = cliOptions
+    // Merge: CLI args override config file, arrays concatenate
+    const configExclude = fileConfig.exclude || []
+    const cliExclude = cliOptions.exclude || []
+    options = {
+      ...cliOptions,
+      driver: cliOptions.driver || fileConfig.driver || 'http',
+      maxDepth: cliOptions.maxDepth ?? fileConfig.maxDepth,
+      crawlDelay: cliOptions.crawlDelay ?? fileConfig.crawlDelay,
+      skipSitemap: cliOptions.skipSitemap || fileConfig.skipSitemap || false,
+      allowSubdomains: cliOptions.allowSubdomains || fileConfig.allowSubdomains || false,
+      verbose: cliOptions.verbose || fileConfig.verbose || false,
+      exclude: configExclude.length > 0 || cliExclude.length > 0
+        ? [...configExclude, ...cliExclude]
+        : undefined,
+      hooks: fileConfig.hooks,
+    }
 
     // Show non-interactive summary when using CLI args
     p.intro(`☁️  mdream v${version}`)

--- a/packages/crawl/src/config.ts
+++ b/packages/crawl/src/config.ts
@@ -1,0 +1,10 @@
+import type { MdreamCrawlConfig } from './types.js'
+import { loadConfig } from 'c12'
+
+export async function loadMdreamConfig(cwd?: string): Promise<MdreamCrawlConfig> {
+  const { config } = await loadConfig<MdreamCrawlConfig>({
+    name: 'mdream',
+    cwd,
+  })
+  return config || {}
+}

--- a/packages/crawl/src/crawl.ts
+++ b/packages/crawl/src/crawl.ts
@@ -1,10 +1,11 @@
 import type { ProcessedFile } from '@mdream/js/llms-txt'
 import type { PlaywrightCrawlerOptions } from 'crawlee'
-import type { CrawlOptions, CrawlResult, PageData, PageMetadata } from './types.ts'
+import type { CrawlHooks, CrawlOptions, CrawlResult, PageData, PageMetadata } from './types.ts'
 import { mkdirSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
 import * as p from '@clack/prompts'
 import { generateLlmsTxtArtifacts } from '@mdream/js/llms-txt'
+import { createHooks } from 'hookable'
 import { htmlToMarkdown } from 'mdream'
 import { ofetch } from 'ofetch'
 import { dirname, join, normalize, resolve } from 'pathe'
@@ -222,8 +223,17 @@ export async function crawlAndGenerate(options: CrawlOptions, onProgress?: (prog
     verbose = false,
     skipSitemap = false,
     allowSubdomains = false,
+    hooks: hooksConfig,
     onPage,
   } = options
+
+  // Set up hooks
+  const hooks = createHooks<CrawlHooks>()
+  if (hooksConfig)
+    hooks.addHooks(hooksConfig)
+  // Backwards compat: convert onPage to crawl:page hook
+  if (onPage)
+    hooks.hook('crawl:page', onPage)
 
   // Single-page mode: maxDepth 0 means just process the given URLs directly
   const singlePageMode = maxDepth === 0
@@ -483,10 +493,10 @@ export async function crawlAndGenerate(options: CrawlOptions, onProgress?: (prog
       md = htmlToMarkdown(content, { origin: pageOrigin, extraction })
       metadata = getMetadata()
     }
-    const title = initialTitle || metadata.title
+    let title = initialTitle || metadata.title
 
-    // Call onPage callback if provided
-    if (onPage && shouldProcessMarkdown) {
+    // Call crawl:page hook
+    if (shouldProcessMarkdown) {
       const pageData: PageData = {
         url,
         html: isMarkdown ? '' : content,
@@ -494,7 +504,8 @@ export async function crawlAndGenerate(options: CrawlOptions, onProgress?: (prog
         metadata,
         origin: pageOrigin,
       }
-      await onPage(pageData)
+      await hooks.callHook('crawl:page', pageData)
+      title = pageData.title
     }
 
     let filePath: string | undefined
@@ -509,6 +520,12 @@ export async function crawlAndGenerate(options: CrawlOptions, onProgress?: (prog
       const safeFilename = normalize(`${filename}.md`)
 
       filePath = join(outputDir, safeFilename)
+
+      // Call crawl:content hook before writing
+      const contentCtx = { url, title, content: md, filePath }
+      await hooks.callHook('crawl:content', contentCtx)
+      md = contentCtx.content
+      filePath = contentCtx.filePath
 
       const fileDir = dirname(filePath)
       if (fileDir && !createdDirs.has(fileDir)) {
@@ -566,6 +583,12 @@ export async function crawlAndGenerate(options: CrawlOptions, onProgress?: (prog
       requestHandler: async ({ request, page }) => {
         progress.crawling.currentUrl = request.loadedUrl
         onProgress?.(progress)
+
+        // crawl:url hook: allow skipping before fetch
+        const urlCtx = { url: request.loadedUrl, skip: false }
+        await hooks.callHook('crawl:url', urlCtx)
+        if (urlCtx.skip)
+          return
 
         const fetchStart = Date.now()
         await page.waitForLoadState('networkidle')
@@ -647,6 +670,12 @@ export async function crawlAndGenerate(options: CrawlOptions, onProgress?: (prog
         await new Promise(resolve => setTimeout(resolve, delay * 1000))
       }
 
+      // crawl:url hook: allow skipping before fetch
+      const urlCtx = { url, skip: false }
+      await hooks.callHook('crawl:url', urlCtx)
+      if (urlCtx.skip)
+        return
+
       try {
         const fetchStart = Date.now()
         const response = await ofetch.raw(url, {
@@ -698,6 +727,9 @@ export async function crawlAndGenerate(options: CrawlOptions, onProgress?: (prog
   // Mark crawling as completed
   progress.crawling.status = 'completed'
   onProgress?.(progress)
+
+  // crawl:done hook: allow filtering/reordering results before generation
+  await hooks.callHook('crawl:done', { results })
 
   // Generate output files if requested
   if (results.some(r => r.success)) {

--- a/packages/crawl/src/index.ts
+++ b/packages/crawl/src/index.ts
@@ -1,2 +1,3 @@
 export { crawlAndGenerate } from './crawl.js'
-export type { CrawlOptions, CrawlResult, PageData } from './types.js'
+export { defineConfig } from './types.js'
+export type { CrawlHooks, CrawlOptions, CrawlResult, MdreamCrawlConfig, PageData } from './types.js'

--- a/packages/crawl/src/types.ts
+++ b/packages/crawl/src/types.ts
@@ -6,6 +6,13 @@ export interface PageData {
   origin: string
 }
 
+export interface CrawlHooks {
+  'crawl:url': (ctx: { url: string, skip: boolean }) => void | Promise<void>
+  'crawl:page': (page: PageData) => void | Promise<void>
+  'crawl:content': (ctx: { url: string, title: string, content: string, filePath: string }) => void | Promise<void>
+  'crawl:done': (ctx: { results: CrawlResult[] }) => void | Promise<void>
+}
+
 export interface CrawlOptions {
   urls: string[]
   outputDir: string
@@ -27,7 +34,25 @@ export interface CrawlOptions {
   verbose?: boolean
   skipSitemap?: boolean
   allowSubdomains?: boolean
+  hooks?: Partial<{ [K in keyof CrawlHooks]: CrawlHooks[K] | CrawlHooks[K][] }>
   onPage?: (page: PageData) => Promise<void> | void
+}
+
+export interface MdreamCrawlConfig {
+  exclude?: string[]
+  driver?: 'http' | 'playwright'
+  maxDepth?: number
+  maxPages?: number
+  crawlDelay?: number
+  skipSitemap?: boolean
+  allowSubdomains?: boolean
+  verbose?: boolean
+  artifacts?: ('llms.txt' | 'llms-full.txt' | 'markdown')[]
+  hooks?: Partial<{ [K in keyof CrawlHooks]: CrawlHooks[K] | CrawlHooks[K][] }>
+}
+
+export function defineConfig(config: MdreamCrawlConfig): MdreamCrawlConfig {
+  return config
 }
 
 export interface ParsedUrlPattern {

--- a/packages/crawl/test/unit/hooks.test.ts
+++ b/packages/crawl/test/unit/hooks.test.ts
@@ -1,0 +1,171 @@
+import type { CrawlHooks, CrawlResult, PageData } from '../../src/types.js'
+import { createHooks } from 'hookable'
+import { describe, expect, it } from 'vitest'
+import { defineConfig } from '../../src/types.js'
+
+describe('hooks', () => {
+  describe('crawl:url', () => {
+    it('should skip url when ctx.skip is set to true', async () => {
+      const hooks = createHooks<CrawlHooks>()
+      hooks.hook('crawl:url', (ctx) => {
+        if (ctx.url.includes('/admin'))
+          ctx.skip = true
+      })
+
+      const ctx1 = { url: 'https://example.com/admin/settings', skip: false }
+      await hooks.callHook('crawl:url', ctx1)
+      expect(ctx1.skip).toBe(true)
+
+      const ctx2 = { url: 'https://example.com/about', skip: false }
+      await hooks.callHook('crawl:url', ctx2)
+      expect(ctx2.skip).toBe(false)
+    })
+
+    it('should support async hooks', async () => {
+      const hooks = createHooks<CrawlHooks>()
+      hooks.hook('crawl:url', async (ctx) => {
+        await new Promise(resolve => setTimeout(resolve, 1))
+        if (ctx.url.includes('/api'))
+          ctx.skip = true
+      })
+
+      const ctx = { url: 'https://example.com/api/v1', skip: false }
+      await hooks.callHook('crawl:url', ctx)
+      expect(ctx.skip).toBe(true)
+    })
+  })
+
+  describe('crawl:page', () => {
+    it('should allow mutating page title', async () => {
+      const hooks = createHooks<CrawlHooks>()
+      hooks.hook('crawl:page', (page) => {
+        page.title = page.title.replace(/ \| My Brand$/, '')
+      })
+
+      const page: PageData = {
+        url: 'https://example.com/about',
+        html: '<html></html>',
+        title: 'About Us | My Brand',
+        metadata: { title: 'About Us | My Brand', links: [] },
+        origin: 'https://example.com',
+      }
+
+      await hooks.callHook('crawl:page', page)
+      expect(page.title).toBe('About Us')
+    })
+  })
+
+  describe('crawl:content', () => {
+    it('should allow transforming content before write', async () => {
+      const hooks = createHooks<CrawlHooks>()
+      hooks.hook('crawl:content', (ctx) => {
+        ctx.content = ctx.content.replace(/SECRET/g, '[REDACTED]')
+      })
+
+      const ctx = {
+        url: 'https://example.com/page',
+        title: 'Page',
+        content: 'Some SECRET data here with another SECRET',
+        filePath: '/output/page.md',
+      }
+
+      await hooks.callHook('crawl:content', ctx)
+      expect(ctx.content).toBe('Some [REDACTED] data here with another [REDACTED]')
+    })
+
+    it('should allow changing filePath', async () => {
+      const hooks = createHooks<CrawlHooks>()
+      hooks.hook('crawl:content', (ctx) => {
+        ctx.filePath = ctx.filePath.replace('.md', '.mdx')
+      })
+
+      const ctx = {
+        url: 'https://example.com/page',
+        title: 'Page',
+        content: '# Hello',
+        filePath: '/output/page.md',
+      }
+
+      await hooks.callHook('crawl:content', ctx)
+      expect(ctx.filePath).toBe('/output/page.mdx')
+    })
+  })
+
+  describe('crawl:done', () => {
+    it('should allow filtering results', async () => {
+      const hooks = createHooks<CrawlHooks>()
+      hooks.hook('crawl:done', (ctx) => {
+        const filtered = ctx.results.filter(r => r.success)
+        ctx.results.length = 0
+        ctx.results.push(...filtered)
+      })
+
+      const results: CrawlResult[] = [
+        { url: 'https://example.com/a', title: 'A', content: '# A', timestamp: 1, success: true },
+        { url: 'https://example.com/b', title: 'B', content: '', timestamp: 2, success: false, error: '404' },
+        { url: 'https://example.com/c', title: 'C', content: '# C', timestamp: 3, success: true },
+      ]
+
+      await hooks.callHook('crawl:done', { results })
+      expect(results).toHaveLength(2)
+      expect(results.every(r => r.success)).toBe(true)
+    })
+  })
+
+  describe('onPage backwards compatibility', () => {
+    it('should work when registered as crawl:page hook', async () => {
+      const pages: string[] = []
+      const hooks = createHooks<CrawlHooks>()
+
+      // Simulate what crawl.ts does with onPage
+      const onPage = (page: PageData) => { pages.push(page.url) }
+      hooks.hook('crawl:page', onPage)
+
+      const page: PageData = {
+        url: 'https://example.com/test',
+        html: '',
+        title: 'Test',
+        metadata: { title: 'Test', links: [] },
+        origin: 'https://example.com',
+      }
+
+      await hooks.callHook('crawl:page', page)
+      expect(pages).toEqual(['https://example.com/test'])
+    })
+  })
+
+  describe('defineConfig', () => {
+    it('should return the config as-is (identity function)', () => {
+      const config = defineConfig({
+        exclude: ['*/admin/*'],
+        hooks: {
+          'crawl:page': (page) => {
+            page.title = page.title.replace(/ \| Brand$/, '')
+          },
+        },
+      })
+
+      expect(config.exclude).toEqual(['*/admin/*'])
+      expect(config.hooks).toBeDefined()
+      expect(config.hooks!['crawl:page']).toBeTypeOf('function')
+    })
+
+    it('should accept all config options', () => {
+      const config = defineConfig({
+        driver: 'playwright',
+        maxDepth: 5,
+        maxPages: 100,
+        crawlDelay: 2,
+        skipSitemap: true,
+        allowSubdomains: true,
+        verbose: true,
+        artifacts: ['llms.txt', 'markdown'],
+        exclude: ['*/private/*'],
+      })
+
+      expect(config.driver).toBe('playwright')
+      expect(config.maxDepth).toBe(5)
+      expect(config.artifacts).toEqual(['llms.txt', 'markdown'])
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ catalogs:
     bumpp:
       specifier: ^11.0.1
       version: 11.0.1
+    c12:
+      specifier: ^3.0.4
+      version: 3.3.3
     cac:
       specifier: ^7.0.0
       version: 7.0.0
@@ -114,6 +117,9 @@ catalogs:
     express:
       specifier: ^5.2.1
       version: 5.2.1
+    hookable:
+      specifier: ^5.5.3
+      version: 5.5.3
     llm-cost:
       specifier: ^1.0.5
       version: 1.0.5
@@ -153,6 +159,9 @@ catalogs:
     tinyglobby:
       specifier: ^0.2.15
       version: 0.2.15
+    tldts:
+      specifier: ^7.0.26
+      version: 7.0.26
     tslib:
       specifier: ^2.8.1
       version: 2.8.1
@@ -334,7 +343,7 @@ importers:
         version: link:../../packages/nuxt
       nuxt:
         specifier: 'catalog:'
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@libsql/client@0.17.0)(@parcel/watcher@2.5.1)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.0)(better-sqlite3@12.6.2)(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)))(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2))(esbuild@0.27.3)(eslint@10.0.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.52.0)(rolldown@1.0.0-rc.8)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.8)(rollup@4.57.1))(rollup@4.57.1)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@libsql/client@0.17.0)(@parcel/watcher@2.5.1)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.0)(better-sqlite3@12.6.2)(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)))(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2))(esbuild@0.27.3)(eslint@10.0.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.52.0)(rolldown@1.0.0-rc.8)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.8)(rollup@4.57.1))(rollup@4.57.1)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
 
   examples/vite-ssr-vue:
     dependencies:
@@ -403,9 +412,15 @@ importers:
       '@mdream/js':
         specifier: workspace:*
         version: link:../js
+      c12:
+        specifier: 'catalog:'
+        version: 3.3.3(magicast@0.5.2)
       crawlee:
         specifier: ^3.16.0
         version: 3.16.0(@types/node@25.5.0)(playwright@1.58.2)
+      hookable:
+        specifier: 'catalog:'
+        version: 5.5.3
       mdream:
         specifier: workspace:*
         version: link:../mdream
@@ -425,7 +440,7 @@ importers:
         specifier: ^1.53.2
         version: 1.58.2
       tldts:
-        specifier: ^7.0.26
+        specifier: 'catalog:'
         version: 7.0.26
       ufo:
         specifier: 'catalog:'
@@ -497,7 +512,7 @@ importers:
         version: link:../js
       '@nuxt/kit':
         specifier: 'catalog:'
-        version: 4.4.2(magicast@0.5.1)
+        version: 4.4.2(magicast@0.3.5)
       consola:
         specifier: 'catalog:'
         version: 3.4.2
@@ -509,7 +524,7 @@ importers:
         version: link:../mdream
       nuxt-site-config:
         specifier: 'catalog:'
-        version: 3.2.21(magicast@0.5.1)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
+        version: 3.2.21(magicast@0.3.5)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
       pathe:
         specifier: 'catalog:'
         version: 2.0.3
@@ -525,13 +540,13 @@ importers:
         version: 2.4.0(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
       '@nuxt/module-builder':
         specifier: 'catalog:'
-        version: 1.0.2(@nuxt/cli@3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.1))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3))
+        version: 1.0.2(@nuxt/cli@3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.3.5))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3))
       '@nuxt/schema':
         specifier: 'catalog:'
         version: 4.4.2
       '@nuxt/test-utils':
         specifier: 'catalog:'
-        version: 4.0.0(jsdom@26.1.0)(magicast@0.5.1)(playwright-core@1.58.2)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vitest@4.1.0)
+        version: 4.0.0(jsdom@26.1.0)(magicast@0.3.5)(playwright-core@1.58.2)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vitest@4.1.0)
       '@types/node':
         specifier: 'catalog:'
         version: 25.5.0
@@ -540,13 +555,13 @@ importers:
         version: 11.0.1
       changelogen:
         specifier: 'catalog:'
-        version: 0.6.2(magicast@0.5.1)
+        version: 0.6.2(magicast@0.3.5)
       eslint:
         specifier: 'catalog:'
         version: 10.0.3(jiti@2.6.1)
       nuxt:
         specifier: 'catalog:'
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@libsql/client@0.17.0)(@parcel/watcher@2.5.1)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.0)(better-sqlite3@12.6.2)(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)))(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2))(esbuild@0.27.3)(eslint@10.0.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.52.0)(rolldown@1.0.0-rc.8)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.8)(rollup@4.57.1))(rollup@4.57.1)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@libsql/client@0.17.0)(@parcel/watcher@2.5.1)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.0)(better-sqlite3@12.6.2)(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)))(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2))(esbuild@0.27.3)(eslint@10.0.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.52.0)(rolldown@1.0.0-rc.8)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.8)(rollup@4.57.1))(rollup@4.57.1)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
 
   packages/vite:
     dependencies:
@@ -8031,18 +8046,11 @@ packages:
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
 
-  tldts-core@7.0.19:
-    resolution: {integrity: sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==}
-
   tldts-core@7.0.26:
     resolution: {integrity: sha512-5WJ2SqFsv4G2Dwi7ZFVRnz6b2H1od39QME1lc2y5Ew3eWiZMAeqOAfWpRP9jHvhUl881406QtZTODvjttJs+ew==}
 
   tldts@6.1.86:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
-    hasBin: true
-
-  tldts@7.0.19:
-    resolution: {integrity: sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==}
     hasBin: true
 
   tldts@7.0.26:
@@ -9210,7 +9218,7 @@ snapshots:
       fs-extra: 11.3.2
       got-scraping: 4.1.2
       ow: 0.28.2
-      tldts: 7.0.19
+      tldts: 7.0.26
       tslib: 2.8.1
       type-fest: 4.41.0
     transitivePeerDependencies:
@@ -9295,7 +9303,7 @@ snapshots:
       minimatch: 9.0.5
       ow: 0.28.2
       stream-json: 1.9.1
-      tldts: 7.0.19
+      tldts: 7.0.26
       tough-cookie: 6.0.0
       tslib: 2.8.1
       type-fest: 4.41.0
@@ -9461,10 +9469,10 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@dxup/nuxt@0.4.0(magicast@0.5.1)(typescript@5.9.3)':
+  '@dxup/nuxt@0.4.0(magicast@0.3.5)(typescript@5.9.3)':
     dependencies:
       '@dxup/unimport': 0.1.2
-      '@nuxt/kit': 4.4.2(magicast@0.5.1)
+      '@nuxt/kit': 4.4.2(magicast@0.3.5)
       chokidar: 5.0.0
       pathe: 2.0.3
       tinyglobby: 0.2.15
@@ -9472,10 +9480,10 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@dxup/nuxt@0.4.0(magicast@0.5.2)(typescript@5.9.3)':
+  '@dxup/nuxt@0.4.0(magicast@0.5.1)(typescript@5.9.3)':
     dependencies:
       '@dxup/unimport': 0.1.2
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      '@nuxt/kit': 4.4.2(magicast@0.5.1)
       chokidar: 5.0.0
       pathe: 2.0.3
       tinyglobby: 0.2.15
@@ -10431,11 +10439,11 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@nuxt/cli@3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.1)':
+  '@nuxt/cli@3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.3.5)':
     dependencies:
       '@bomb.sh/tab': 0.0.14(cac@6.7.14)(citty@0.2.1)
       '@clack/prompts': 1.1.0
-      c12: 3.3.3(magicast@0.5.1)
+      c12: 3.3.3(magicast@0.3.5)
       citty: 0.2.1
       confbox: 0.2.4
       consola: 3.4.2
@@ -10469,11 +10477,11 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxt/cli@3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)':
+  '@nuxt/cli@3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.1)':
     dependencies:
       '@bomb.sh/tab': 0.0.14(cac@6.7.14)(citty@0.2.1)
       '@clack/prompts': 1.1.0
-      c12: 3.3.3(magicast@0.5.2)
+      c12: 3.3.3(magicast@0.5.1)
       citty: 0.2.1
       confbox: 0.2.4
       consola: 3.4.2
@@ -10518,17 +10526,17 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/devtools-kit@2.7.0(magicast@0.5.1)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))':
+  '@nuxt/devtools-kit@2.7.0(magicast@0.3.5)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))':
     dependencies:
-      '@nuxt/kit': 3.21.1(magicast@0.5.1)
+      '@nuxt/kit': 3.21.1(magicast@0.3.5)
       execa: 8.0.1
       vite: 7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/devtools-kit@3.2.2(magicast@0.5.1)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))':
+  '@nuxt/devtools-kit@3.2.2(magicast@0.3.5)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))':
     dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.5.1)
+      '@nuxt/kit': 4.4.2(magicast@0.3.5)
       execa: 8.0.1
       vite: 7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -10672,9 +10680,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/kit@3.21.1(magicast@0.5.1)':
+  '@nuxt/kit@4.4.2(magicast@0.3.5)':
     dependencies:
-      c12: 3.3.3(magicast@0.5.1)
+      c12: 3.3.3(magicast@0.3.5)
       consola: 3.4.2
       defu: 6.1.4
       destr: 2.0.5
@@ -10683,8 +10691,7 @@ snapshots:
       ignore: 7.0.5
       jiti: 2.6.1
       klona: 2.0.6
-      knitwork: 1.3.0
-      mlly: 1.8.0
+      mlly: 1.8.1
       ohash: 2.0.11
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -10748,9 +10755,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/module-builder@1.0.2(@nuxt/cli@3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.1))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3))':
+  '@nuxt/module-builder@1.0.2(@nuxt/cli@3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.3.5))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3))':
     dependencies:
-      '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.1)
+      '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.3.5)
       citty: 0.1.6
       consola: 3.4.2
       defu: 6.1.4
@@ -10770,74 +10777,6 @@ snapshots:
       - sass
       - vue
       - vue-tsc
-
-  '@nuxt/nitro-server@4.4.2(0ae7c63400f7eda6d3ee6687e83810f8)':
-    dependencies:
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
-      '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.9.3))
-      '@vue/shared': 3.5.30
-      consola: 3.4.2
-      defu: 6.1.4
-      destr: 2.0.5
-      devalue: 5.6.4
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      h3: 1.15.6
-      impound: 1.1.5
-      klona: 2.0.6
-      mocked-exports: 0.1.1
-      nitropack: 2.13.1(@libsql/client@0.17.0)(better-sqlite3@12.6.2)(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2))(rolldown@1.0.0-rc.8)
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@libsql/client@0.17.0)(@parcel/watcher@2.5.1)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.0)(better-sqlite3@12.6.2)(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)))(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2))(esbuild@0.27.3)(eslint@10.0.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.52.0)(rolldown@1.0.0-rc.8)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.8)(rollup@4.57.1))(rollup@4.57.1)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
-      nypm: 0.6.5
-      ohash: 2.0.11
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      rou3: 0.8.1
-      std-env: 4.0.0
-      ufo: 1.6.3
-      unctx: 2.5.0
-      unstorage: 1.17.4(db0@0.3.4(@libsql/client@0.17.0)(better-sqlite3@12.6.2)(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)))(ioredis@5.9.3)
-      vue: 3.5.30(typescript@5.9.3)
-      vue-bundle-renderer: 2.2.0
-      vue-devtools-stub: 0.1.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@babel/core'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bare-abort-controller
-      - better-sqlite3
-      - db0
-      - drizzle-orm
-      - encoding
-      - idb-keyval
-      - ioredis
-      - magicast
-      - mysql2
-      - react-native-b4a
-      - rolldown
-      - sqlite3
-      - supports-color
-      - typescript
-      - uploadthing
-      - xml2js
 
   '@nuxt/nitro-server@4.4.2(372528ba01d52a0033a13ca0620b0c27)':
     dependencies:
@@ -10907,6 +10846,74 @@ snapshots:
       - uploadthing
       - xml2js
 
+  '@nuxt/nitro-server@4.4.2(665491ecb54797dbfb2b1e31e798d436)':
+    dependencies:
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@nuxt/devalue': 2.0.2
+      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.9.3))
+      '@vue/shared': 3.5.30
+      consola: 3.4.2
+      defu: 6.1.4
+      destr: 2.0.5
+      devalue: 5.6.4
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      h3: 1.15.6
+      impound: 1.1.5
+      klona: 2.0.6
+      mocked-exports: 0.1.1
+      nitropack: 2.13.1(@libsql/client@0.17.0)(better-sqlite3@12.6.2)(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2))(rolldown@1.0.0-rc.8)
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@libsql/client@0.17.0)(@parcel/watcher@2.5.1)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.0)(better-sqlite3@12.6.2)(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)))(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2))(esbuild@0.27.3)(eslint@10.0.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.52.0)(rolldown@1.0.0-rc.8)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.8)(rollup@4.57.1))(rollup@4.57.1)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
+      nypm: 0.6.5
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      rou3: 0.8.1
+      std-env: 4.0.0
+      ufo: 1.6.3
+      unctx: 2.5.0
+      unstorage: 1.17.4(db0@0.3.4(@libsql/client@0.17.0)(better-sqlite3@12.6.2)(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)))(ioredis@5.9.3)
+      vue: 3.5.30(typescript@5.9.3)
+      vue-bundle-renderer: 2.2.0
+      vue-devtools-stub: 0.1.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/core'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bare-abort-controller
+      - better-sqlite3
+      - db0
+      - drizzle-orm
+      - encoding
+      - idb-keyval
+      - ioredis
+      - magicast
+      - mysql2
+      - react-native-b4a
+      - rolldown
+      - sqlite3
+      - supports-color
+      - typescript
+      - uploadthing
+      - xml2js
+
   '@nuxt/schema@3.20.1':
     dependencies:
       '@vue/shared': 3.5.30
@@ -10923,6 +10930,15 @@ snapshots:
       pkg-types: 2.3.0
       std-env: 4.0.0
 
+  '@nuxt/telemetry@2.7.0(@nuxt/kit@4.4.2(magicast@0.3.5))':
+    dependencies:
+      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      citty: 0.2.1
+      consola: 3.4.2
+      ofetch: 2.0.0-alpha.3
+      rc9: 3.0.0
+      std-env: 3.10.0
+
   '@nuxt/telemetry@2.7.0(@nuxt/kit@4.4.2(magicast@0.5.1))':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.1)
@@ -10932,21 +10948,12 @@ snapshots:
       rc9: 3.0.0
       std-env: 3.10.0
 
-  '@nuxt/telemetry@2.7.0(@nuxt/kit@4.4.2(magicast@0.5.2))':
-    dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      citty: 0.2.1
-      consola: 3.4.2
-      ofetch: 2.0.0-alpha.3
-      rc9: 3.0.0
-      std-env: 3.10.0
-
-  '@nuxt/test-utils@4.0.0(jsdom@26.1.0)(magicast@0.5.1)(playwright-core@1.58.2)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vitest@4.1.0)':
+  '@nuxt/test-utils@4.0.0(jsdom@26.1.0)(magicast@0.3.5)(playwright-core@1.58.2)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vitest@4.1.0)':
     dependencies:
       '@clack/prompts': 1.0.0
-      '@nuxt/devtools-kit': 2.7.0(magicast@0.5.1)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
-      '@nuxt/kit': 3.21.1(magicast@0.5.1)
-      c12: 3.3.3(magicast@0.5.1)
+      '@nuxt/devtools-kit': 2.7.0(magicast@0.3.5)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      '@nuxt/kit': 3.21.1(magicast@0.3.5)
+      c12: 3.3.3(magicast@0.3.5)
       consola: 3.4.2
       defu: 6.1.4
       destr: 2.0.5
@@ -10970,7 +10977,7 @@ snapshots:
       tinyexec: 1.0.2
       ufo: 1.6.3
       unplugin: 3.0.0
-      vitest-environment-nuxt: 1.0.1(jsdom@26.1.0)(magicast@0.5.1)(playwright-core@1.58.2)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vitest@4.1.0)
+      vitest-environment-nuxt: 1.0.1(jsdom@26.1.0)(magicast@0.3.5)(playwright-core@1.58.2)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vitest@4.1.0)
       vue: 3.5.29(typescript@5.9.3)
     optionalDependencies:
       jsdom: 26.1.0
@@ -10982,9 +10989,9 @@ snapshots:
       - typescript
       - vite
 
-  '@nuxt/vite-builder@4.4.2(0f6b729c35afcd5d41c61f027c92d589)':
+  '@nuxt/vite-builder@4.4.2(c2106b64280613a921f09d499c62ee99)':
     dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      '@nuxt/kit': 4.4.2(magicast@0.5.1)
       '@rollup/plugin-replace': 6.0.3(rollup@4.57.1)
       '@vitejs/plugin-vue': 6.0.4(rolldown-vite@7.3.1(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
       '@vitejs/plugin-vue-jsx': 5.1.4(rolldown-vite@7.3.1(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
@@ -11000,7 +11007,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.1
       mocked-exports: 0.1.1
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@libsql/client@0.17.0)(@parcel/watcher@2.5.1)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.0)(better-sqlite3@12.6.2)(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)))(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2))(esbuild@0.27.3)(eslint@10.0.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.52.0)(rolldown@1.0.0-rc.8)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.8)(rollup@4.57.1))(rollup@4.57.1)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@libsql/client@0.17.0)(@parcel/watcher@2.5.1)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.0)(better-sqlite3@12.6.2)(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)))(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2))(esbuild@0.27.3)(eslint@10.0.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.52.0)(rolldown@1.0.0-rc.8)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.8)(rollup@4.57.1))(rollup@4.57.1)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -11043,9 +11050,9 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.4.2(c2106b64280613a921f09d499c62ee99)':
+  '@nuxt/vite-builder@4.4.2(ff10b69c4df98f7f3a408f08df888f35)':
     dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.5.1)
+      '@nuxt/kit': 4.4.2(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.3(rollup@4.57.1)
       '@vitejs/plugin-vue': 6.0.4(rolldown-vite@7.3.1(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
       '@vitejs/plugin-vue-jsx': 5.1.4(rolldown-vite@7.3.1(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
@@ -11061,7 +11068,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.1
       mocked-exports: 0.1.1
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@libsql/client@0.17.0)(@parcel/watcher@2.5.1)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.0)(better-sqlite3@12.6.2)(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)))(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2))(esbuild@0.27.3)(eslint@10.0.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.52.0)(rolldown@1.0.0-rc.8)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.8)(rollup@4.57.1))(rollup@4.57.1)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@libsql/client@0.17.0)(@parcel/watcher@2.5.1)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.0)(better-sqlite3@12.6.2)(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)))(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2))(esbuild@0.27.3)(eslint@10.0.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.52.0)(rolldown@1.0.0-rc.8)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.8)(rollup@4.57.1))(rollup@4.57.1)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -12075,7 +12082,7 @@ snapshots:
 
   '@unhead/vue@2.1.12(vue@3.5.30(typescript@5.9.3))':
     dependencies:
-      hookable: 6.0.1
+      hookable: 6.1.0
       unhead: 2.1.12
       vue: 3.5.30(typescript@5.9.3)
 
@@ -12842,9 +12849,9 @@ snapshots:
 
   change-case@5.4.4: {}
 
-  changelogen@0.6.2(magicast@0.5.1):
+  changelogen@0.6.2(magicast@0.3.5):
     dependencies:
-      c12: 3.3.3(magicast@0.5.1)
+      c12: 3.3.3(magicast@0.3.5)
       confbox: 0.2.4
       consola: 3.4.2
       convert-gitmoji: 0.1.5
@@ -15496,9 +15503,9 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt-site-config-kit@3.2.21(magicast@0.5.1)(vue@3.5.30(typescript@5.9.3)):
+  nuxt-site-config-kit@3.2.21(magicast@0.3.5)(vue@3.5.30(typescript@5.9.3)):
     dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.5.1)
+      '@nuxt/kit': 4.4.2(magicast@0.3.5)
       pkg-types: 2.3.0
       site-config-stack: 3.2.21(vue@3.5.30(typescript@5.9.3))
       std-env: 3.10.0
@@ -15507,12 +15514,12 @@ snapshots:
       - magicast
       - vue
 
-  nuxt-site-config@3.2.21(magicast@0.5.1)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3)):
+  nuxt-site-config@3.2.21(magicast@0.3.5)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3)):
     dependencies:
-      '@nuxt/devtools-kit': 3.2.2(magicast@0.5.1)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
-      '@nuxt/kit': 4.4.2(magicast@0.5.1)
+      '@nuxt/devtools-kit': 3.2.2(magicast@0.3.5)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      '@nuxt/kit': 4.4.2(magicast@0.3.5)
       h3: 1.15.5
-      nuxt-site-config-kit: 3.2.21(magicast@0.5.1)(vue@3.5.30(typescript@5.9.3))
+      nuxt-site-config-kit: 3.2.21(magicast@0.3.5)(vue@3.5.30(typescript@5.9.3))
       pathe: 2.0.3
       pkg-types: 2.3.0
       sirv: 3.0.2
@@ -15523,19 +15530,19 @@ snapshots:
       - vite
       - vue
 
-  nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@libsql/client@0.17.0)(@parcel/watcher@2.5.1)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.0)(better-sqlite3@12.6.2)(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)))(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2))(esbuild@0.27.3)(eslint@10.0.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.52.0)(rolldown@1.0.0-rc.8)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.8)(rollup@4.57.1))(rollup@4.57.1)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2):
+  nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@libsql/client@0.17.0)(@parcel/watcher@2.5.1)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.0)(better-sqlite3@12.6.2)(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)))(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2))(esbuild@0.27.3)(eslint@10.0.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.52.0)(rolldown@1.0.0-rc.8)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.8)(rollup@4.57.1))(rollup@4.57.1)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2):
     dependencies:
-      '@dxup/nuxt': 0.4.0(magicast@0.5.1)(typescript@5.9.3)
-      '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.1)
+      '@dxup/nuxt': 0.4.0(magicast@0.3.5)(typescript@5.9.3)
+      '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.3.5)
       '@nuxt/devtools': 3.2.4(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
-      '@nuxt/kit': 4.4.2(magicast@0.5.1)
-      '@nuxt/nitro-server': 4.4.2(372528ba01d52a0033a13ca0620b0c27)
+      '@nuxt/kit': 4.4.2(magicast@0.3.5)
+      '@nuxt/nitro-server': 4.4.2(665491ecb54797dbfb2b1e31e798d436)
       '@nuxt/schema': 4.4.2
-      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.4.2(magicast@0.5.1))
-      '@nuxt/vite-builder': 4.4.2(c2106b64280613a921f09d499c62ee99)
+      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.4.2(magicast@0.3.5))
+      '@nuxt/vite-builder': 4.4.2(ff10b69c4df98f7f3a408f08df888f35)
       '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.9.3))
       '@vue/shared': 3.5.30
-      c12: 3.3.3(magicast@0.5.1)
+      c12: 3.3.3(magicast@0.3.5)
       chokidar: 5.0.0
       compatx: 0.2.0
       consola: 3.4.2
@@ -15652,19 +15659,19 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@libsql/client@0.17.0)(@parcel/watcher@2.5.1)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.0)(better-sqlite3@12.6.2)(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)))(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2))(esbuild@0.27.3)(eslint@10.0.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.52.0)(rolldown@1.0.0-rc.8)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.8)(rollup@4.57.1))(rollup@4.57.1)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2):
+  nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@libsql/client@0.17.0)(@parcel/watcher@2.5.1)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.0)(better-sqlite3@12.6.2)(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)))(drizzle-orm@0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2))(esbuild@0.27.3)(eslint@10.0.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.52.0)(rolldown@1.0.0-rc.8)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.8)(rollup@4.57.1))(rollup@4.57.1)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2):
     dependencies:
-      '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@5.9.3)
-      '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
+      '@dxup/nuxt': 0.4.0(magicast@0.5.1)(typescript@5.9.3)
+      '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.1)
       '@nuxt/devtools': 3.2.4(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.2(0ae7c63400f7eda6d3ee6687e83810f8)
+      '@nuxt/kit': 4.4.2(magicast@0.5.1)
+      '@nuxt/nitro-server': 4.4.2(372528ba01d52a0033a13ca0620b0c27)
       '@nuxt/schema': 4.4.2
-      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.4.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.2(0f6b729c35afcd5d41c61f027c92d589)
+      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.4.2(magicast@0.5.1))
+      '@nuxt/vite-builder': 4.4.2(c2106b64280613a921f09d499c62ee99)
       '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.9.3))
       '@vue/shared': 3.5.30
-      c12: 3.3.3(magicast@0.5.2)
+      c12: 3.3.3(magicast@0.5.1)
       chokidar: 5.0.0
       compatx: 0.2.0
       consola: 3.4.2
@@ -17346,17 +17353,11 @@ snapshots:
 
   tldts-core@6.1.86: {}
 
-  tldts-core@7.0.19: {}
-
   tldts-core@7.0.26: {}
 
   tldts@6.1.86:
     dependencies:
       tldts-core: 6.1.86
-
-  tldts@7.0.19:
-    dependencies:
-      tldts-core: 7.0.19
 
   tldts@7.0.26:
     dependencies:
@@ -17391,7 +17392,7 @@ snapshots:
 
   tough-cookie@6.0.0:
     dependencies:
-      tldts: 7.0.19
+      tldts: 7.0.26
 
   tr46@0.0.3: {}
 
@@ -17533,7 +17534,7 @@ snapshots:
 
   unhead@2.1.12:
     dependencies:
-      hookable: 6.0.1
+      hookable: 6.1.0
 
   unicode-emoji-modifier-base@1.0.0: {}
 
@@ -17797,9 +17798,9 @@ snapshots:
       terser: 5.44.1
       yaml: 2.8.2
 
-  vitest-environment-nuxt@1.0.1(jsdom@26.1.0)(magicast@0.5.1)(playwright-core@1.58.2)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vitest@4.1.0):
+  vitest-environment-nuxt@1.0.1(jsdom@26.1.0)(magicast@0.3.5)(playwright-core@1.58.2)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vitest@4.1.0):
     dependencies:
-      '@nuxt/test-utils': 4.0.0(jsdom@26.1.0)(magicast@0.5.1)(playwright-core@1.58.2)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vitest@4.1.0)
+      '@nuxt/test-utils': 4.0.0(jsdom@26.1.0)(magicast@0.3.5)(playwright-core@1.58.2)(typescript@5.9.3)(vite@7.2.6(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vitest@4.1.0)
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@jest/globals'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,6 +40,7 @@ catalog:
   '@vitest/browser-playwright': ^4.1.0
   ai: ^6.0.116
   bumpp: ^11.0.1
+  c12: ^3.0.4
   cac: ^7.0.0
   changelogen: ^0.6.2
   compression: ^1.8.1
@@ -49,6 +50,7 @@ catalog:
   defu: ^6.1.4
   eslint: ^10.0.3
   express: ^5.2.1
+  hookable: ^5.5.3
   llm-cost: ^1.0.5
   miniflare: ^4.20260317.0
   node-html-markdown: ^2.0.0
@@ -62,6 +64,7 @@ catalog:
   playwright: ^1.58.2
   sirv: ^3.0.2
   tinyglobby: ^0.2.15
+  tldts: ^7.0.26
   tslib: ^2.8.1
   turndown: ^7.2.2
   turndown-plugin-gfm: ^1.0.2


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #26

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Adds c12-based config file loading (`mdream.config.ts`) and four hookable hooks (`crawl:url`, `crawl:page`, `crawl:content`, `crawl:done`) to `@mdream/crawl`. This enables users to exclude paths, transform page titles (e.g. strip branding suffixes), modify content before disk write, and filter/reorder results before llms.txt generation, all without forking the crawler.

The `onPage` callback continues to work via backwards-compatible conversion to the `crawl:page` hook. CLI args override config file values, and array options like `exclude` are concatenated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration file support (mdream.config.ts/js) now available for persisting crawl settings
  * Hooks system added with four lifecycle events (crawl:url, crawl:page, crawl:content, crawl:done) for extended customization
  * defineConfig helper function available for type-safe configuration management

* **Deprecations**
  * onPage callback deprecated; use hooks['crawl:page'] instead (backward compatible)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->