### PR TITLE
perf(core): avoid redundant allocations in case-insensitive tag handling

### DIFF
--- a/crates/core/src/consts.rs
+++ b/crates/core/src/consts.rs
@@ -274,7 +274,43 @@ pub const CLOSE_BRACKET_CHAR: u8 = 93; // ']'
 /// tags into a rendering via `tagOverrides`.
 #[inline]
 pub fn get_tag_id(name: &str) -> Option<u8> {
-    let bytes = name.as_bytes();
+    get_tag_id_bytes(name.as_bytes())
+}
+
+/// Case-insensitive built-in tag lookup over raw bytes.
+///
+/// Lowercases ASCII into a stack-allocated `[u8; 10]` buffer, avoiding the heap
+/// allocation `name.to_ascii_lowercase()` would incur when the input contains
+/// uppercase bytes. Returns `None` for any tag not in the built-in set.
+#[inline]
+pub fn get_tag_id_ci_bytes(name: &[u8]) -> Option<u8> {
+    let len = name.len();
+    if len == 0 || len > 10 {
+        return None;
+    }
+    // Fast path: already-lowercase (the HTML5 common case) dispatches directly
+    // without copying. Only fall through to the stack-buffer lowercase when an
+    // uppercase byte is actually present.
+    let mut has_upper = false;
+    let mut i = 0;
+    while i < len {
+        if name[i].is_ascii_uppercase() { has_upper = true; break; }
+        i += 1;
+    }
+    if !has_upper {
+        return get_tag_id_bytes(name);
+    }
+    let mut buf = [0u8; 10];
+    let mut j = 0;
+    while j < len {
+        buf[j] = name[j].to_ascii_lowercase();
+        j += 1;
+    }
+    get_tag_id_bytes(&buf[..len])
+}
+
+#[inline]
+fn get_tag_id_bytes(bytes: &[u8]) -> Option<u8> {
     let len = bytes.len();
     if len == 0 || len > 10 {
         return None;

--- a/crates/core/src/consts.rs
+++ b/crates/core/src/consts.rs
@@ -272,6 +272,10 @@ pub const CLOSE_BRACKET_CHAR: u8 = 93; // ']'
 /// memcmp (typically a single word load + compare).
 /// Returns `None` for any tag not in the built-in set; callers can opt those
 /// tags into a rendering via `tagOverrides`.
+/// Longest built-in HTML tag name (`blockquote`, `figcaption`); also the size
+/// of the stack buffer used for the case-insensitive lookup.
+const MAX_BUILTIN_TAG_LEN: usize = 10;
+
 #[inline]
 pub fn get_tag_id(name: &str) -> Option<u8> {
     get_tag_id_bytes(name.as_bytes())
@@ -279,13 +283,13 @@ pub fn get_tag_id(name: &str) -> Option<u8> {
 
 /// Case-insensitive built-in tag lookup over raw bytes.
 ///
-/// Lowercases ASCII into a stack-allocated `[u8; 10]` buffer, avoiding the heap
+/// Lowercases ASCII into a stack-allocated `MAX_BUILTIN_TAG_LEN` buffer, avoiding the heap
 /// allocation `name.to_ascii_lowercase()` would incur when the input contains
 /// uppercase bytes. Returns `None` for any tag not in the built-in set.
 #[inline]
 pub fn get_tag_id_ci_bytes(name: &[u8]) -> Option<u8> {
     let len = name.len();
-    if len == 0 || len > 10 {
+    if len == 0 || len > MAX_BUILTIN_TAG_LEN {
         return None;
     }
     // Fast path: already-lowercase (the HTML5 common case) dispatches directly
@@ -300,7 +304,7 @@ pub fn get_tag_id_ci_bytes(name: &[u8]) -> Option<u8> {
     if !has_upper {
         return get_tag_id_bytes(name);
     }
-    let mut buf = [0u8; 10];
+    let mut buf = [0u8; MAX_BUILTIN_TAG_LEN];
     let mut j = 0;
     while j < len {
         buf[j] = name[j].to_ascii_lowercase();
@@ -312,7 +316,7 @@ pub fn get_tag_id_ci_bytes(name: &[u8]) -> Option<u8> {
 #[inline]
 fn get_tag_id_bytes(bytes: &[u8]) -> Option<u8> {
     let len = bytes.len();
-    if len == 0 || len > 10 {
+    if len == 0 || len > MAX_BUILTIN_TAG_LEN {
         return None;
     }
     // Each arm reads tail bytes directly: `&bytes[1..]` against a fixed-length

--- a/crates/core/src/convert.rs
+++ b/crates/core/src/convert.rs
@@ -501,11 +501,7 @@ impl ConvertState {
                         peek_end += 1;
                     }
                     let peek_name = &chunk[peek_start..peek_end];
-                    let peek_tag_id = if peek_name.bytes().any(|b| b.is_ascii_uppercase()) {
-                        crate::consts::get_tag_id(&peek_name.to_ascii_lowercase())
-                    } else {
-                        crate::consts::get_tag_id(peek_name)
-                    };
+                    let peek_tag_id = crate::consts::get_tag_id_ci_bytes(peek_name.as_bytes());
                     if self.stack.last().is_some_and(|curr| curr.tag_id == peek_tag_id) {
                         // Matching closing tag: fall through to normal closing tag processing
                         if !text_buffer.is_empty() {
@@ -571,13 +567,17 @@ impl ConvertState {
                 };
                 let tag_name_raw = &chunk[tag_name_start..tag_name_end];
 
-                let tag_name: Cow<str> = if tag_name_raw.bytes().any(|b| b.is_ascii_uppercase()) {
+                // CI lookup first: built-in tags (the common case) skip the
+                // lowercase allocation entirely. Only fall back to a Cow when
+                // the override path actually needs the lowercased name.
+                let builtin_tag_id = crate::consts::get_tag_id_ci_bytes(tag_name_raw.as_bytes());
+                let tag_name: Cow<str> = if builtin_tag_id.is_some() {
+                    Cow::Borrowed(tag_name_raw)
+                } else if tag_name_raw.bytes().any(|b| b.is_ascii_uppercase()) {
                     Cow::Owned(tag_name_raw.to_ascii_lowercase())
                 } else {
                     Cow::Borrowed(tag_name_raw)
                 };
-
-                let builtin_tag_id = crate::consts::get_tag_id(&tag_name);
                 let tag_id = if builtin_tag_id.is_some() { builtin_tag_id } else {
                     self.options.plugins.as_ref()
                         .and_then(|p| p.tag_overrides.as_ref())
@@ -2031,12 +2031,14 @@ impl ConvertState {
         }
 
         let tag_name_raw = &html_chunk[tag_name_start..i];
-        let tag_name: Cow<str> = if tag_name_raw.bytes().any(|b| b.is_ascii_uppercase()) {
+        let builtin_tag_id = crate::consts::get_tag_id_ci_bytes(tag_name_raw.as_bytes());
+        let tag_name: Cow<str> = if builtin_tag_id.is_some() {
+            Cow::Borrowed(tag_name_raw)
+        } else if tag_name_raw.bytes().any(|b| b.is_ascii_uppercase()) {
             Cow::Owned(tag_name_raw.to_ascii_lowercase())
         } else {
             Cow::Borrowed(tag_name_raw)
         };
-        let builtin_tag_id = crate::consts::get_tag_id(&tag_name);
         // Closing tag may target an aliased custom element (e.g. </ex> where
         // tagOverrides: { ex: 'em' } opened a TAG_EM node). Resolve the alias
         // here so the close matches the open.

--- a/crates/core/src/helpers.rs
+++ b/crates/core/src/helpers.rs
@@ -234,11 +234,9 @@ pub(crate) fn parse_attributes(attr_str: &str) -> Attributes {
                     state = BEFORE_VALUE;
                 } else if !is_space {
                     let raw = &attr_str[name_start_saved..name_end_saved];
-                    let name = if raw.bytes().any(|b| b.is_ascii_uppercase()) {
-                        raw.to_ascii_lowercase()
-                    } else {
-                        raw.to_string()
-                    };
+                    // Single-pass lowercase: the result is owned either way,
+                    // so the uppercase pre-scan would only add a redundant pass.
+                    let name = raw.to_ascii_lowercase();
                     result.insert(name, String::new());
                     state = NAME;
                     name_start = i;
@@ -259,11 +257,9 @@ pub(crate) fn parse_attributes(attr_str: &str) -> Attributes {
             QUOTED_VALUE => {
                 if char_code == quote_char {
                     let raw = &attr_str[name_start_saved..name_end_saved];
-                    let name = if raw.bytes().any(|b| b.is_ascii_uppercase()) {
-                        raw.to_ascii_lowercase()
-                    } else {
-                        raw.to_string()
-                    };
+                    // Single-pass lowercase: the result is owned either way,
+                    // so the uppercase pre-scan would only add a redundant pass.
+                    let name = raw.to_ascii_lowercase();
                     result.insert(name, decode_html_entities(&attr_str[value_start..i]).into_owned());
                     state = WHITESPACE;
                 }
@@ -271,11 +267,9 @@ pub(crate) fn parse_attributes(attr_str: &str) -> Attributes {
             UNQUOTED_VALUE => {
                 if is_space {
                     let raw = &attr_str[name_start_saved..name_end_saved];
-                    let name = if raw.bytes().any(|b| b.is_ascii_uppercase()) {
-                        raw.to_ascii_lowercase()
-                    } else {
-                        raw.to_string()
-                    };
+                    // Single-pass lowercase: the result is owned either way,
+                    // so the uppercase pre-scan would only add a redundant pass.
+                    let name = raw.to_ascii_lowercase();
                     result.insert(name, decode_html_entities(&attr_str[value_start..i]).into_owned());
                     state = WHITESPACE;
                 }
@@ -287,15 +281,15 @@ pub(crate) fn parse_attributes(attr_str: &str) -> Attributes {
 
     if state == NAME {
         let raw = &attr_str[name_start..];
-        let lc = if raw.bytes().any(|b| b.is_ascii_uppercase()) { raw.to_ascii_lowercase() } else { raw.to_string() };
+        let lc = raw.to_ascii_lowercase();
         result.insert(lc, String::new());
     } else if state == UNQUOTED_VALUE {
         let raw = &attr_str[name_start_saved..name_end_saved];
-        let name = if raw.bytes().any(|b| b.is_ascii_uppercase()) { raw.to_ascii_lowercase() } else { raw.to_string() };
+        let name = raw.to_ascii_lowercase();
         result.insert(name, decode_html_entities(&attr_str[value_start..]).into_owned());
     } else if state == AFTER_NAME {
         let raw = &attr_str[name_start_saved..name_end_saved];
-        let name = if raw.bytes().any(|b| b.is_ascii_uppercase()) { raw.to_ascii_lowercase() } else { raw.to_string() };
+        let name = raw.to_ascii_lowercase();
         result.insert(name, String::new());
     }
 

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -33,6 +33,15 @@ fn mismatched_case_open_close() {
     assert_eq!(convert("<H2>Heading</h2>"), "## Heading");
 }
 
+#[test]
+fn non_nesting_tags_case_insensitive_close() {
+    // The peek-ahead close-tag match must be case-insensitive too.
+    assert_eq!(
+        convert("<head><SCRIPT>var x = 1 < 2;</SCRIPT></head><body><p>ok</p></body>"),
+        "ok"
+    );
+}
+
 // ── Headings ──
 
 #[test]

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -12,6 +12,27 @@ fn convert_with_origin(html: &str, origin: &str) -> String {
     })
 }
 
+// ── Case-insensitive tag names ──
+
+#[test]
+fn uppercase_tag_names() {
+    assert_eq!(convert("<H1>Title</H1>"), "# Title");
+    assert_eq!(convert("<DIV><P>Hello</P></DIV>"), "Hello");
+    assert_eq!(convert("<STRONG>bold</STRONG>"), "**bold**");
+}
+
+#[test]
+fn mixed_case_tag_names() {
+    assert_eq!(convert("<Strong>bold</Strong>"), "**bold**");
+    assert_eq!(convert("<eM>italic</Em>"), "_italic_");
+}
+
+#[test]
+fn mismatched_case_open_close() {
+    assert_eq!(convert("<p>text</P>"), "text");
+    assert_eq!(convert("<H2>Heading</h2>"), "## Heading");
+}
+
 // ── Headings ──
 
 #[test]


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Tag-name case handling in the Rust core did redundant work on hot paths.

**`get_tag_id_ci_bytes`** — a case-insensitive built-in tag lookup over raw bytes. Already-lowercase HTML (the overwhelmingly common case) dispatches directly with zero copying; uppercase tags lowercase into a stack-allocated `[u8; 10]` buffer instead of heap-allocating through `to_ascii_lowercase()`. The three `convert.rs` tag lookups now borrow the raw name for built-in tags and only allocate a `Cow` when a `tagOverride` genuinely needs the lowercased string.

**`parse_attributes`** (adjacent fix) — every attribute name was lowercased via an uppercase pre-scan followed by `to_ascii_lowercase()` or `to_string()`, two full passes. Since the name is owned either way, a single `to_ascii_lowercase()` pass produces identical output.

### 🧪 Benchmark

`convert_bench`, branch vs `main`, median of 3 runs (default profile):

| fixture | main | branch |
|---|---|---|
| mdn-array (230 KB) | 0.53 ms | 0.50 ms |
| github-docs (420 KB) | 0.72 ms | 0.69 ms |
| wikipedia-10x (1.6 MB) | 3.96 ms | 3.96 ms |

No regression; a small consistent gain on attribute-heavy docs. The fixtures are all-lowercase HTML, so the larger win (skipping the `to_ascii_lowercase()` heap allocation) applies to uppercase/legacy HTML not represented in the bench suite.

Adds case-insensitive tag-name conversion tests.

### Notes

The JS engine was checked for an equivalent change: its tag lookup needs a string key for `TagIdMap` regardless, and V8 already fast-paths `toLowerCase()` on already-lowercase strings, so there is no comparable allocation to remove there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust case-insensitive HTML tag handling to ensure correct conversion (including mismatched open/close and non-nesting/script-close scenarios).
  * Simplified attribute-name normalization to avoid incorrect attribute parsing.

* **Performance**
  * Reduced unnecessary string allocations and optimized tag-name processing for faster parsing.

* **Tests**
  * Added tests covering uppercase, mixed-case, and mismatched-case tag scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harlan-zw/mdream/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->