### PR TITLE
feat(negotiate): RFC 7231 content negotiation with 406 support

### DIFF
--- a/packages/js/src/negotiate.ts
+++ b/packages/js/src/negotiate.ts
@@ -164,6 +164,11 @@ export function negotiateContent(acceptHeader?: string, secFetchDest?: string): 
     bestHtmlPos = bestWildcardPos
   }
 
+  // Both concrete types were explicitly rejected (q=0) and only a wildcard
+  // remained. The wildcard satisfied `sawAcceptable`, but we literally cannot
+  // serve anything the client didn't veto, so 406 is the honest answer.
+  if (bestMdPos === -1 && bestHtmlPos === -1)
+    return 'not-acceptable'
   if (bestMdPos === -1)
     return 'html'
   if (bestHtmlPos === -1)

--- a/packages/js/src/negotiate.ts
+++ b/packages/js/src/negotiate.ts
@@ -1,3 +1,5 @@
+export type ContentNegotiationResult = 'markdown' | 'html' | 'not-acceptable'
+
 interface AcceptEntry {
   type: string
   q: number
@@ -25,7 +27,6 @@ export function parseAcceptHeader(accept: string): AcceptEntry[] {
     }
     else {
       type = part.slice(0, semicolonIdx).trim()
-      // Extract q value without regex for performance
       const paramStr = part.slice(semicolonIdx + 1)
       const qIdx = paramStr.indexOf('q=')
       if (qIdx !== -1) {
@@ -43,36 +44,46 @@ export function parseAcceptHeader(accept: string): AcceptEntry[] {
 }
 
 /**
- * Determine if a client prefers markdown over HTML using proper content negotiation.
+ * Perform RFC 7231 content negotiation for HTML vs Markdown.
  *
- * Uses Accept header quality weights and position ordering:
- * - If text/markdown or text/plain has higher quality than text/html -> markdown
- * - If same quality, earlier position in Accept header wins
- * - Bare wildcard does NOT trigger markdown (prevents breaking OG crawlers)
- * - sec-fetch-dest: document always returns false (browser navigation)
- *
- * @param acceptHeader - The HTTP Accept header value
- * @param secFetchDest - The Sec-Fetch-Dest header value
+ * Resolution rules:
+ * - `Sec-Fetch-Dest: document` always returns `'html'` (browser navigation).
+ * - Missing or empty Accept header returns `'html'` (server picks default).
+ * - q=0 entries are treated as explicit rejections and ignored for matching
+ *   (but still count towards "something was listed").
+ * - `text/markdown` and `text/plain` are the markdown-capable types.
+ * - `text/html` and `application/xhtml+xml` are the html-capable types.
+ * - `*_/_*` and `text/*` are wildcards; they satisfy 406 but never on their
+ *   own tip negotiation towards markdown (preserves OG crawler behavior).
+ * - If nothing in the Accept header can be served (no explicit match, no
+ *   wildcard), returns `'not-acceptable'` so the caller can send 406.
+ * - Otherwise, compares best markdown entry vs best html-or-wildcard entry
+ *   by q, then by position.
  */
-export function shouldServeMarkdown(acceptHeader?: string, secFetchDest?: string): boolean {
-  if (secFetchDest === 'document') {
-    return false
-  }
+export function negotiateContent(acceptHeader?: string, secFetchDest?: string): ContentNegotiationResult {
+  if (secFetchDest === 'document')
+    return 'html'
 
   const accept = acceptHeader || ''
   if (!accept)
-    return false
+    return 'html'
 
-  const parts = accept.split(',')
   let bestMdQ = -1
   let bestMdPos = -1
-  let htmlQ = -1
-  let htmlPos = -1
+  let bestHtmlQ = -1
+  let bestHtmlPos = -1
+  let bestWildcardQ = -1
+  let bestWildcardPos = -1
+  let sawAnyEntry = false
+  let sawAcceptable = false
 
+  const parts = accept.split(',')
   for (let i = 0; i < parts.length; i++) {
     const part = parts[i]!.trim()
     if (!part)
       continue
+    sawAnyEntry = true
+
     const semicolonIdx = part.indexOf(';')
     let type: string
     let q = 1
@@ -93,26 +104,55 @@ export function shouldServeMarkdown(acceptHeader?: string, secFetchDest?: string
       }
     }
 
+    if (q === 0)
+      continue
+
     if (type === 'text/markdown' || type === 'text/plain') {
-      if (q > bestMdQ || (q === bestMdQ && (bestMdPos === -1 || i < bestMdPos))) {
+      sawAcceptable = true
+      if (q > bestMdQ || (q === bestMdQ && bestMdPos === -1)) {
         bestMdQ = q
         bestMdPos = i
       }
     }
-    else if (type === 'text/html') {
-      htmlQ = q
-      htmlPos = i
+    else if (type === 'text/html' || type === 'application/xhtml+xml') {
+      sawAcceptable = true
+      if (q > bestHtmlQ || (q === bestHtmlQ && bestHtmlPos === -1)) {
+        bestHtmlQ = q
+        bestHtmlPos = i
+      }
+    }
+    else if (type === '*/*' || type === 'text/*') {
+      sawAcceptable = true
+      if (q > bestWildcardQ || (q === bestWildcardQ && bestWildcardPos === -1)) {
+        bestWildcardQ = q
+        bestWildcardPos = i
+      }
     }
   }
 
-  if (bestMdPos === -1)
-    return false
-  if (htmlPos === -1)
-    return true
-  if (bestMdQ > htmlQ)
-    return true
-  if (bestMdQ === htmlQ && bestMdPos < htmlPos)
-    return true
+  if (sawAnyEntry && !sawAcceptable)
+    return 'not-acceptable'
 
-  return false
+  if (bestMdPos === -1)
+    return 'html'
+
+  const htmlQ = bestHtmlQ >= 0 ? bestHtmlQ : bestWildcardQ
+  const htmlPos = bestHtmlPos >= 0 ? bestHtmlPos : bestWildcardPos
+
+  if (htmlPos === -1)
+    return 'markdown'
+  if (bestMdQ > htmlQ)
+    return 'markdown'
+  if (bestMdQ === htmlQ && bestMdPos < htmlPos)
+    return 'markdown'
+  return 'html'
+}
+
+/**
+ * Determine if a client prefers markdown over HTML. Convenience wrapper over
+ * {@link negotiateContent}; treats `'not-acceptable'` the same as `'html'`
+ * (callers that want 406 semantics should use `negotiateContent` directly).
+ */
+export function shouldServeMarkdown(acceptHeader?: string, secFetchDest?: string): boolean {
+  return negotiateContent(acceptHeader, secFetchDest) === 'markdown'
 }

--- a/packages/js/src/negotiate.ts
+++ b/packages/js/src/negotiate.ts
@@ -76,6 +76,9 @@ export function negotiateContent(acceptHeader?: string, secFetchDest?: string): 
   let bestWildcardPos = -1
   let sawAnyEntry = false
   let sawAcceptable = false
+  // Track explicit q=0 rejections so wildcard fallback can't resurrect them.
+  let rejectedMd = false
+  let rejectedHtml = false
 
   const parts = accept.split(',')
   for (let i = 0; i < parts.length; i++) {
@@ -93,7 +96,15 @@ export function negotiateContent(acceptHeader?: string, secFetchDest?: string): 
     else {
       type = part.slice(0, semicolonIdx).trim()
       const paramStr = part.slice(semicolonIdx + 1)
-      const qIdx = paramStr.indexOf('q=')
+      // Find q= case-insensitively without allocating.
+      let qIdx = -1
+      for (let j = 0; j < paramStr.length - 1; j++) {
+        const c = paramStr.charCodeAt(j)
+        if ((c === 113 || c === 81) && paramStr.charCodeAt(j + 1) === 61 /* = */) {
+          qIdx = j
+          break
+        }
+      }
       if (qIdx !== -1) {
         const qStart = qIdx + 2
         let qEnd = qStart
@@ -104,24 +115,34 @@ export function negotiateContent(acceptHeader?: string, secFetchDest?: string): 
       }
     }
 
-    if (q === 0)
-      continue
+    // Normalize type for case-insensitive comparison (media types per RFC 7231).
+    const normalized = type.toLowerCase()
 
-    if (type === 'text/markdown' || type === 'text/plain') {
+    if (normalized === 'text/markdown' || normalized === 'text/plain') {
+      if (q === 0) {
+        rejectedMd = true
+        continue
+      }
       sawAcceptable = true
       if (q > bestMdQ || (q === bestMdQ && bestMdPos === -1)) {
         bestMdQ = q
         bestMdPos = i
       }
     }
-    else if (type === 'text/html' || type === 'application/xhtml+xml') {
+    else if (normalized === 'text/html' || normalized === 'application/xhtml+xml') {
+      if (q === 0) {
+        rejectedHtml = true
+        continue
+      }
       sawAcceptable = true
       if (q > bestHtmlQ || (q === bestHtmlQ && bestHtmlPos === -1)) {
         bestHtmlQ = q
         bestHtmlPos = i
       }
     }
-    else if (type === '*/*' || type === 'text/*') {
+    else if (normalized === '*/*' || normalized === 'text/*') {
+      if (q === 0)
+        continue
       sawAcceptable = true
       if (q > bestWildcardQ || (q === bestWildcardQ && bestWildcardPos === -1)) {
         bestWildcardQ = q
@@ -133,17 +154,23 @@ export function negotiateContent(acceptHeader?: string, secFetchDest?: string): 
   if (sawAnyEntry && !sawAcceptable)
     return 'not-acceptable'
 
+  // Apply wildcard fallback only when the concrete type wasn't explicitly rejected.
+  if (bestMdPos === -1 && !rejectedMd && bestWildcardPos !== -1) {
+    bestMdQ = bestWildcardQ
+    bestMdPos = bestWildcardPos
+  }
+  if (bestHtmlPos === -1 && !rejectedHtml && bestWildcardPos !== -1) {
+    bestHtmlQ = bestWildcardQ
+    bestHtmlPos = bestWildcardPos
+  }
+
   if (bestMdPos === -1)
     return 'html'
-
-  const htmlQ = bestHtmlQ >= 0 ? bestHtmlQ : bestWildcardQ
-  const htmlPos = bestHtmlPos >= 0 ? bestHtmlPos : bestWildcardPos
-
-  if (htmlPos === -1)
+  if (bestHtmlPos === -1)
     return 'markdown'
-  if (bestMdQ > htmlQ)
+  if (bestMdQ > bestHtmlQ)
     return 'markdown'
-  if (bestMdQ === htmlQ && bestMdPos < htmlPos)
+  if (bestMdQ === bestHtmlQ && bestMdPos < bestHtmlPos)
     return 'markdown'
   return 'html'
 }

--- a/packages/js/test/unit/negotiate.test.ts
+++ b/packages/js/test/unit/negotiate.test.ts
@@ -187,6 +187,22 @@ describe('negotiateContent', () => {
     expect(negotiateContent('text/html;q=0, application/json;q=0')).toBe('not-acceptable')
   })
 
+  it('does not let wildcard resurrect explicitly rejected types', () => {
+    // text/html was rejected, so */* can only satisfy markdown.
+    expect(negotiateContent('text/html;q=0, */*;q=1, text/markdown;q=0.5')).toBe('markdown')
+    // text/markdown was rejected, so */* can only satisfy html.
+    expect(negotiateContent('text/markdown;q=0, */*;q=1, text/html;q=0.5')).toBe('html')
+    // Both explicitly rejected; wildcard can't resurrect either -> default html.
+    expect(negotiateContent('text/markdown;q=0, text/html;q=0, */*;q=1')).toBe('html')
+  })
+
+  it('normalizes media types case-insensitively', () => {
+    expect(negotiateContent('Text/Markdown')).toBe('markdown')
+    expect(negotiateContent('TEXT/HTML')).toBe('html')
+    expect(negotiateContent('Text/Markdown;Q=1')).toBe('markdown')
+    expect(negotiateContent('Application/XHTML+XML')).toBe('html')
+  })
+
   it('accepts application/xhtml+xml as html-capable', () => {
     expect(negotiateContent('application/xhtml+xml')).toBe('html')
   })

--- a/packages/js/test/unit/negotiate.test.ts
+++ b/packages/js/test/unit/negotiate.test.ts
@@ -192,8 +192,8 @@ describe('negotiateContent', () => {
     expect(negotiateContent('text/html;q=0, */*;q=1, text/markdown;q=0.5')).toBe('markdown')
     // text/markdown was rejected, so */* can only satisfy html.
     expect(negotiateContent('text/markdown;q=0, */*;q=1, text/html;q=0.5')).toBe('html')
-    // Both explicitly rejected; wildcard can't resurrect either -> default html.
-    expect(negotiateContent('text/markdown;q=0, text/html;q=0, */*;q=1')).toBe('html')
+    // Both explicitly rejected; wildcard cannot satisfy anything we can serve.
+    expect(negotiateContent('text/markdown;q=0, text/html;q=0, */*;q=1')).toBe('not-acceptable')
   })
 
   it('normalizes media types case-insensitively', () => {

--- a/packages/js/test/unit/negotiate.test.ts
+++ b/packages/js/test/unit/negotiate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parseAcceptHeader, shouldServeMarkdown } from '../../src/negotiate'
+import { negotiateContent, parseAcceptHeader, shouldServeMarkdown } from '../../src/negotiate'
 
 describe('parseAcceptHeader', () => {
   it('returns empty array for empty string', () => {
@@ -133,5 +133,66 @@ describe('shouldServeMarkdown', () => {
 
   it('allows markdown when sec-fetch-dest is undefined', () => {
     expect(shouldServeMarkdown('text/markdown', undefined)).toBe(true)
+  })
+})
+
+describe('negotiateContent', () => {
+  it('returns html for sec-fetch-dest: document regardless of Accept', () => {
+    expect(negotiateContent('text/markdown', 'document')).toBe('html')
+    expect(negotiateContent('*/*', 'document')).toBe('html')
+  })
+
+  it('returns html for missing Accept header', () => {
+    expect(negotiateContent()).toBe('html')
+    expect(negotiateContent('')).toBe('html')
+  })
+
+  it('returns html for standard browser Accept header', () => {
+    expect(negotiateContent('text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8')).toBe('html')
+  })
+
+  it('returns html for bare wildcard', () => {
+    expect(negotiateContent('*/*')).toBe('html')
+  })
+
+  it('returns markdown for text/markdown only', () => {
+    expect(negotiateContent('text/markdown')).toBe('markdown')
+  })
+
+  it('returns markdown when text/markdown beats text/html by quality', () => {
+    expect(negotiateContent('text/markdown, text/html;q=0.9, */*;q=0.1')).toBe('markdown')
+  })
+
+  it('returns html when text/html beats text/markdown by quality', () => {
+    expect(negotiateContent('text/markdown;q=0.5, text/html;q=1.0')).toBe('html')
+  })
+
+  it('returns markdown when text/plain has higher q than text/html', () => {
+    expect(negotiateContent('text/html;q=0.5, text/plain;q=0.9')).toBe('markdown')
+  })
+
+  it('returns not-acceptable when Accept lists only unsupported types', () => {
+    expect(negotiateContent('application/x-content-negotiation-probe')).toBe('not-acceptable')
+    expect(negotiateContent('application/json')).toBe('not-acceptable')
+    expect(negotiateContent('application/pdf, application/json')).toBe('not-acceptable')
+  })
+
+  it('returns html when wildcard is present alongside unsupported types', () => {
+    expect(negotiateContent('application/json, */*')).toBe('html')
+  })
+
+  it('treats q=0 as rejection', () => {
+    expect(negotiateContent('text/html;q=0, text/markdown')).toBe('markdown')
+    expect(negotiateContent('text/markdown;q=0, text/html')).toBe('html')
+    expect(negotiateContent('text/html;q=0, application/json;q=0')).toBe('not-acceptable')
+  })
+
+  it('accepts application/xhtml+xml as html-capable', () => {
+    expect(negotiateContent('application/xhtml+xml')).toBe('html')
+  })
+
+  it('respects text/* wildcard as html fallback', () => {
+    expect(negotiateContent('text/*')).toBe('html')
+    expect(negotiateContent('text/markdown, text/*')).toBe('markdown')
   })
 })

--- a/packages/nuxt/src/runtime/server/middleware/mdream.ts
+++ b/packages/nuxt/src/runtime/server/middleware/mdream.ts
@@ -90,18 +90,12 @@ export default defineEventHandler(async (event) => {
   await nitroApp.hooks.callHook('mdream:negotiate', negotiateContext)
   clientPrefersMarkdown = negotiateContext.shouldServe
 
-  // Strict 406 only when we negotiate (no .md extension, no hook override
-  // asking for markdown, and Accept listed nothing we can serve).
-  if (!hasMarkdownExtension && !clientPrefersMarkdown && negotiation === 'not-acceptable') {
-    return createError({
-      statusCode: 406,
-      statusMessage: 'Not Acceptable',
-      message: 'This resource can be served as text/html or text/markdown.',
-    })
-  }
-
-  // Early exit: skip if not requesting .md and client doesn't prefer markdown
-  if (!hasMarkdownExtension && !clientPrefersMarkdown) {
+  // Early exit: skip if not requesting .md and client doesn't prefer markdown.
+  // We defer the 406 decision until after fetching downstream, because this
+  // middleware runs for every extensionless route and we can't 406 a JSON-only
+  // endpoint like /health just because Accept didn't list text/*.
+  const wantsNotAcceptable = !hasMarkdownExtension && !clientPrefersMarkdown && negotiation === 'not-acceptable'
+  if (!hasMarkdownExtension && !clientPrefersMarkdown && !wantsNotAcceptable) {
     return
   }
 
@@ -143,7 +137,18 @@ export default defineEventHandler(async (event) => {
           message: `Expected text/html but got ${contentType} for ${path}`,
         })
       }
+      // Not an HTML route, fall through so the non-HTML response is served
       return
+    }
+
+    // We now know the route serves HTML. If the client's Accept header listed
+    // nothing we can serve, this is a genuine 406.
+    if (wantsNotAcceptable) {
+      return createError({
+        statusCode: 406,
+        statusMessage: 'Not Acceptable',
+        message: 'This resource can be served as text/html or text/markdown.',
+      })
     }
 
     html = response._data as string

--- a/packages/nuxt/src/runtime/server/middleware/mdream.ts
+++ b/packages/nuxt/src/runtime/server/middleware/mdream.ts
@@ -2,16 +2,16 @@ import type { H3Event } from 'h3'
 import type { MdreamOptions } from 'mdream'
 import type { MdreamMarkdownContext, MdreamNegotiateContext, ModuleRuntimeConfig } from '../../types.js'
 import { withSiteUrl } from '#site-config/server/composables/utils'
-import { shouldServeMarkdown as _shouldServeMarkdown } from '@mdream/js/negotiate'
+import { negotiateContent } from '@mdream/js/negotiate'
 import { consola } from 'consola'
-import { createError, defineEventHandler, getHeader, setHeader } from 'h3'
+import { appendHeader, createError, defineEventHandler, getHeader, setHeader } from 'h3'
 import { htmlToMarkdown } from 'mdream'
 import { useNitroApp, useRuntimeConfig } from 'nitropack/runtime'
 
 const logger = consola.withTag('nuxt-mdream')
 
-function shouldServeMarkdown(event: H3Event): boolean {
-  return _shouldServeMarkdown(
+function negotiate(event: H3Event) {
+  return negotiateContent(
     getHeader(event, 'accept'),
     getHeader(event, 'sec-fetch-dest'),
   )
@@ -76,13 +76,29 @@ export default defineEventHandler(async (event) => {
 
   // Check if we should serve markdown based on Accept header or .md extension
   const hasMarkdownExtension = path.endsWith('.md')
-  let clientPrefersMarkdown = shouldServeMarkdown(event)
+  const negotiation = negotiate(event)
+
+  // Advertise that the response varies by these request headers so caches
+  // don't collapse markdown and html responses together.
+  appendHeader(event, 'Vary', 'Accept, Sec-Fetch-Dest')
+
+  let clientPrefersMarkdown = negotiation === 'markdown'
 
   // Allow users to override the negotiate decision via hook
   const nitroApp = useNitroApp()
   const negotiateContext: MdreamNegotiateContext = { event, shouldServe: clientPrefersMarkdown }
   await nitroApp.hooks.callHook('mdream:negotiate', negotiateContext)
   clientPrefersMarkdown = negotiateContext.shouldServe
+
+  // Strict 406 only when we negotiate (no .md extension, no hook override
+  // asking for markdown, and Accept listed nothing we can serve).
+  if (!hasMarkdownExtension && !clientPrefersMarkdown && negotiation === 'not-acceptable') {
+    return createError({
+      statusCode: 406,
+      statusMessage: 'Not Acceptable',
+      message: 'This resource can be served as text/html or text/markdown.',
+    })
+  }
 
   // Early exit: skip if not requesting .md and client doesn't prefer markdown
   if (!hasMarkdownExtension && !clientPrefersMarkdown) {

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -15,33 +15,28 @@ const GLOB_QUESTION_RE = /\?/g
 
 /**
  * Merge the given tokens into the response's `Vary` header, preserving any
- * existing tokens and avoiding duplicates.
+ * existing tokens and avoiding case-insensitive duplicates.
  */
 function mergeVary(res: ServerResponse, tokens: string) {
-  const existing = res.getHeader('Vary')
-  const set = new Set<string>()
-  if (existing) {
-    for (const token of String(existing).split(',')) {
-      const trimmed = token.trim()
-      if (trimmed)
-        set.add(trimmed.toLowerCase())
-    }
-  }
+  const existing = res.getHeader?.('Vary')
   const merged: string[] = []
+  const seen = new Set<string>()
+  const add = (raw: string) => {
+    const t = raw.trim()
+    if (!t)
+      return
+    const k = t.toLowerCase()
+    if (seen.has(k))
+      return
+    seen.add(k)
+    merged.push(t)
+  }
   if (existing) {
-    for (const token of String(existing).split(',')) {
-      const trimmed = token.trim()
-      if (trimmed)
-        merged.push(trimmed)
-    }
+    for (const token of String(existing).split(','))
+      add(token)
   }
-  for (const token of tokens.split(',')) {
-    const trimmed = token.trim()
-    if (trimmed && !set.has(trimmed.toLowerCase())) {
-      merged.push(trimmed)
-      set.add(trimmed.toLowerCase())
-    }
-  }
+  for (const token of tokens.split(','))
+    add(token)
   res.setHeader('Vary', merged.join(', '))
 }
 
@@ -237,16 +232,13 @@ export function viteHtmlToMarkdownPlugin(userOptions: ViteHtmlToMarkdownOptions 
       // them together. Merge to preserve any Vary set upstream.
       mergeVary(res, 'Accept, Sec-Fetch-Dest')
 
-      // Reject when Accept listed nothing we can serve (RFC 7231 §6.5.6).
-      if (!hasMarkdownExtension && !clientPrefersMarkdown && negotiation === 'not-acceptable') {
-        res.statusCode = 406
-        res.setHeader('Content-Type', 'text/plain; charset=utf-8')
-        res.end('Not Acceptable: this resource can be served as text/html or text/markdown.')
-        return
-      }
+      const wantsNotAcceptable = !hasMarkdownExtension && !clientPrefersMarkdown && negotiation === 'not-acceptable'
 
-      // Skip if not requesting .md and client doesn't prefer markdown
-      if (!hasMarkdownExtension && !clientPrefersMarkdown) {
+      // Skip if not requesting .md and client doesn't prefer markdown and
+      // Accept isn't strictly unsatisfiable. For the not-acceptable case we
+      // still proceed, but only to confirm the route is one we serve before
+      // returning 406 (so non-HTML endpoints fall through to next()).
+      if (!hasMarkdownExtension && !clientPrefersMarkdown && !wantsNotAcceptable) {
         return next()
       }
 
@@ -254,6 +246,15 @@ export function viteHtmlToMarkdownPlugin(userOptions: ViteHtmlToMarkdownOptions 
 
       try {
         const result = await handleMarkdownRequest(url, getServer(), getOutDir())
+
+        // Route is one we serve; if the client's Accept left us nothing to
+        // return, this is now a genuine 406.
+        if (wantsNotAcceptable) {
+          res.statusCode = 406
+          res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+          res.end('Not Acceptable: this resource can be served as text/html or text/markdown.')
+          return
+        }
 
         res.setHeader('Content-Type', 'text/markdown; charset=utf-8')
         res.setHeader('Cache-Control', cacheControl)
@@ -264,6 +265,11 @@ export function viteHtmlToMarkdownPlugin(userOptions: ViteHtmlToMarkdownOptions 
         log(`Served ${url} from ${result.source} (cached: ${result.cached})`)
       }
       catch (error) {
+        // Route has no HTML representation. For not-acceptable requests we
+        // never owned the route, so hand back to the next middleware.
+        if (wantsNotAcceptable) {
+          return next()
+        }
         const message = error instanceof Error ? error.message : String(error)
         log(`Error serving ${url}: ${message}`)
         res.statusCode = 404

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -13,6 +13,38 @@ const GLOB_DOUBLE_STAR_RE = /\*\*/g
 const GLOB_STAR_RE = /\*/g
 const GLOB_QUESTION_RE = /\?/g
 
+/**
+ * Merge the given tokens into the response's `Vary` header, preserving any
+ * existing tokens and avoiding duplicates.
+ */
+function mergeVary(res: ServerResponse, tokens: string) {
+  const existing = res.getHeader('Vary')
+  const set = new Set<string>()
+  if (existing) {
+    for (const token of String(existing).split(',')) {
+      const trimmed = token.trim()
+      if (trimmed)
+        set.add(trimmed.toLowerCase())
+    }
+  }
+  const merged: string[] = []
+  if (existing) {
+    for (const token of String(existing).split(',')) {
+      const trimmed = token.trim()
+      if (trimmed)
+        merged.push(trimmed)
+    }
+  }
+  for (const token of tokens.split(',')) {
+    const trimmed = token.trim()
+    if (trimmed && !set.has(trimmed.toLowerCase())) {
+      merged.push(trimmed)
+      set.add(trimmed.toLowerCase())
+    }
+  }
+  res.setHeader('Vary', merged.join(', '))
+}
+
 const DEFAULT_OPTIONS: Required<Omit<ViteHtmlToMarkdownOptions, 'mdreamOptions'>> & { mdreamOptions: Partial<MdreamOptions> } = {
   include: ['*.html', '**/*.html'], // Include root level and nested
   exclude: ['**/node_modules/**'],
@@ -200,10 +232,14 @@ export function viteHtmlToMarkdownPlugin(userOptions: ViteHtmlToMarkdownOptions 
         return next()
       }
 
+      // This path participates in negotiation (markdown vs html), so every
+      // response from here on must advertise Vary so caches don't collapse
+      // them together. Merge to preserve any Vary set upstream.
+      mergeVary(res, 'Accept, Sec-Fetch-Dest')
+
       // Reject when Accept listed nothing we can serve (RFC 7231 §6.5.6).
       if (!hasMarkdownExtension && !clientPrefersMarkdown && negotiation === 'not-acceptable') {
         res.statusCode = 406
-        res.setHeader('Vary', 'Accept, Sec-Fetch-Dest')
         res.setHeader('Content-Type', 'text/plain; charset=utf-8')
         res.end('Not Acceptable: this resource can be served as text/html or text/markdown.')
         return
@@ -220,7 +256,6 @@ export function viteHtmlToMarkdownPlugin(userOptions: ViteHtmlToMarkdownOptions 
         const result = await handleMarkdownRequest(url, getServer(), getOutDir())
 
         res.setHeader('Content-Type', 'text/markdown; charset=utf-8')
-        res.setHeader('Vary', 'Accept, Sec-Fetch-Dest')
         res.setHeader('Cache-Control', cacheControl)
         res.setHeader('X-Markdown-Source', result.source)
         res.setHeader('X-Markdown-Cached', result.cached.toString())

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -4,7 +4,7 @@ import type { Plugin, ViteDevServer } from 'vite'
 import type { CacheEntry, MarkdownConversionResult, ViteHtmlToMarkdownOptions } from './types.js'
 import fs from 'node:fs'
 import path from 'node:path'
-import { shouldServeMarkdown } from '@mdream/js/negotiate'
+import { negotiateContent } from '@mdream/js/negotiate'
 import { htmlToMarkdown } from 'mdream'
 
 const GLOB_BACKSLASH_RE = /\\/g
@@ -178,10 +178,11 @@ export function viteHtmlToMarkdownPlugin(userOptions: ViteHtmlToMarkdownOptions 
     return async (req: IncomingMessage, res: ServerResponse, next: () => void) => {
       const path = new URL(req.url || '', 'http://localhost').pathname
       const hasMarkdownExtension = path.endsWith('.md')
-      const clientPrefersMarkdown = shouldServeMarkdown(
+      const negotiation = negotiateContent(
         req.headers.accept,
         req.headers['sec-fetch-dest'] as string | undefined,
       )
+      const clientPrefersMarkdown = negotiation === 'markdown'
 
       // never run on API routes or internal routes
       if (path.startsWith('/api') || path.startsWith('/_') || path.startsWith('/@')) {
@@ -199,6 +200,15 @@ export function viteHtmlToMarkdownPlugin(userOptions: ViteHtmlToMarkdownOptions 
         return next()
       }
 
+      // Reject when Accept listed nothing we can serve (RFC 7231 §6.5.6).
+      if (!hasMarkdownExtension && !clientPrefersMarkdown && negotiation === 'not-acceptable') {
+        res.statusCode = 406
+        res.setHeader('Vary', 'Accept, Sec-Fetch-Dest')
+        res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+        res.end('Not Acceptable: this resource can be served as text/html or text/markdown.')
+        return
+      }
+
       // Skip if not requesting .md and client doesn't prefer markdown
       if (!hasMarkdownExtension && !clientPrefersMarkdown) {
         return next()
@@ -210,6 +220,7 @@ export function viteHtmlToMarkdownPlugin(userOptions: ViteHtmlToMarkdownOptions 
         const result = await handleMarkdownRequest(url, getServer(), getOutDir())
 
         res.setHeader('Content-Type', 'text/markdown; charset=utf-8')
+        res.setHeader('Vary', 'Accept, Sec-Fetch-Dest')
         res.setHeader('Cache-Control', cacheControl)
         res.setHeader('X-Markdown-Source', result.source)
         res.setHeader('X-Markdown-Cached', result.cached.toString())


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [ ] Documentation
- [ ] Bug fix
- [x] Enhancement
- [x] New feature
- [ ] Chore
- [ ] Breaking change

### Description

Previously `shouldServeMarkdown()` collapsed every negotiation outcome into a boolean, so middleware couldn't tell "client explicitly rejected everything" apart from "client prefers html". This adds a new `negotiateContent()` returning `'markdown' | 'html' | 'not-acceptable'` so the Nuxt and Vite middlewares can respond with a proper 406 when the `Accept` header lists nothing we can serve.

Other improvements:

- Handles `q=0` as explicit rejection.
- Recognises `application/xhtml+xml` as html-capable and `text/*` as a wildcard.
- Nuxt and Vite middleware emit `Vary: Accept, Sec-Fetch-Dest` so caches don't collapse markdown and html responses together.
- `shouldServeMarkdown()` is kept as a thin wrapper for existing callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tri-state content negotiation (Markdown, HTML, Not Acceptable) for finer client preference handling.
  * Middleware now returns HTTP 406 when the client’s Accept preferences cannot be satisfied and advertises varied cache variants.

* **Bug Fixes**
  * Ensured Vary: Accept, Sec-Fetch-Dest is set to avoid incorrect cached formats.
  * Improved handling of missing/empty Accept and Sec-Fetch-Dest=document, q=0 rejections, wildcard fallbacks, and case-insensitive media-type matching.

* **Tests**
  * Expanded unit tests covering negotiation scenarios and 406 behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->