### PR TITLE
fix(lists): handle code blocks and inline code inside list items

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -221,11 +221,11 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "mdream"
-version = "1.0.3"
+version = "1.0.4"
 
 [[package]]
 name = "mdream-edge"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "js-sys",
  "mdream",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "mdream-node"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "mdream",
  "napi",

--- a/crates/core/src/convert.rs
+++ b/crates/core/src/convert.rs
@@ -983,20 +983,40 @@ impl ConvertState {
         }
 
         // Indent code block content inside a list item so the fenced block stays
-        // within the list item's content column.
+        // within the list item's content column. Skip indent for blank lines and
+        // lines that already begin with whitespace — preserves the original
+        // indentation structure from the HTML and matches the JS engine.
         let li_depth = self.depth_map[TAG_LI as usize] as usize;
         let indented_storage;
-        let text = if self.depth_map[TAG_PRE as usize] > 0 && li_depth > 0 && text.contains('\n') {
+        let text = if self.depth_map[TAG_PRE as usize] > 0 && li_depth > 0
+            && (text.contains('\n') || last_char == b'\n') {
             let indent = "  ".repeat(li_depth);
-            let trimmed = text.trim_end_matches('\n');
-            let mut out = String::with_capacity(trimmed.len() + indent.len() * 2);
-            for (i, line) in trimmed.split('\n').enumerate() {
-                if i > 0 {
-                    out.push('\n');
+            let mut out = String::with_capacity(text.len() + indent.len() * 2);
+            let bytes = text.as_bytes();
+            // Prepend indent for the first line when the buffer ended with a
+            // newline (code fence opener) and this text doesn't already start
+            // with leading whitespace.
+            if last_char == b'\n' {
+                let first = bytes.first().copied().unwrap_or(0);
+                if first != b' ' && first != b'\t' && first != b'\n' {
                     out.push_str(&indent);
                 }
-                out.push_str(line);
             }
+            let mut prev = 0usize;
+            for (i, &b) in bytes.iter().enumerate() {
+                if b == b'\n' {
+                    out.push_str(&text[prev..=i]);
+                    let next = i + 1;
+                    if next < bytes.len() {
+                        let c = bytes[next];
+                        if c != b' ' && c != b'\t' && c != b'\n' {
+                            out.push_str(&indent);
+                        }
+                    }
+                    prev = next;
+                }
+            }
+            out.push_str(&text[prev..]);
             indented_storage = out;
             indented_storage.as_str()
         } else {

--- a/crates/core/src/convert.rs
+++ b/crates/core/src/convert.rs
@@ -2009,11 +2009,14 @@ impl ConvertState {
     #[inline]
     fn update_escape_ctx_on_close(&mut self, id: u8) {
         match id {
-            TAG_TABLE => { if self.depth_map[id as usize] == 0 { self.escape_ctx &= !ESC_TABLE; } }
-            TAG_CODE => { if self.depth_map[TAG_CODE as usize] == 0 && self.depth_map[TAG_PRE as usize] == 0 { self.escape_ctx &= !ESC_CODE_PRE; } }
-            TAG_PRE => { if self.depth_map[TAG_PRE as usize] == 0 { self.in_pre = false; if self.depth_map[TAG_CODE as usize] == 0 { self.escape_ctx &= !ESC_CODE_PRE; } } }
-            TAG_A => { if self.depth_map[id as usize] == 0 { self.escape_ctx &= !ESC_LINK; } }
-            TAG_BLOCKQUOTE => { if self.depth_map[id as usize] == 0 { self.escape_ctx &= !ESC_BLOCKQUOTE; } }
+            TAG_TABLE if self.depth_map[id as usize] == 0 => self.escape_ctx &= !ESC_TABLE,
+            TAG_CODE if self.depth_map[TAG_CODE as usize] == 0 && self.depth_map[TAG_PRE as usize] == 0 => self.escape_ctx &= !ESC_CODE_PRE,
+            TAG_PRE if self.depth_map[TAG_PRE as usize] == 0 => {
+                self.in_pre = false;
+                if self.depth_map[TAG_CODE as usize] == 0 { self.escape_ctx &= !ESC_CODE_PRE; }
+            }
+            TAG_A if self.depth_map[id as usize] == 0 => self.escape_ctx &= !ESC_LINK,
+            TAG_BLOCKQUOTE if self.depth_map[id as usize] == 0 => self.escape_ctx &= !ESC_BLOCKQUOTE,
             _ => {}
         }
     }

--- a/crates/core/src/convert.rs
+++ b/crates/core/src/convert.rs
@@ -982,6 +982,27 @@ impl ConvertState {
             return;
         }
 
+        // Indent code block content inside a list item so the fenced block stays
+        // within the list item's content column.
+        let li_depth = self.depth_map[TAG_LI as usize] as usize;
+        let indented_storage;
+        let text = if self.depth_map[TAG_PRE as usize] > 0 && li_depth > 0 && text.contains('\n') {
+            let indent = "  ".repeat(li_depth);
+            let trimmed = text.trim_end_matches('\n');
+            let mut out = String::with_capacity(trimmed.len() + indent.len() * 2);
+            for (i, line) in trimmed.split('\n').enumerate() {
+                if i > 0 {
+                    out.push('\n');
+                    out.push_str(&indent);
+                }
+                out.push_str(line);
+            }
+            indented_storage = out;
+            indented_storage.as_str()
+        } else {
+            text
+        };
+
         if self.should_add_spacing_before_text(last_char, text) {
             self.buffer.push(' ');
             self.last_content_cache_len = text.len() + 1;
@@ -1058,6 +1079,12 @@ impl ConvertState {
                         return Some(Cow::Owned(s));
                     }
                 }
+                if self.depth_map[TAG_LI as usize] > 0 {
+                    let last_char = self.buffer.as_bytes().last().copied().unwrap_or(0);
+                    if last_char != 0 && last_char != b' ' && last_char != b'\n' {
+                        return Some(Cow::Borrowed(" "));
+                    }
+                }
                 None
             }
             TAG_BLOCKQUOTE => {
@@ -1080,16 +1107,32 @@ impl ConvertState {
             TAG_CODE => {
                 if self.depth_map[TAG_PRE as usize] > 0 {
                     let lang = Self::get_language_from_class(node.attributes.get("class"));
-                    if lang.is_empty() {
+                    let li_depth = self.depth_map[TAG_LI as usize] as usize;
+                    if li_depth > 0 {
+                        let indent = "  ".repeat(li_depth);
+                        let mut s = String::with_capacity(2 + indent.len() * 2 + 4 + lang.len() + 1);
+                        s.push_str("\n\n");
+                        s.push_str(&indent);
+                        s.push_str("```");
+                        s.push_str(lang);
+                        s.push('\n');
+                        s.push_str(&indent);
+                        Some(Cow::Owned(s))
+                    } else if lang.is_empty() {
                         Some(Cow::Borrowed("```\n"))
                     } else {
-                        {
-                            let mut s = String::with_capacity(4 + lang.len());
-                            s.push_str("```");
-                            s.push_str(lang);
-                            s.push('\n');
-                            Some(Cow::Owned(s))
-                        }
+                        let mut s = String::with_capacity(4 + lang.len());
+                        s.push_str("```");
+                        s.push_str(lang);
+                        s.push('\n');
+                        Some(Cow::Owned(s))
+                    }
+                } else if self.depth_map[TAG_LI as usize] > 0 {
+                    let last_char = self.buffer.as_bytes().last().copied().unwrap_or(0);
+                    if last_char != 0 && last_char != b' ' && last_char != b'\n' {
+                        Some(Cow::Borrowed(" `"))
+                    } else {
+                        Some(Cow::Borrowed(MARKDOWN_INLINE_CODE))
                     }
                 } else {
                     Some(Cow::Borrowed(MARKDOWN_INLINE_CODE))
@@ -1206,7 +1249,18 @@ impl ConvertState {
             TAG_INS => Some(Cow::Borrowed("</ins>")),
             TAG_CODE => {
                 if self.depth_map[TAG_PRE as usize] > 0 {
-                    Some(Cow::Borrowed("\n```"))
+                    let li_depth = self.depth_map[TAG_LI as usize] as usize;
+                    if li_depth > 0 {
+                        let indent = "  ".repeat(li_depth);
+                        let mut s = String::with_capacity(1 + indent.len() * 2 + 5);
+                        s.push('\n');
+                        s.push_str(&indent);
+                        s.push_str("```\n\n");
+                        s.push_str(&indent);
+                        Some(Cow::Owned(s))
+                    } else {
+                        Some(Cow::Borrowed("\n```"))
+                    }
                 } else {
                     Some(Cow::Borrowed(MARKDOWN_INLINE_CODE))
                 }

--- a/crates/core/src/helpers.rs
+++ b/crates/core/src/helpers.rs
@@ -185,6 +185,7 @@ pub(crate) fn process_tag_attributes(html_chunk: &str, position: usize, tag_hand
     (false, i, Attributes::new(), false)
 }
 
+#[allow(clippy::collapsible_match)]
 pub(crate) fn parse_attributes(attr_str: &str) -> Attributes {
     let mut result = Attributes::with_capacity(4);
     if attr_str.is_empty() {

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -191,6 +191,22 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
           textNode.value = ` ${textNode.value}`
         }
 
+        // Indent code block content when inside a list item so the fenced block
+        // stays within the list item's content column. Only add indent to lines
+        // that start at column 0 — preserves any existing indentation in the
+        // HTML source and stays safe for text nodes that span stream chunks.
+        if ((state.depthMap[TAG_PRE] || 0) > 0 && (state.depthMap[TAG_LI] || 0) > 0) {
+          const indent = '  '.repeat(state.depthMap[TAG_LI]!)
+          let value = textNode.value.replace(/\n(?=[^ \t\n])/g, `\n${indent}`)
+          // Prepend indent for first line if the previous buffer ended with a
+          // newline (code fence opener) and the text doesn't already start with
+          // leading whitespace.
+          if (lastChar === '\n' && value[0] && value[0] !== ' ' && value[0] !== '\t' && value[0] !== '\n') {
+            value = indent + value
+          }
+          textNode.value = value
+        }
+
         state.buffer.push(textNode.value)
         state.lastContentCache = textNode.value
       }

--- a/packages/js/src/stream.ts
+++ b/packages/js/src/stream.ts
@@ -26,7 +26,7 @@ export async function* streamHtmlToMarkdown(
 
   const processor = createMarkdownProcessor(options, resolvedPlugins, tagOverrideHandlers)
   const parseState: ParseState = {
-    depthMap: new Uint8Array(1024),
+    depthMap: processor.state.depthMap,
     depth: 0,
     resolvedPlugins,
     tagOverrideHandlers,

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -331,17 +331,37 @@ export const tagHandlers: Record<number, TagHandler> = {
     spacing: BLOCKQUOTE_SPACING,
   },
   [TAG_CODE]: {
-    enter: ({ node }) => {
+    enter: ({ node, state }) => {
       if ((node.depthMap[TAG_PRE] || 0) > 0) {
         const language = getLanguageFromClass(node.attributes?.class)
+        const liDepth = node.depthMap[TAG_LI] || 0
+        if (liDepth > 0) {
+          const indent = '  '.repeat(liDepth)
+          return `\n\n${indent}${MARKDOWN_CODE_BLOCK}${language}\n`
+        }
         return `${MARKDOWN_CODE_BLOCK}${language}\n`
+      }
+      // Inline code: inside a list item, the usual paragraph boundary is
+      // collapsed, so manually insert a separator space when following content.
+      if ((node.depthMap[TAG_LI] || 0) > 0) {
+        const lastEntry = state.buffer.at(-1)
+        const lastChar = lastEntry?.charAt(lastEntry.length - 1) || ''
+        if (lastChar && lastChar !== ' ' && lastChar !== '\n') {
+          return ` ${MARKDOWN_INLINE_CODE}`
+        }
       }
       return MARKDOWN_INLINE_CODE
     },
     exit: ({ node }) => {
-      return (node.depthMap[TAG_PRE] || 0) > 0
-        ? `\n${MARKDOWN_CODE_BLOCK}`
-        : MARKDOWN_INLINE_CODE
+      if ((node.depthMap[TAG_PRE] || 0) > 0) {
+        const liDepth = node.depthMap[TAG_LI] || 0
+        if (liDepth > 0) {
+          const indent = '  '.repeat(liDepth)
+          return `\n${indent}${MARKDOWN_CODE_BLOCK}\n\n${indent}`
+        }
+        return `\n${MARKDOWN_CODE_BLOCK}`
+      }
+      return MARKDOWN_INLINE_CODE
     },
     collapsesInnerWhiteSpace: true,
     spacing: NO_SPACING,
@@ -522,6 +542,15 @@ export const tagHandlers: Record<number, TagHandler> = {
         if (lastChar && lastChar !== '\n' && lastChar !== ' ' && lastChar !== '>') {
           const prefix = '> '.repeat(bqDepth)
           return `\n${prefix.trimEnd()}\n${prefix}`
+        }
+      }
+      // Inside a list item, paragraphs are collapsed inline. Insert a space so
+      // sibling text/inline-code doesn't run into adjacent content.
+      if ((node.depthMap[TAG_LI] || 0) > 0) {
+        const lastEntry = state.buffer.at(-1)
+        const lastChar = lastEntry?.charAt(lastEntry.length - 1) || ''
+        if (lastChar && lastChar !== ' ' && lastChar !== '\n') {
+          return ' '
         }
       }
     },

--- a/packages/mdream/test/unit/nodes/lists.test.ts
+++ b/packages/mdream/test/unit/nodes/lists.test.ts
@@ -44,6 +44,32 @@ describe.each(engines)('lists $name', (engineConfig) => {
     expect(markdown).toBe('- [Get started](/en/get-started)/\n- [Writing on GitHub](/en/get-started/writing-on-github)/\n- [Start writing on GitHub](/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github)/\n- [Basic formatting syntax](/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)')
   })
 
+  // https://github.com/harlan-zw/mdream/issues/73
+  it('code block inside ordered list item', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const html = `<ol><li><p>text</p><pre><code class="language-bash"># comment
+echo test
+</code></pre><p>text</p></li></ol>`
+    const markdown = htmlToMarkdown(html, { engine })
+    expect(markdown).toBe('1. text\n\n  ```bash\n  # comment\n  echo test\n  ```\n\n  text')
+  })
+
+  it('code block inside unordered list item', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const html = `<ul><li><p>text</p><pre><code class="language-bash"># comment
+echo test
+</code></pre><p>text</p></li></ul>`
+    const markdown = htmlToMarkdown(html, { engine })
+    expect(markdown).toBe('- text\n\n  ```bash\n  # comment\n  echo test\n  ```\n\n  text')
+  })
+
+  it('inline code between paragraphs inside list item has spacing', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const html = '<ol><li><p>text</p><code># comment</code><p>text</p></li></ol>'
+    const markdown = htmlToMarkdown(html, { engine })
+    expect(markdown).toBe('1. text `# comment` text')
+  })
+
   it('self closing tags in lists', async () => {
     const engine = await resolveEngine(engineConfig.engine)
     const html = `<ul class="hds-term-items"></li>

--- a/packages/mdream/test/unit/nodes/lists.test.ts
+++ b/packages/mdream/test/unit/nodes/lists.test.ts
@@ -70,6 +70,24 @@ echo test
     expect(markdown).toBe('1. text `# comment` text')
   })
 
+  it('code block with blank lines inside list item preserves them', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const html = `<ol><li><p>x</p><pre><code>line1
+
+line2</code></pre></li></ol>`
+    const markdown = htmlToMarkdown(html, { engine })
+    expect(markdown).toBe('1. x\n\n  ```\n  line1\n\n  line2\n  ```')
+  })
+
+  it('code block with pre-indented content inside list item preserves existing indentation', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const html = `<ol><li><p>x</p><pre><code>function() {
+  return 1;
+}</code></pre></li></ol>`
+    const markdown = htmlToMarkdown(html, { engine })
+    expect(markdown).toBe('1. x\n\n  ```\n  function() {\n  return 1;\n  }\n  ```')
+  })
+
   it('self closing tags in lists', async () => {
     const engine = await resolveEngine(engineConfig.engine)
     const html = `<ul class="hds-term-items"></li>


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #73

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Code blocks nested inside `<li>` were emitting without the leading blank line and indentation needed to render as part of the list item, producing broken markdown. The fix adds proper blank-line separation and indents fenced code to the list item's content column so the block stays inside the item. Inline `<code>` and `<p>` between siblings inside list items now also get a separator space when they'd otherwise collide. Both JS and Rust engines are updated, with matching test coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * List-aware rendering: fenced code blocks, inline code, and paragraphs inside list items now preserve correct indentation, blank lines, and spacing.

* **Tests**
  * Added unit tests validating fenced and inline code behavior and spacing within list items.

* **Refactor / Chore**
  * Parsing state for list depth is now shared and a minor lint suppression was added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->