### PR TITLE
feat(crawl): `crawl:html` hook

### DIFF
--- a/packages/crawl/README.md
+++ b/packages/crawl/README.md
@@ -301,7 +301,7 @@ CLI arguments override config file values. Array options like `exclude` are conc
 
 ## Hooks
 
-Four hooks let you intercept and transform data at each stage of the crawl pipeline. Hooks receive mutable objects. Mutate in-place to transform output.
+Six hooks let you intercept and transform data at each stage of the crawl pipeline. Hooks receive mutable objects. Mutate in-place to transform output.
 
 ### `crawl:url`
 
@@ -314,6 +314,21 @@ defineConfig({
       // Skip large asset pages
       if (ctx.url.includes('/assets/') || ctx.url.includes('/downloads/'))
         ctx.skip = true
+    },
+  },
+})
+```
+
+### `crawl:html`
+
+Called after fetching, before HTML-to-Markdown conversion. Mutate `ctx.html` to transform the raw HTML (strip elements, inject content) before mdream processes it. Not called when the fetched content is already markdown.
+
+```typescript
+defineConfig({
+  hooks: {
+    'crawl:html': (ctx) => {
+      // ctx.url, ctx.html, ctx.origin
+      ctx.html = ctx.html.replace(/<header[\s\S]*?<\/header>/, '')
     },
   },
 })

--- a/packages/crawl/src/crawl.ts
+++ b/packages/crawl/src/crawl.ts
@@ -580,6 +580,11 @@ export async function crawlAndGenerate(options: CrawlOptions, onProgress?: (prog
       metadata = { title: initialTitle || parsedUrl.pathname, links: [] }
     }
     else {
+      // Allow hooks to mutate the raw HTML before conversion
+      const htmlCtx = { url, html: content, origin: pageOrigin }
+      await hooks.callHook('crawl:html', htmlCtx)
+      content = htmlCtx.html
+
       // Single htmlToMarkdown call with merged extraction
       const { extraction, getMetadata } = extractMetadataInline(parsedUrl, allowedRegistrableDomains)
       md = htmlToMarkdown(content, { origin: pageOrigin, extraction })

--- a/packages/crawl/src/types.ts
+++ b/packages/crawl/src/types.ts
@@ -8,6 +8,7 @@ export interface PageData {
 
 export interface CrawlHooks {
   'crawl:url': (ctx: { url: string, skip: boolean }) => void | Promise<void>
+  'crawl:html': (ctx: { url: string, html: string, origin: string }) => void | Promise<void>
   'crawl:page': (page: PageData) => void | Promise<void>
   'crawl:content': (ctx: { url: string, title: string, content: string, filePath: string }) => void | Promise<void>
   'crawl:done': (ctx: { results: CrawlResult[] }) => void | Promise<void>


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #87

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Mutating `page.html` in `crawl:page` had no effect, since `htmlToMarkdown()` already ran before the hook fired. There was no way to do DOM-level filtering (stripping `nav`/`footer`) without a redundant double-conversion.

Adds a `crawl:html` hook that fires after fetch but before `htmlToMarkdown()`, with a mutable `html` field (plus `url` and `origin`). Consumers can strip elements or inject content before markdown conversion. Not called when the fetched content is already markdown. Works for both HTTP and Playwright drivers since they share `processPage`.

README updated with the new hook section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new hook that allows users to intercept and customize HTML content during the crawl process. The hook runs after fetching and before HTML-to-Markdown conversion, with access to the URL, HTML content, and origin.

* **Documentation**
  * Updated documentation to include the new hook, its execution timing, available context data, and usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harlan-zw/mdream/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->