### PR TITLE
fix: emit override enter strings without synthesized spacing

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -223,11 +223,11 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "mdream"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "mdream-edge"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "js-sys",
  "mdream",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "mdream-node"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mdream",
  "napi",

--- a/crates/core/src/convert.rs
+++ b/crates/core/src/convert.rs
@@ -653,6 +653,9 @@ impl ConvertState {
         let is_inline: bool;
         let node_spacing: Option<[u8; 2]>;
         let output: Option<Cow<'static, str>>;
+        // True when `output` is a user-supplied override enter string — emit it
+        // verbatim without synthesizing a separating space (issue #93).
+        let enter_is_literal: bool;
         {
             let (ancestors, last) = self.stack.split_at(stack_len - 1);
             let node = &last[0];
@@ -701,11 +704,14 @@ impl ConvertState {
             // Check override enter string
             output = if let Some(ov) = override_config {
                 if let Some(ref s) = ov.enter {
+                    enter_is_literal = true;
                     Some(Cow::Owned(s.clone()))
                 } else {
+                    enter_is_literal = false;
                     self.get_enter_output(node, ancestors)
                 }
             } else {
+                enter_is_literal = false;
                 self.get_enter_output(node, ancestors)
             };
         }
@@ -740,7 +746,7 @@ impl ConvertState {
                 }
             }
 
-        self.write_output(true, is_inline, configured_new_lines, output.as_deref());
+        self.write_output(true, is_inline, configured_new_lines, output.as_deref(), enter_is_literal);
 
         // After write_output, the emitted `[` (if any) is the last byte of the
         // buffer. Stash that exact position so emit_exit_element can find the
@@ -926,7 +932,7 @@ impl ConvertState {
         // TAG_A exit: write ](url) directly to buffer — zero allocation
         if !has_override && tag_id == Some(TAG_A) && table_separator.is_none() {
             // Handle whitespace trimming (write_output with None)
-            self.write_output(false, is_inline, configured_new_lines, None);
+            self.write_output(false, is_inline, configured_new_lines, None, false);
             // Write link close directly
             if let Some(href) = node.attributes.get("href") {
                 let resolved = Self::resolve_url(href, self.options.origin.as_deref(), self.options.clean_urls);
@@ -987,7 +993,7 @@ impl ConvertState {
             output.as_deref()
         };
 
-        self.write_output(false, is_inline, configured_new_lines, effective);
+        self.write_output(false, is_inline, configured_new_lines, effective, false);
 
         // Record fragment link position for deferred fixup (no String alloc)
         if self.clean_flags & CLEAN_FRAGMENTS != 0 && tag_id == Some(TAG_A)
@@ -1415,7 +1421,7 @@ impl ConvertState {
     // ========================================================================
 
     #[inline]
-    fn write_output(&mut self, is_enter: bool, is_inline: bool, configured_new_lines: u8, output: Option<&str>) {
+    fn write_output(&mut self, is_enter: bool, is_inline: bool, configured_new_lines: u8, output: Option<&str>, literal: bool) {
         let output_str = output.unwrap_or("");
 
         // Fast path: no newlines, no output, no whitespace state to manage
@@ -1490,7 +1496,7 @@ impl ConvertState {
                     self.has_last_text_node = false;
                 }
 
-            if is_enter && !output_str.is_empty() && last_char != 0 && self.needs_spacing(last_char, output_str.as_bytes()[0]) {
+            if is_enter && !literal && !output_str.is_empty() && last_char != 0 && self.needs_spacing(last_char, output_str.as_bytes()[0]) {
                 self.buffer.push(' ');
                 self.last_content_cache_len = 1;
             }

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -364,7 +364,7 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
     }
 
     // Add spacing between inline elements if needed
-    if (output[0]?.[0] && eventType === NodeEventEnter && lastChar && needsSpacing(lastChar, output[0][0], state)) {
+    if (output[0]?.[0] && eventType === NodeEventEnter && !node.tagHandler?.literalEnter && lastChar && needsSpacing(lastChar, output[0][0], state)) {
       state.buffer.push(' ')
       state.lastContentCache = ' '
     }

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -954,6 +954,7 @@ export function buildTagOverrideHandlers(overrides: Record<string, TagOverride |
       if (override.enter !== undefined) {
         const enterStr = override.enter
         handler.enter = () => enterStr
+        handler.literalEnter = true
       }
       if (override.exit !== undefined) {
         const exitStr = override.exit

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -338,6 +338,12 @@ export interface TagHandler {
   // Number of newlines to add before/after the tag
   spacing?: readonly [number, number]
   excludesTextNodes?: boolean
+  /**
+   * When true, the `enter` string is emitted verbatim without synthesizing a
+   * separating space before it. Set for user-supplied tagOverride enter
+   * strings so markers like `^`/`~` attach to adjacent content (issue #93).
+   */
+  literalEnter?: boolean
 }
 
 // Plugin-specific context interfaces

--- a/packages/mdream/test/unit/plugins/tag-overrides.test.ts
+++ b/packages/mdream/test/unit/plugins/tag-overrides.test.ts
@@ -83,6 +83,20 @@ describe.each(engines)('tagOverrides $name', (engineConfig) => {
     expect(markdown).toBe('_text_')
   })
 
+  it('converts sup/sub to extended markdown syntax (issue #93)', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const markdown = htmlToMarkdown('<p>E = mc<sup>2</sup> and H<sub>2</sub>O</p>', {
+      plugins: {
+        tagOverrides: {
+          sup: { enter: '^', exit: '^', isInline: true, spacing: [0, 0] },
+          sub: { enter: '~', exit: '~', isInline: true, spacing: [0, 0] },
+        },
+      },
+      engine,
+    })
+    expect(markdown).toBe('E = mc^2^ and H~2~O')
+  })
+
   it('works alongside extraction without interference', async () => {
     const engine = await resolveEngine(engineConfig.engine)
     const extracted: string[] = []

--- a/packages/mdream/test/unit/plugins/tag-overrides.test.ts
+++ b/packages/mdream/test/unit/plugins/tag-overrides.test.ts
@@ -88,8 +88,8 @@ describe.each(engines)('tagOverrides $name', (engineConfig) => {
     const markdown = htmlToMarkdown('<p>E = mc<sup>2</sup> and H<sub>2</sub>O</p>', {
       plugins: {
         tagOverrides: {
-          sup: { enter: '^', exit: '^', isInline: true, spacing: [0, 0] },
-          sub: { enter: '~', exit: '~', isInline: true, spacing: [0, 0] },
+          sup: { enter: '^', exit: '^' },
+          sub: { enter: '~', exit: '~' },
         },
       },
       engine,


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #93

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`<sub>`/`<sup>` can be converted to extended markdown (`~lower~` / `^upper^`) via `tagOverrides`, but the converter synthesized a separating space before the override enter string since `^`/`~` are not recognized as inline-attaching markers, producing `mc ^2^` instead of `mc^2^`.

Override enter strings are now emitted verbatim: when a `tagOverride` supplies an explicit `enter` string, the inter-element space heuristic is skipped so markers attach to adjacent content. Real spaces from source HTML still flow through as text nodes, so `m <sup>2</sup>` keeps its space. The change is scoped to the override path on both the Rust and JS engines; default conversion is untouched.

Usage for issue #93:

```js
htmlToMarkdown(html, {
  tagOverrides: {
    sup: { enter: '^', exit: '^' },
    sub: { enter: '~', exit: '~' },
  },
})
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unwanted spacing when custom tag enter strings are used so markers no longer get separated from adjacent content.

* **New Features**
  * Tag override handlers can now mark enter output as literal so custom enter/exit strings attach precisely to surrounding text.

* **Tests**
  * Added a unit test verifying custom tag overrides (e.g., superscript/subscript) produce exact inline markdown output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harlan-zw/mdream/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->