### PR TITLE
fix: include `<th>` cells in table cell detection for HTML passthrough

### DIFF
--- a/crates/core/src/convert.rs
+++ b/crates/core/src/convert.rs
@@ -255,6 +255,12 @@ pub struct ConvertState {
 }
 
 impl ConvertState {
+    /// Check if we're inside a table cell (either `<td>` or `<th>`).
+    #[inline]
+    fn in_table_cell(&self) -> bool {
+        self.depth_map[TAG_TD as usize] > 0 || self.depth_map[TAG_TH as usize] > 0
+    }
+
     pub fn new(options: HTMLToMarkdownOptions, capacity: usize) -> Self {
         let mut s = Self {
             depth_map: [0; MAX_TAG_ID],
@@ -1040,7 +1046,7 @@ impl ConvertState {
             TAG_DETAILS => Some(Cow::Borrowed("<details>")),
             TAG_SUMMARY => Some(Cow::Borrowed("<summary>")),
             TAG_BR => {
-                if self.depth_map[TAG_TD as usize] > 0 { Some(Cow::Borrowed("<br>")) } else { None }
+                if self.in_table_cell() { Some(Cow::Borrowed("<br>")) } else { None }
             }
             TAG_H1 | TAG_H2 | TAG_H3 | TAG_H4 | TAG_H5 | TAG_H6 => {
                 let depth = (tag_id - TAG_H1) as usize;
@@ -1119,13 +1125,13 @@ impl ConvertState {
                 }
             }
             TAG_UL => {
-                if self.depth_map[TAG_TD as usize] > 0 { Some(Cow::Borrowed("<ul>")) } else { None }
+                if self.in_table_cell() { Some(Cow::Borrowed("<ul>")) } else { None }
             }
             TAG_OL => {
-                if self.depth_map[TAG_TD as usize] > 0 { Some(Cow::Borrowed("<ol>")) } else { None }
+                if self.in_table_cell() { Some(Cow::Borrowed("<ol>")) } else { None }
             }
             TAG_LI => {
-                if self.depth_map[TAG_TD as usize] > 0 {
+                if self.in_table_cell() {
                     return Some(Cow::Borrowed("<li>"));
                 }
                 let ul_depth = self.depth_map[TAG_UL as usize] as usize;
@@ -1164,13 +1170,13 @@ impl ConvertState {
                 }
             }
             TAG_TABLE => {
-                if self.depth_map[TAG_TD as usize] > 0 { Some(Cow::Borrowed("<table>")) } else { None }
+                if self.in_table_cell() { Some(Cow::Borrowed("<table>")) } else { None }
             }
             TAG_THEAD => {
-                if self.depth_map[TAG_TD as usize] > 0 { Some(Cow::Borrowed("<thead>")) } else { None }
+                if self.in_table_cell() { Some(Cow::Borrowed("<thead>")) } else { None }
             }
             TAG_TR => {
-                if self.depth_map[TAG_TD as usize] > 0 { Some(Cow::Borrowed("<tr>")) }
+                if self.in_table_cell() { Some(Cow::Borrowed("<tr>")) }
                 else { Some(Cow::Borrowed("| ")) }
             }
             TAG_TH => {
@@ -1235,13 +1241,13 @@ impl ConvertState {
                 }
             }
             TAG_UL => {
-                if self.depth_map[TAG_TD as usize] > 0 { Some(Cow::Borrowed("</ul>")) } else { None }
+                if self.in_table_cell() { Some(Cow::Borrowed("</ul>")) } else { None }
             }
             TAG_OL => {
-                if self.depth_map[TAG_TD as usize] > 0 { Some(Cow::Borrowed("</ol>")) } else { None }
+                if self.in_table_cell() { Some(Cow::Borrowed("</ol>")) } else { None }
             }
             TAG_LI => {
-                if self.depth_map[TAG_TD as usize] > 0 { Some(Cow::Borrowed("</li>")) } else { None }
+                if self.in_table_cell() { Some(Cow::Borrowed("</li>")) } else { None }
             }
             TAG_A => {
                 if let Some(href) = node.attributes.get("href") {
@@ -1275,13 +1281,13 @@ impl ConvertState {
                 }
             }
             TAG_TABLE => {
-                if self.depth_map[TAG_TD as usize] > 0 { Some(Cow::Borrowed("</table>")) } else { None }
+                if self.in_table_cell() { Some(Cow::Borrowed("</table>")) } else { None }
             }
             TAG_THEAD => {
-                if self.depth_map[TAG_TD as usize] > 0 { Some(Cow::Borrowed("</thead>")) } else { None }
+                if self.in_table_cell() { Some(Cow::Borrowed("</thead>")) } else { None }
             }
             TAG_TR => {
-                if self.depth_map[TAG_TD as usize] > 0 || self.depth_map[TAG_TABLE as usize] > 1 {
+                if self.in_table_cell() || self.depth_map[TAG_TABLE as usize] > 1 {
                     Some(Cow::Borrowed("</tr>"))
                 } else {
                     Some(Cow::Borrowed(" |"))

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -154,7 +154,7 @@ function resolveUrl(url: string, origin?: string): string {
 
 // Helper function to check if we're inside a table cell
 function isInsideTableCell(node: HandlerContext['node']): boolean {
-  return (node.depthMap[TAG_TD] || 0) > 0
+  return (node.depthMap[TAG_TD] || 0) > 0 || (node.depthMap[TAG_TH] || 0) > 0
 }
 
 // Helper function to get language from code class attribute

--- a/packages/mdream/test/unit/nodes/table.test.ts
+++ b/packages/mdream/test/unit/nodes/table.test.ts
@@ -183,6 +183,45 @@ describe.each(engines)('tables $name', (engineConfig) => {
     expect(streamed.trim()).toBe(md)
   })
 
+  it('handles lists inside th cells as HTML passthrough', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const html = `
+      <table>
+        <tr>
+          <th><ul><li>A</li><li>B</li></ul></th>
+          <th>Normal</th>
+        </tr>
+        <tr>
+          <td>Value</td>
+          <td>Text</td>
+        </tr>
+      </table>
+    `
+    const markdown = htmlToMarkdown(html, { engine })
+    // list inside th should render as HTML, not as markdown list markers
+    expect(markdown).toContain('<ul>')
+    expect(markdown).toContain('<li>')
+    expect(markdown).not.toMatch(/^- A/m)
+  })
+
+  it('handles br inside th cells', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const html = `
+      <table>
+        <tr>
+          <th>Line 1<br>Line 2</th>
+          <th>Header</th>
+        </tr>
+        <tr>
+          <td>Value</td>
+          <td>Data</td>
+        </tr>
+      </table>
+    `
+    const markdown = htmlToMarkdown(html, { engine })
+    expect(markdown).toContain('Line 1<br>Line 2')
+  })
+
   it('github advanced example', async () => {
     const engine = await resolveEngine(engineConfig.engine)
     const html = `


### PR DESCRIPTION
`isInsideTableCell` (JS) and the equivalent depth checks in the Rust engine only tested `TAG_TD`, so child elements inside `<th>` header cells got wrong treatment:

- `<br>` silently dropped instead of preserved as `<br>`
- `<ul>`/`<ol>` rendered as markdown list markers, breaking table structure
- nested `<table>`, `<thead>`, `<tr>` not wrapped in HTML passthrough

JS fix: one-liner adding `TAG_TH` to `isInsideTableCell`. Rust fix: extracted an `in_table_cell()` helper and replaced all 13 bare `TAG_TD` checks with it.

Tests cover both list-in-th and br-in-th scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of line breaks, lists, and nested tables within table header cells to be consistent with regular table cells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->