### PR TITLE
feat(core): collapse bare links into GFM autolink shorthand

### DIFF
--- a/crates/core/src/convert.rs
+++ b/crates/core/src/convert.rs
@@ -30,6 +30,19 @@ const CLEAN_EMPTY_LINK_TEXT: u8 = 32;
 /// Known tracking query parameter prefixes to strip when clean_urls is enabled.
 const TRACKING_PREFIXES: [&str; 6] = ["utm_", "fbclid", "gclid", "mc_eid", "msclkid", "oly_"];
 
+/// Whether `s` looks like a bare absolute URI suitable for GFM autolink
+/// shorthand (`<http://…>`). Conservative: only common web/mail schemes,
+/// no whitespace or angle brackets that would break the autolink syntax.
+#[inline]
+fn is_autolink_uri(s: &str) -> bool {
+    let has_scheme = s.starts_with("http://")
+        || s.starts_with("https://")
+        || s.starts_with("ftp://")
+        || s.starts_with("mailto:");
+    if !has_scheme { return false; }
+    !s.bytes().any(|b| b == b' ' || b == b'<' || b == b'>' || b == b'\n' || b == b'\r' || b == b'\t')
+}
+
 /// Check if a query parameter key is a tracking parameter.
 #[inline]
 fn is_tracking_param(key: &str) -> bool {
@@ -717,9 +730,6 @@ impl ConvertState {
                             }
                         self.skip_current_link = false;
                     }
-                    // Record buffer position BEFORE write_output emits `[`
-                    // so we can find and remove it later if needed
-                    self.link_bracket_pos = self.buffer.len();
                 } else if id == TAG_IMG && self.clean_flags & CLEAN_EMPTY_IMAGES != 0 {
                     let node = &self.stack[self.stack.len() - 1];
                     let alt = node.attributes.get("alt").map_or("", String::as_str);
@@ -731,6 +741,18 @@ impl ConvertState {
             }
 
         self.write_output(true, is_inline, configured_new_lines, output.as_deref());
+
+        // After write_output, the emitted `[` (if any) is the last byte of the
+        // buffer. Stash that exact position so emit_exit_element can find the
+        // bracket in O(1) instead of scanning forward.
+        if tag_id == Some(TAG_A) {
+            let buf_len = self.buffer.len();
+            self.link_bracket_pos = if buf_len > 0 && self.buffer.as_bytes()[buf_len - 1] == b'[' {
+                buf_len - 1
+            } else {
+                buf_len
+            };
+        }
 
         // Clean: track heading start for slug collection
         if self.clean_flags & CLEAN_FRAGMENTS != 0
@@ -917,6 +939,26 @@ impl ConvertState {
                         if cache == title { title = ""; }
                     }
                 }
