### PR TITLE
fix(rust): opening tags inside <script> bypasses quote tracking

### DIFF
--- a/crates/core/src/convert.rs
+++ b/crates/core/src/convert.rs
@@ -562,6 +562,19 @@ impl ConvertState {
                 }
             } else {
                 // Opening tag
+                // For non-nesting tags that exclude text nodes (script, style),
+                // skip ALL opening tags — only the matching closing tag should exit the mode.
+                // Without this, text like `<script>` in JS comments/strings gets misinterpreted
+                // as a real nested tag, corrupting the tag stack.
+                if self.in_non_nesting {
+                    if let Some(parent) = self.stack.last() {
+                        if parent.excludes_text_nodes {
+                            text_buffer.push(cc as char);
+                            i += 1;
+                            continue;
+                        }
+                    }
+                }
                 let mut i2 = i + 1;
                 let tag_name_start = i2;
                 let mut tag_name_end = None;

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -1160,3 +1160,18 @@ fn style_tag_with_angle_bracket_selector() {
     let result = convert("<head><style>div > p { color: red; }</style></head><body><p>Styled</p></body>");
     assert!(result.contains("Styled"));
 }
+
+#[test]
+fn script_with_inline_svg_containing_script_tag_reference() {
+    // Script content that mentions <script> in a JS comment or string should not
+    // corrupt the tag stack. The parser must only exit non-nesting mode on the
+    // matching closing tag (</script>), ignoring opening tags like <script> in text.
+    let html = r#"<head><script>
+    // load <script> in <head> via nuxt.config.ts
+    var icon = '<svg width="48" height="48"><path d="M12 9v4" stroke-width="2" stroke-linecap="round"/></svg>';
+    for (var i = 0; i < buttons.length; i++) { }
+    </script></head><body><main><h1>Title</h1><p>Body content here</p></main></body>"#;
+    let result = convert(html);
+    assert!(result.contains("Title"), "Title missing from output: {}", result);
+    assert!(result.contains("Body content here"), "Body content missing from output: {}", result);
+}


### PR DESCRIPTION
## Bug

When a `<script>` tag contains text that references `<script>` (e.g. in a JS comment like `// load <script> in <head>`), the Rust parser's TURBO SKIP optimization skips quote tracking for `excludesTextNodes` elements. This means when the parser encounters `<script>` text inside the script content, it cannot rely on `in_quotes` to skip it , and since the tag name matches the current non-nesting tag, the parser treats it as a real nested `<script>` opening tag.

This corrupts the tag stack: the real `</script>` closes the phantom nested tag instead of the original, and everything after , including the entire `<body>`, is swallowed. The output is just the page title.

### Reproducer

Any page with an inline script that references its own tag name in comments or string literals:

```html
<head>
  <script>
    // load <script> in <head> via config
    var icon = '<svg><path d="M12 9v4"/></svg>';
  </script>
</head>
<body>
  <h1>This content is lost</h1>
</body>
```

Real-world trigger: Nuxt browser-guard scripts that contain inline SVG and `<script>` references.

## Fix

For non-nesting tags with `excludesTextNodes` (script, style, noscript), skip **all** opening tags — only the matching closing tag (`</script>`) should be able to exit non-nesting mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parser to correctly handle script and style tag content containing HTML-like text, preventing misinterpretation and parsing errors.

* **Tests**
  * Added test validating parser behavior with HTML-like text in script tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->