### PR TITLE
fix: separate paragraphs in list items with blank lines

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -223,11 +223,11 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "mdream"
-version = "1.0.5"
+version = "1.0.6"
 
 [[package]]
 name = "mdream-edge"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "js-sys",
  "mdream",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "mdream-node"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "mdream",
  "napi",

--- a/crates/core/src/convert.rs
+++ b/crates/core/src/convert.rs
@@ -1093,7 +1093,7 @@ impl ConvertState {
                         return Some(Cow::Owned(s));
                     }
                 }
-                if self.depth_map[TAG_LI as usize] > 0 {
+                if self.depth_map[TAG_LI as usize] > 0 && !self.in_table_cell() {
                     let last_char = self.buffer.as_bytes().last().copied().unwrap_or(0);
                     if last_char != 0 && last_char != b' ' && last_char != b'\n' {
                         let indent = self.list_indent.as_str();

--- a/crates/core/src/convert.rs
+++ b/crates/core/src/convert.rs
@@ -1096,7 +1096,11 @@ impl ConvertState {
                 if self.depth_map[TAG_LI as usize] > 0 {
                     let last_char = self.buffer.as_bytes().last().copied().unwrap_or(0);
                     if last_char != 0 && last_char != b' ' && last_char != b'\n' {
-                        return Some(Cow::Borrowed(" "));
+                        let indent = self.list_indent.as_str();
+                        let mut s = String::with_capacity(2 + indent.len());
+                        s.push_str("\n\n");
+                        s.push_str(indent);
+                        return Some(Cow::Owned(s));
                     }
                 }
                 None

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -301,6 +301,31 @@ fn loose_ordered_list_with_code_block_renders_as_commonmark_loose_list() {
     );
 }
 
+// https://github.com/harlan-zw/mdream/issues/81
+#[test]
+fn multiple_paragraphs_in_list_item_separated_by_blank_lines() {
+    let html = r#"
+<ol>
+    <li>
+        <p><strong>text</strong>:</p>
+        <p>text</p>
+        <p>text</p>
+        <pre><code>text</code></pre>
+    </li>
+</ol>
+"#;
+    assert_eq!(
+        convert(html),
+        "1. **text**:\n\n   text\n\n   text\n\n   ```\n   text\n   ```"
+    );
+}
+
+#[test]
+fn multiple_paragraphs_in_unordered_list_item_form_loose_list() {
+    let html = "<ul><li><p>a</p><p>b</p></li></ul>";
+    assert_eq!(convert(html), "- a\n\n  b");
+}
+
 // https://github.com/harlan-zw/mdream/issues/76
 #[test]
 fn inline_code_inside_strong_inside_list_no_leading_space() {

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -326,6 +326,22 @@ fn multiple_paragraphs_in_unordered_list_item_form_loose_list() {
     assert_eq!(convert(html), "- a\n\n  b");
 }
 
+#[test]
+fn multiple_paragraphs_in_list_item_inside_table_cell_stay_inline() {
+    // Lists inside table cells are preserved as raw HTML, so paragraph breaks
+    // must not inject blank markdown lines that would split the table row.
+    let html = "<table><tr><td><ul><li><p>a</p><p>b</p></li></ul></td></tr></table>";
+    let out = convert(html);
+    assert!(
+        out.contains("<ul><li>"),
+        "expected raw list HTML in table cell, got: {out}"
+    );
+    assert!(
+        !out.contains("\n\n"),
+        "expected no blank lines inside table cell, got: {out}"
+    );
+}
+
 // https://github.com/harlan-zw/mdream/issues/76
 #[test]
 fn inline_code_inside_strong_inside_list_no_leading_space() {

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -552,7 +552,7 @@ export const tagHandlers: Record<number, TagHandler> = {
           return `\n${prefix.trimEnd()}\n${prefix}`
         }
       }
-      if ((node.depthMap[TAG_LI] || 0) > 0) {
+      if ((node.depthMap[TAG_LI] || 0) > 0 && !isInsideTableCell(node)) {
         const lastEntry = state.buffer.at(-1)
         const lastChar = lastEntry?.charAt(lastEntry.length - 1) || ''
         if (lastChar && lastChar !== ' ' && lastChar !== '\n') {

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -552,13 +552,11 @@ export const tagHandlers: Record<number, TagHandler> = {
           return `\n${prefix.trimEnd()}\n${prefix}`
         }
       }
-      // Inside a list item, paragraphs are collapsed inline. Insert a space so
-      // sibling text/inline-code doesn't run into adjacent content.
       if ((node.depthMap[TAG_LI] || 0) > 0) {
         const lastEntry = state.buffer.at(-1)
         const lastChar = lastEntry?.charAt(lastEntry.length - 1) || ''
         if (lastChar && lastChar !== ' ' && lastChar !== '\n') {
-          return ' '
+          return `\n\n${state.listIndent}`
         }
       }
     },

--- a/packages/mdream/test/unit/nodes/lists.test.ts
+++ b/packages/mdream/test/unit/nodes/lists.test.ts
@@ -70,7 +70,7 @@ echo test
     const engine = await resolveEngine(engineConfig.engine)
     const html = '<ol><li><p>text</p><code># comment</code><p>text</p></li></ol>'
     const markdown = htmlToMarkdown(html, { engine })
-    expect(markdown).toBe('1. text `# comment` text')
+    expect(markdown).toBe('1. text `# comment`\n\n   text')
   })
 
   it('code block with blank lines inside list item preserves them', async () => {

--- a/packages/mdream/test/unit/nodes/lists.test.ts
+++ b/packages/mdream/test/unit/nodes/lists.test.ts
@@ -73,6 +73,16 @@ echo test
     expect(markdown).toBe('1. text `# comment`\n\n   text')
   })
 
+  it('multiple paragraphs in list item inside table cell stay inline', async () => {
+    // Lists inside table cells are preserved as raw HTML, so paragraph breaks
+    // must not inject blank markdown lines that would split the table row.
+    const engine = await resolveEngine(engineConfig.engine)
+    const html = '<table><tr><td><ul><li><p>a</p><p>b</p></li></ul></td></tr></table>'
+    const markdown = htmlToMarkdown(html, { engine })
+    expect(markdown).toContain('<ul><li>')
+    expect(markdown).not.toContain('\n\n')
+  })
+
   it('code block with blank lines inside list item preserves them', async () => {
     const engine = await resolveEngine(engineConfig.engine)
     const html = `<ol><li><p>x</p><pre><code>line1


### PR DESCRIPTION
### Linked issue

Resolves #81

### Type of change

- [ ] Documentation
- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Chore
- [ ] Breaking change

### Description

Adjacent `<p>` children inside an `<li>` were being joined by a single space, producing single-line list items. They now render as loose-list paragraphs separated by blank lines and indented to the list marker, matching CommonMark loose list semantics. Fix applied to both the JS tag handler and the Rust `convert` path, with new tests on both sides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering of list items with multiple paragraphs or code blocks: paragraphs now separate with a blank line and proper list indentation instead of running together.
  * Preserved table-cell content formatting: list HTML inside table cells remains raw so paragraph breaks do not inject extra blank Markdown lines.

* **Tests**
  * Added regression tests to ensure correct multi-paragraph list and table-cell behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->