+                // GFM autolink shorthand: when href equals text content and is a
+                // bare absolute URI (http(s)://, ftp://, mailto:), emit `<href>`
+                // instead of the verbose `[href](href)`. link_bracket_pos points
+                // directly at the `[` byte (set in emit_enter_element), so this
+                // is an O(1) check.
+                if title.is_empty() && is_autolink_uri(&resolved) {
+                    let bp = self.link_bracket_pos;
+                    let buf_bytes = self.buffer.as_bytes();
+                    if bp < buf_bytes.len() && buf_bytes[bp] == b'['
+                        && self.buffer.is_char_boundary(bp + 1)
+                        && &self.buffer[bp + 1..] == resolved.as_ref() {
+                        self.buffer.truncate(bp);
+                        self.buffer.push('<');
+                        self.buffer.push_str(&resolved);
+                        self.buffer.push('>');
+                        self.last_content_cache_len = self.buffer.len();
+                        self.last_node_is_inline = is_inline;
+                        return;
+                    }
+                }
                 self.buffer.push_str("](");
                 self.buffer.push_str(&resolved);
                 if !title.is_empty() {
@@ -931,10 +973,8 @@ impl ConvertState {
             if self.clean_flags & CLEAN_FRAGMENTS != 0
                 && let Some(href) = node.attributes.get("href")
                     && href.starts_with('#') && href.len() > 1 {
-                        let mut bp = self.link_bracket_pos;
-                        let buf = self.buffer.as_bytes();
-                        while bp < buf.len() && buf[bp] != b'[' { bp += 1; }
-                        self.fragment_links.push((bp, self.buffer.len()));
+                        // link_bracket_pos now points exactly at `[` (set in emit_enter_element).
+                        self.fragment_links.push((self.link_bracket_pos, self.buffer.len()));
                     }
             self.last_node_is_inline = is_inline;
             return;
@@ -953,11 +993,7 @@ impl ConvertState {
         if self.clean_flags & CLEAN_FRAGMENTS != 0 && tag_id == Some(TAG_A)
             && let Some(href) = node.attributes.get("href")
                 && href.starts_with('#') && href.len() > 1 {
-                    // Find actual [ position from recorded hint
-                    let mut bp = self.link_bracket_pos;
-                    let buf = self.buffer.as_bytes();
-                    while bp < buf.len() && buf[bp] != b'[' { bp += 1; }
-                    self.fragment_links.push((bp, self.buffer.len()));
+                    self.fragment_links.push((self.link_bracket_pos, self.buffer.len()));
                 }
     }
 

--- a/crates/core/src/convert.rs
+++ b/crates/core/src/convert.rs
@@ -943,12 +943,12 @@ impl ConvertState {
                 // bare absolute URI (http(s)://, ftp://, mailto:), emit `<href>`
                 // instead of the verbose `[href](href)`. link_bracket_pos points
                 // directly at the `[` byte (set in emit_enter_element), so this
-                // is an O(1) check.
+                // is an O(1) check. `[` is single-byte UTF-8, so `bp + 1` is
+                // always a char boundary once `buf_bytes[bp]` is confirmed `[`.
                 if title.is_empty() && is_autolink_uri(&resolved) {
                     let bp = self.link_bracket_pos;
                     let buf_bytes = self.buffer.as_bytes();
                     if bp < buf_bytes.len() && buf_bytes[bp] == b'['
-                        && self.buffer.is_char_boundary(bp + 1)
                         && &self.buffer[bp + 1..] == resolved.as_ref() {
                         self.buffer.truncate(bp);
                         self.buffer.push('<');

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -110,6 +110,54 @@ fn multiple_links_in_paragraph() {
     );
 }
 
+#[test]
+fn autolink_collapses_when_text_equals_href() {
+    assert_eq!(
+        convert(r#"<a href="https://example.com">https://example.com</a>"#),
+        "<https://example.com>"
+    );
+}
+
+#[test]
+fn autolink_collapses_mailto() {
+    assert_eq!(
+        convert(r#"<a href="mailto:hi@example.com">mailto:hi@example.com</a>"#),
+        "<mailto:hi@example.com>"
+    );
+}
+
+#[test]
+fn autolink_in_paragraph() {
+    assert_eq!(
+        convert(r#"<p>Visit <a href="https://example.com">https://example.com</a> now.</p>"#),
+        "Visit <https://example.com> now."
+    );
+}
+
+#[test]
+fn autolink_not_collapsed_when_text_differs() {
+    assert_eq!(
+        convert(r#"<a href="https://example.com">Example</a>"#),
+        "[Example](https://example.com)"
+    );
+}
+
+#[test]
+fn autolink_not_collapsed_with_title() {
+    assert_eq!(
+        convert(r#"<a href="https://example.com" title="Site">https://example.com</a>"#),
+        r#"[https://example.com](https://example.com "Site")"#
+    );
+}
+
+#[test]
+fn autolink_not_collapsed_for_relative_href() {
+    assert_eq!(
+        convert(r#"<a href="/page">/page</a>"#),
+        "[/page](/page)"
+    );
+}
+
 // ── Images ──
 
 #[test]

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -135,6 +135,22 @@ fn autolink_in_paragraph() {
 }
 
 #[test]
+fn autolink_collapses_ftp_urls() {
+    assert_eq!(
+        convert(r#"<a href="ftp://files.example.com">ftp://files.example.com</a>"#),
+        "<ftp://files.example.com>"
+    );
+}
+
+#[test]
+fn autolink_not_collapsed_with_whitespace_in_href() {
+    assert_eq!(
+        convert(r#"<a href="https://example.com/a b">https://example.com/a b</a>"#),
+        "[https://example.com/a b](https://example.com/a b)"
+    );
+}
+
+#[test]
 fn autolink_not_collapsed_when_text_differs() {
     assert_eq!(
         convert(r#"<a href="https://example.com">Example</a>"#),

--- a/packages/js/src/clean.ts
+++ b/packages/js/src/clean.ts
@@ -241,17 +241,46 @@ export function cleanBlankLines(md: string): string {
 
 // ── Redundant links ──
 
+// A bare absolute URI eligible for GFM autolink shorthand. Mirrors the scheme
+// list used by the converter so `<url>` autolinks can be recognised here.
+function isAutolinkUri(s: string): boolean {
+  if (!(s.startsWith('http://') || s.startsWith('https://')
+    || s.startsWith('ftp://') || s.startsWith('mailto:'))) {
+    return false
+  }
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i)
+    if (c === 32 || c === 60 || c === 62 || c === 10 || c === 13 || c === 9)
+      return false
+  }
+  return true
+}
+
 export function cleanRedundantLinks(md: string): string {
   const len = md.length
   let result = ''
   let i = 0
   while (i < len) {
-    if (md.charCodeAt(i) === 91 /* [ */) {
+    const code = md.charCodeAt(i)
+    if (code === 91 /* [ */) {
       const link = parseLink(md, i)
       if (link && link.text === link.url) {
         result += link.text
         i = link.end
         continue
+      }
+    }
+    else if (code === 60 /* < */) {
+      // A GFM autolink `<url>` has identical text and target by construction,
+      // so it is redundant under the same rule as `[url](url)`.
+      const close = md.indexOf('>', i + 1)
+      if (close !== -1) {
+        const inner = md.slice(i + 1, close)
+        if (isAutolinkUri(inner)) {
+          result += inner
+          i = close + 1
+          continue
+        }
       }
     }
     result += md[i]

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -438,11 +438,10 @@ export const tagHandlers: Record<number, TagHandler> = {
       if (!title && isAutolinkUri(href)) {
         const buf = state.buffer
         let i = buf.length - 1
-        let inner = ''
         while (i >= 0 && buf[i] !== '[') {
-          inner = buf[i] + inner
           i--
         }
+        const inner = i >= 0 ? buf.slice(i + 1).join('') : ''
         if (i >= 0 && inner === href) {
           buf.length = i
           const auto = `<${href}>`

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -441,8 +441,9 @@ export const tagHandlers: Record<number, TagHandler> = {
         // Sum the link-text length while scanning back for `[`, so the
         // slice/join allocation only happens when the text could equal href.
         let textLen = 0
-        while (i >= 0 && buf[i] !== '[') {
-          textLen += buf[i].length
+        let entry: string | undefined
+        while (i >= 0 && (entry = buf[i]) !== '[') {
+          textLen += entry!.length
           i--
         }
         if (i >= 0 && textLen === href.length && buf.slice(i + 1).join('') === href) {

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -441,9 +441,11 @@ export const tagHandlers: Record<number, TagHandler> = {
         // Sum the link-text length while scanning back for `[`, so the
         // slice/join allocation only happens when the text could equal href.
         let textLen = 0
-        let entry: string | undefined
-        while (i >= 0 && (entry = buf[i]) !== '[') {
-          textLen += entry!.length
+        while (i >= 0) {
+          const entry = buf[i]!
+          if (entry === '[')
+            break
+          textLen += entry.length
           i--
         }
         if (i >= 0 && textLen === href.length && buf.slice(i + 1).join('') === href) {

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -152,6 +152,21 @@ function resolveUrl(url: string, origin?: string): string {
   return url
 }
 
+// GFM autolink shorthand: only inline-syntax-safe absolute URIs are eligible
+// for `<url>` rendering. Conservative scheme list matches the Rust core.
+function isAutolinkUri(s: string): boolean {
+  if (!(s.startsWith('http://') || s.startsWith('https://')
+    || s.startsWith('ftp://') || s.startsWith('mailto:'))) {
+    return false
+  }
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i)
+    if (c === 32 || c === 60 || c === 62 || c === 10 || c === 13 || c === 9)
+      return false
+  }
+  return true
+}
+
 // Helper function to check if we're inside a table cell
 function isInsideTableCell(node: HandlerContext['node']): boolean {
   return (node.depthMap[TAG_TD] || 0) > 0 || (node.depthMap[TAG_TH] || 0) > 0
@@ -416,6 +431,25 @@ export const tagHandlers: Record<number, TagHandler> = {
       const lastContent = state.lastContentCache
       if (lastContent === title) {
         title = ''
+      }
+      // GFM autolink shorthand: when the link text equals href and href is a
+      // bare absolute URI, emit `<href>` instead of `[href](href)`. Mirrors
+      // the Rust core (crates/core/src/convert.rs).
+      if (!title && isAutolinkUri(href)) {
+        const buf = state.buffer
+        let i = buf.length - 1
+        let inner = ''
+        while (i >= 0 && buf[i] !== '[') {
+          inner = buf[i] + inner
+          i--
+        }
+        if (i >= 0 && inner === href) {
+          buf.length = i
+          const auto = `<${href}>`
+          buf.push(auto)
+          state.lastContentCache = auto
+          return ''
+        }
       }
       return title ? `](${href} "${title}")` : `](${href})`
     },

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -438,11 +438,14 @@ export const tagHandlers: Record<number, TagHandler> = {
       if (!title && isAutolinkUri(href)) {
         const buf = state.buffer
         let i = buf.length - 1
+        // Sum the link-text length while scanning back for `[`, so the
+        // slice/join allocation only happens when the text could equal href.
+        let textLen = 0
         while (i >= 0 && buf[i] !== '[') {
+          textLen += buf[i].length
           i--
         }
-        const inner = i >= 0 ? buf.slice(i + 1).join('') : ''
-        if (i >= 0 && inner === href) {
+        if (i >= 0 && textLen === href.length && buf.slice(i + 1).join('') === href) {
           buf.length = i
           const auto = `<${href}>`
           buf.push(auto)

--- a/packages/js/test/unit/autolink.test.ts
+++ b/packages/js/test/unit/autolink.test.ts
@@ -17,6 +17,16 @@ describe('gfm autolink shorthand', () => {
       .toBe('Visit <https://example.com> now.')
   })
 
+  it('collapses ftp links', () => {
+    expect(htmlToMarkdown('<a href="ftp://files.example.com">ftp://files.example.com</a>'))
+      .toBe('<ftp://files.example.com>')
+  })
+
+  it('does not collapse hrefs containing whitespace', () => {
+    expect(htmlToMarkdown('<a href="https://example.com/a b">https://example.com/a b</a>'))
+      .toBe('[https://example.com/a b](https://example.com/a b)')
+  })
+
   it('keeps verbose link when text differs from href', () => {
     expect(htmlToMarkdown('<a href="https://example.com">Example</a>'))
       .toBe('[Example](https://example.com)')

--- a/packages/js/test/unit/autolink.test.ts
+++ b/packages/js/test/unit/autolink.test.ts
@@ -31,4 +31,9 @@ describe('gfm autolink shorthand', () => {
     expect(htmlToMarkdown('<a href="/page">/page</a>'))
       .toBe('[/page](/page)')
   })
+
+  it('clean mode strips the autolink to bare text via redundantLinks', () => {
+    expect(htmlToMarkdown('<a href="https://example.com">https://example.com</a>', { clean: true }))
+      .toBe('https://example.com')
+  })
 })

--- a/packages/js/test/unit/autolink.test.ts
+++ b/packages/js/test/unit/autolink.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { htmlToMarkdown } from '../../src/index'
+
+describe('gfm autolink shorthand', () => {
+  it('collapses link when text equals href', () => {
+    expect(htmlToMarkdown('<a href="https://example.com">https://example.com</a>'))
+      .toBe('<https://example.com>')
+  })
+
+  it('collapses mailto links', () => {
+    expect(htmlToMarkdown('<a href="mailto:hi@example.com">mailto:hi@example.com</a>'))
+      .toBe('<mailto:hi@example.com>')
+  })
+
+  it('collapses autolink inside a paragraph', () => {
+    expect(htmlToMarkdown('<p>Visit <a href="https://example.com">https://example.com</a> now.</p>'))
+      .toBe('Visit <https://example.com> now.')
+  })
+
+  it('keeps verbose link when text differs from href', () => {
+    expect(htmlToMarkdown('<a href="https://example.com">Example</a>'))
+      .toBe('[Example](https://example.com)')
+  })
+
+  it('keeps verbose link when a title is present', () => {
+    expect(htmlToMarkdown('<a href="https://example.com" title="Site">https://example.com</a>'))
+      .toBe('[https://example.com](https://example.com "Site")')
+  })
+
+  it('does not collapse relative hrefs', () => {
+    expect(htmlToMarkdown('<a href="/page">/page</a>'))
+      .toBe('[/page](/page)')
+  })
+})


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Bare links where the visible text already equals the `href` were rendered verbosely as `[https://example.com](https://example.com)`. They now collapse to the GFM autolink shorthand `<https://example.com>`.

Collapse applies only when there is no `title` and the href is a bare absolute URI (`http://`, `https://`, `ftp://`, `mailto:`) free of whitespace/angle brackets. As part of this, `link_bracket_pos` is set to point exactly at the emitted `[`, so the collapse (and the existing fragment-link tracking) is an O(1) check instead of a forward scan.

Mirrored across the Rust core (`crates/core`) and the `@mdream/js` TypeScript handlers, with unit tests on both sides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Convert eligible HTML links into GFM autolink shorthand (e.g., <url>), including mailto/ftp, when link text exactly matches the absolute URL.

* **Bug Fixes / Improvements**
  * More reliable link position tracking and fragment handling for correct cleaning and rendering of collapsed autolinks.
  * Conservative URI validation to avoid collapsing unsafe or relative links.

* **Tests**
  * Added unit and conversion tests covering autolink collapsing and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harlan-zw/mdream/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->