### PR TITLE
chore: exclude chokidar/semver from pnpm trust-downgrade policy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,13 @@
 shellEmulator: true
 
 trustPolicy: no-downgrade
+# These versions predate npm provenance/trusted-publishing, while their newer
+# releases publish with it, so no-downgrade flags them as trust downgrades.
+# Both are long-standing, widely-audited packages (chokidar by paulmillr,
+# semver by npm); the flag is a known false positive.
+trustPolicyExclude:
+  - 'chokidar@4.0.3'
+  - 'semver@6.3.1'
 
 packages:
   - packages/*


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The v1.2.0 release failed: all 14 `native / Build *` jobs errored at `pnpm install --frozen-lockfile`, which cascaded into the `docker` and `publish` jobs being skipped.

```
[ERR_PNPM_TRUST_DOWNGRADE] 2 lockfile entries failed verification:
  chokidar@4.0.3  High-risk trust downgrade (possible package takeover)
  semver@6.3.1    High-risk trust downgrade (possible package takeover)
```

`trustPolicy: no-downgrade` rejects a package when an earlier-published version had stronger trust evidence. `chokidar@4.0.3` and `semver@6.3.1` predate npm provenance/trusted-publishing, while their newer releases (chokidar 5.x, semver 7.x) publish with it, so the policy reads the old versions as downgrades. Both are long-standing, widely-audited packages (chokidar by paulmillr, semver by npm); this is a known false positive, tracked upstream for `chokidar@4.0.3`.

Adds `trustPolicyExclude` for those two exact versions, the escape hatch pnpm documents for known-safe packages. The policy stays enforced for everything else; pinning to exact versions means a future bump gets re-checked.

Verified locally: `pnpm install --frozen-lockfile` passes the supply-chain check with this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency trust policy configuration to exclude specific package versions from validation checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harlan-zw/mdream/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->