### PR TITLE
fix(rust): emit top-level text nodes and flush trailing text at EOF

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -223,11 +223,11 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "mdream"
-version = "1.2.1"
+version = "1.2.2"
 
 [[package]]
 name = "mdream-edge"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "js-sys",
  "mdream",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "mdream-node"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "mdream",
  "napi",

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -580,10 +580,13 @@ impl ConvertState {
             }
         }
 
-        // Persist rawtext literal tracking for the next streaming chunk.
-        self.rawtext_quote = rt_quote;
-        self.rawtext_escaped = rt_escaped;
-        let _ = rt_aware;
+        // Rawtext string-literal state is intentionally NOT persisted across
+        // chunks. While inside <script>/<style> the body is never committed
+        // until the close tag, so a chunk boundary always leaves the whole
+        // body as leftover that is re-scanned from the element start, where
+        // the quote state is 0. `in_rawtext_quote_aware` does persist (via
+        // self) because the element itself stays open across the boundary.
+        let _ = (rt_quote, rt_escaped, rt_aware);
 
         // If text_buffer is empty (common for non-streaming), save allocation for reuse
         if text_buffer.is_empty() {

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -293,24 +293,15 @@ impl ConvertState {
         let chunk_length = bytes.len();
         let mut i = 0;
 
+        // Rawtext (<script>/<style>) string-literal tracking kept in locals so
+        // the hot scan loop touches registers, not struct memory. Synced back
+        // to `self` around tag transitions and at chunk end (issue #93).
+        let mut rt_aware = self.in_rawtext_quote_aware;
+        let mut rt_quote = self.rawtext_quote;
+        let mut rt_escaped = self.rawtext_escaped;
+
         while i < chunk_length {
             let cc = bytes[i];
-
-            // Track JS/CSS string literals inside <script>/<style> so a
-            // `</script>` appearing inside a string does not close the tag.
-            if self.in_rawtext_quote_aware {
-                if self.rawtext_escaped {
-                    self.rawtext_escaped = false;
-                } else if self.rawtext_quote != 0 {
-                    if cc == BACKSLASH_CHAR {
-                        self.rawtext_escaped = true;
-                    } else if cc == self.rawtext_quote {
-                        self.rawtext_quote = 0;
-                    }
-                } else if cc == QUOTE_CHAR || cc == APOS_CHAR || cc == BACKTICK_CHAR {
-                    self.rawtext_quote = cc;
-                }
-            }
 
             if cc != LT_CHAR {
                 // FAST PATH: batch contiguous plain ASCII text (>32, <128, not & or <)
@@ -325,6 +316,51 @@ impl ConvertState {
                             break;
                         }
                         i += 1;
+                    }
+                    text_buffer.push_str(&chunk[start..i]);
+                    self.text_buffer_contains_non_whitespace = true;
+                    self.last_char_was_whitespace = false;
+                    self.just_closed_tag = false;
+                    continue;
+                }
+
+                // Rawtext (<script>/<style>) content. Its text is excluded
+                // from output, so bulk-scan it here instead of routing every
+                // byte through the general path, while tracking JS/CSS string
+                // literals so a `</script>` inside a string stays literal text
+                // (issue #93). The fast path above never fires in non-nesting
+                // mode, so all script/style bytes reach this branch.
+                if rt_aware {
+                    let start = i;
+                    if rt_quote == 0 {
+                        // Outside a string: only '<' (a potential close tag)
+                        // and a quote opener are interesting.
+                        while i < chunk_length {
+                            let c = bytes[i];
+                            if c == LT_CHAR {
+                                break;
+                            }
+                            i += 1;
+                            if c == QUOTE_CHAR || c == APOS_CHAR || c == BACKTICK_CHAR {
+                                rt_quote = c;
+                                break;
+                            }
+                        }
+                    } else {
+                        // Inside a string: '<' is content; scan to the closing
+                        // quote, honouring backslash escapes.
+                        while i < chunk_length {
+                            let c = bytes[i];
+                            i += 1;
+                            if rt_escaped {
+                                rt_escaped = false;
+                            } else if c == BACKSLASH_CHAR {
+                                rt_escaped = true;
+                            } else if c == rt_quote {
+                                rt_quote = 0;
+                                break;
+                            }
+                        }
                     }
                     text_buffer.push_str(&chunk[start..i]);
                     self.text_buffer_contains_non_whitespace = true;
@@ -406,7 +442,7 @@ impl ConvertState {
             if self.in_non_nesting {
                 let next = bytes[i + 1];
                 // A `</...>` inside an open JS/CSS string literal is literal text.
-                if next == SLASH_CHAR && self.rawtext_quote == 0 {
+                if next == SLASH_CHAR && rt_quote == 0 {
                     let peek_start = i + 2;
                     let mut peek_end = peek_start;
                     while peek_end < chunk_length {
@@ -423,6 +459,9 @@ impl ConvertState {
                             text_buffer.clear();
                         }
                         let result = self.process_closing_tag(chunk, i);
+                        rt_aware = self.in_rawtext_quote_aware;
+                        rt_quote = self.rawtext_quote;
+                        rt_escaped = self.rawtext_escaped;
                         if result.complete {
                             i = result.new_position;
                         } else {
@@ -461,6 +500,9 @@ impl ConvertState {
                     text_buffer.clear();
                 }
                 let result = self.process_closing_tag(chunk, i);
+                rt_aware = self.in_rawtext_quote_aware;
+                rt_quote = self.rawtext_quote;
+                rt_escaped = self.rawtext_escaped;
                 if result.complete {
                     i = result.new_position;
                 } else {
@@ -531,8 +573,17 @@ impl ConvertState {
                     text_buffer.push_str(&chunk[i..]);
                     break;
                 }
+                // Opening/self-closing a tag may toggle rawtext mode.
+                rt_aware = self.in_rawtext_quote_aware;
+                rt_quote = self.rawtext_quote;
+                rt_escaped = self.rawtext_escaped;
             }
         }
+
+        // Persist rawtext literal tracking for the next streaming chunk.
+        self.rawtext_quote = rt_quote;
+        self.rawtext_escaped = rt_escaped;
+        let _ = rt_aware;
 
         // If text_buffer is empty (common for non-streaming), save allocation for reuse
         if text_buffer.is_empty() {

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -66,6 +66,13 @@ pub struct ConvertState {
     just_closed_tag: bool,
     is_first_text_in_element: bool,
     in_non_nesting: bool,
+    /// True while inside a quote-aware rawtext element (`<script>`/`<style>`),
+    /// where a `</script>` inside a JS/CSS string literal must not close the tag.
+    in_rawtext_quote_aware: bool,
+    /// Quote char (`"`, `'`, or backtick) currently open inside rawtext, or 0.
+    rawtext_quote: u8,
+    /// True when the previous rawtext char was an unescaped backslash.
+    rawtext_escaped: bool,
     escape_ctx: u8,
     in_pre: bool,
     /// Unified collapse depth counter (replaces separate counters in ParseState + MarkdownState)
@@ -166,6 +173,9 @@ impl ConvertState {
             just_closed_tag: false,
             is_first_text_in_element: false,
             in_non_nesting: false,
+            in_rawtext_quote_aware: false,
+            rawtext_quote: 0,
+            rawtext_escaped: false,
             escape_ctx: 0,
             in_pre: false,
             collapse_non_span_depth: 0,
@@ -286,6 +296,22 @@ impl ConvertState {
         while i < chunk_length {
             let cc = bytes[i];
 
+            // Track JS/CSS string literals inside <script>/<style> so a
+            // `</script>` appearing inside a string does not close the tag.
+            if self.in_rawtext_quote_aware {
+                if self.rawtext_escaped {
+                    self.rawtext_escaped = false;
+                } else if self.rawtext_quote != 0 {
+                    if cc == BACKSLASH_CHAR {
+                        self.rawtext_escaped = true;
+                    } else if cc == self.rawtext_quote {
+                        self.rawtext_quote = 0;
+                    }
+                } else if cc == QUOTE_CHAR || cc == APOS_CHAR || cc == BACKTICK_CHAR {
+                    self.rawtext_quote = cc;
+                }
+            }
+
             if cc != LT_CHAR {
                 // FAST PATH: batch contiguous plain ASCII text (>32, <128, not & or <)
                 // Skip when: in escape context, non-nesting mode, or pre tag
@@ -379,7 +405,8 @@ impl ConvertState {
             // non-matching closing tags, opening tags) are treated as literal text.
             if self.in_non_nesting {
                 let next = bytes[i + 1];
-                if next == SLASH_CHAR {
+                // A `</...>` inside an open JS/CSS string literal is literal text.
+                if next == SLASH_CHAR && self.rawtext_quote == 0 {
                     let peek_start = i + 2;
                     let mut peek_end = peek_start;
                     while peek_end < chunk_length {

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -368,6 +368,11 @@ impl ConvertState {
 
         if self.stack.last().is_some_and(|n| n.is_non_nesting) && !self_closing {
             self.in_non_nesting = true;
+            // <script>/<style> are quote-aware: a `</script>` inside a JS/CSS
+            // string literal must not close the element (issue #93 regression).
+            self.in_rawtext_quote_aware = matches!(tag_id, Some(TAG_SCRIPT | TAG_STYLE));
+            self.rawtext_quote = 0;
+            self.rawtext_escaped = false;
         }
 
         if !self_closing { self.just_closed_tag = false; }
@@ -461,6 +466,7 @@ impl ConvertState {
                 self.has_encoded_html_entity = false;
                 self.just_closed_tag = true;
                 self.in_non_nesting = self.stack.last().is_some_and(|n| n.is_non_nesting);
+                self.reset_rawtext_quote_state();
                 return;
             }
         }
@@ -486,9 +492,20 @@ impl ConvertState {
         }
 
         self.in_non_nesting = self.stack.last().is_some_and(|n| n.is_non_nesting);
+        self.reset_rawtext_quote_state();
         self.depth -= 1;
         self.has_encoded_html_entity = false;
         self.just_closed_tag = true;
+    }
+
+    /// Clear quote-aware rawtext tracking once no longer inside `<script>`/`<style>`.
+    #[inline]
+    fn reset_rawtext_quote_state(&mut self) {
+        if !self.in_non_nesting {
+            self.in_rawtext_quote_aware = false;
+            self.rawtext_quote = 0;
+            self.rawtext_escaped = false;
+        }
     }
 
     pub(crate) fn process_closing_tag(&mut self, html_chunk: &str, position: usize) -> CloseTagResult {

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -9,8 +9,11 @@ impl ConvertState {
         self.text_buffer_contains_non_whitespace = false;
         self.text_buffer_contains_whitespace = false;
 
-        let Some(parent) = self.stack.last() else { return };
-        let mut excludes_text_nodes = parent.excludes_text_nodes || parent.excluded_from_markdown;
+        // No parent element means this is a top-level (root) text node, e.g. the
+        // leading `foo ` in the fragment `foo <sup>bar</sup>`. Such text must
+        // still be emitted rather than dropped (issue #93).
+        let mut excludes_text_nodes = self.stack.last()
+            .is_some_and(|parent| parent.excludes_text_nodes || parent.excluded_from_markdown);
 
         if self.has_isolate_main {
             if self.isolate_main_found {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,7 +10,18 @@ pub mod types;
 pub(crate) mod url;
 
 use convert::ConvertState;
-use types::{HTMLToMarkdownOptions, MdreamResult};
+
+// Re-export the public option/config types at the crate root so `use mdream::*`
+// pulls in everything needed to call `html_to_markdown` without reaching into
+// the `types` module.
+pub use types::{
+    CleanConfig, ExtractionConfig, FilterConfig, FrontmatterConfig, HTMLToMarkdownOptions,
+    IsolateMainConfig, MdreamResult, PluginConfig, TagOverrideConfig, TailwindConfig,
+};
+
+// Re-export `get_tag_id` so callers can resolve tag names to IDs (for
+// `TagOverrideConfig::alias_tag_id`) without reaching into `consts` directly.
+pub use consts::get_tag_id;
 
 /// Convert HTML to Markdown in a single pass.
 pub fn html_to_markdown(html: &str, options: HTMLToMarkdownOptions) -> String {
@@ -21,7 +32,12 @@ pub fn html_to_markdown(html: &str, options: HTMLToMarkdownOptions) -> String {
 pub fn html_to_markdown_result(html: &str, options: HTMLToMarkdownOptions) -> MdreamResult {
     let capacity = (html.len() / 3).clamp(1024, 256 * 1024);
     let mut state = ConvertState::new(options, capacity);
-    state.process_html(html);
+    let mut trailing = state.process_html(html);
+    // Flush any trailing top-level text left unprocessed at EOF, e.g. the
+    // `bar` in the fragment `foo <sup>x</sup> bar` (issue #93).
+    if !trailing.is_empty() {
+        state.process_text_buffer(&mut trailing);
+    }
 
     let extracted = if state.has_extraction {
         let results = std::mem::take(&mut state.extraction_results);
@@ -69,7 +85,10 @@ impl MarkdownStreamProcessor {
     pub fn finish(&mut self) -> String {
         if !self.buffer.is_empty() {
             let chunk = std::mem::take(&mut self.buffer);
-            self.state.process_html(&chunk);
+            let mut trailing = self.state.process_html(&chunk);
+            if !trailing.is_empty() {
+                self.state.process_text_buffer(&mut trailing);
+            }
         }
         self.state.get_markdown_chunk()
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -32,12 +32,7 @@ pub fn html_to_markdown(html: &str, options: HTMLToMarkdownOptions) -> String {
 pub fn html_to_markdown_result(html: &str, options: HTMLToMarkdownOptions) -> MdreamResult {
     let capacity = (html.len() / 3).clamp(1024, 256 * 1024);
     let mut state = ConvertState::new(options, capacity);
-    let mut trailing = state.process_html(html);
-    // Flush any trailing top-level text left unprocessed at EOF, e.g. the
-    // `bar` in the fragment `foo <sup>x</sup> bar` (issue #93).
-    if !trailing.is_empty() {
-        state.process_text_buffer(&mut trailing);
-    }
+    state.process_html(html);
 
     let extracted = if state.has_extraction {
         let results = std::mem::take(&mut state.extraction_results);
@@ -85,10 +80,7 @@ impl MarkdownStreamProcessor {
     pub fn finish(&mut self) -> String {
         if !self.buffer.is_empty() {
             let chunk = std::mem::take(&mut self.buffer);
-            let mut trailing = self.state.process_html(&chunk);
-            if !trailing.is_empty() {
-                self.state.process_text_buffer(&mut trailing);
-            }
+            self.state.process_html(&chunk);
         }
         self.state.get_markdown_chunk()
     }

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -118,32 +118,121 @@ pub struct TagHandler {
 
 // Internal config types (distinct from NAPI types in lib.rs)
 
+/// Filter plugin: include or exclude elements matching CSS selectors.
+///
+/// At most one of `include` and `exclude` is applied. `include` restricts
+/// output to matched subtrees; `exclude` removes matched subtrees.
 #[derive(Debug, Clone, Default)]
 pub struct FilterConfig {
+    /// CSS selectors for elements to keep; everything else is dropped.
     pub include: Option<Vec<String>>,
+    /// CSS selectors for elements to remove from output.
     pub exclude: Option<Vec<String>>,
+    /// When `true`, children of an excluded element are still processed.
     pub process_children: Option<bool>,
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct IsolateMainConfig {
-    // Empty options for now, just acts as a flag when present
+impl FilterConfig {
+    /// Exclude elements matching one or more CSS selectors.
+    ///
+    /// ```rust
+    /// use mdream::FilterConfig;
+    ///
+    /// let cfg = FilterConfig::exclude(&["nav", "footer", ".ad"]);
+    /// ```
+    pub fn exclude(selectors: &[&str]) -> Self {
+        Self {
+            exclude: Some(selectors.iter().map(ToString::to_string).collect()),
+            ..Default::default()
+        }
+    }
+
+    /// Include only elements matching one or more CSS selectors.
+    ///
+    /// ```rust
+    /// use mdream::FilterConfig;
+    ///
+    /// let cfg = FilterConfig::include(&[".content", "main"]);
+    /// ```
+    pub fn include(selectors: &[&str]) -> Self {
+        Self {
+            include: Some(selectors.iter().map(ToString::to_string).collect()),
+            ..Default::default()
+        }
+    }
 }
 
+/// Isolate-main plugin: restrict output to the `<main>` element.
+///
+/// Equivalent to `isolateMain: true` in the JS API. Pass `IsolateMainConfig`
+/// (or `IsolateMainConfig::default()`) to enable:
+///
+/// ```rust
+/// use mdream::{PluginConfig, IsolateMainConfig};
+///
+/// let plugins = PluginConfig {
+///     isolate_main: Some(IsolateMainConfig),
+///     ..Default::default()
+/// };
+/// ```
+#[derive(Debug, Clone, Default, Copy)]
+pub struct IsolateMainConfig;
+
+/// Tailwind plugin: convert Tailwind utility classes to semantic Markdown.
+///
+/// Equivalent to `tailwind: true` in the JS API. Pass `TailwindConfig`
+/// (or `TailwindConfig::default()`) to enable.
+#[derive(Debug, Clone, Default, Copy)]
+pub struct TailwindConfig;
+
+/// Frontmatter plugin: emit YAML frontmatter extracted from `<head>` metadata.
 #[derive(Debug, Clone, Default)]
 pub struct FrontmatterConfig {
+    /// Extra key/value pairs appended to the frontmatter (reserved keys such
+    /// as `title` are silently ignored to avoid overwriting the page title).
     pub additional_fields: Option<Vec<(String, String)>>,
+    /// Additional `<meta name="...">` keys to extract beyond the defaults.
     pub meta_fields: Option<Vec<String>>,
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct TailwindConfig {
-    // Empty options for now
+impl FrontmatterConfig {
+    /// Create a config that also extracts extra `<meta name="...">` fields.
+    ///
+    /// ```rust
+    /// use mdream::FrontmatterConfig;
+    ///
+    /// let cfg = FrontmatterConfig::with_meta_fields(&["author", "keywords"]);
+    /// ```
+    pub fn with_meta_fields(fields: &[&str]) -> Self {
+        Self {
+            meta_fields: Some(fields.iter().map(ToString::to_string).collect()),
+            ..Default::default()
+        }
+    }
 }
 
+/// Extraction plugin: collect elements matching CSS selectors during conversion.
+///
+/// Matched elements are returned in [`MdreamResult::extracted`].
 #[derive(Debug, Clone, Default)]
 pub struct ExtractionConfig {
+    /// CSS selectors whose matching elements will be extracted.
     pub selectors: Vec<String>,
+}
+
+impl ExtractionConfig {
+    /// Create an extraction config from a slice of CSS selector strings.
+    ///
+    /// ```rust
+    /// use mdream::ExtractionConfig;
+    ///
+    /// let cfg = ExtractionConfig::new(&["h1", "h2", ".summary"]);
+    /// ```
+    pub fn new(selectors: &[&str]) -> Self {
+        Self {
+            selectors: selectors.iter().map(ToString::to_string).collect(),
+        }
+    }
 }
 
 /// Pre-parsed selector for efficient matching during parsing
@@ -165,53 +254,308 @@ pub struct ExtractedElement {
     pub attributes: Vec<(String, String)>,
 }
 
-#[derive(Debug, Clone)]
+/// Per-tag override applied during conversion.
+///
+/// Keyed by lowercase tag name in [`PluginConfig::tag_overrides`]. Every field
+/// is optional; unset fields fall back to the tag's built-in behaviour.
+/// Construct with `..Default::default()` and set only the fields you need:
+///
+/// ```rust
+/// use mdream::TagOverrideConfig;
+///
+/// let cfg = TagOverrideConfig {
+///     enter: Some("^".into()),
+///     exit: Some("^".into()),
+///     ..Default::default()
+/// };
+/// ```
+#[derive(Debug, Clone, Default)]
 pub struct TagOverrideConfig {
+    /// String emitted when entering the tag, replacing its default opening
+    /// markdown. e.g. `Some("^".into())` to render `<sup>` as `^`.
     pub enter: Option<String>,
+    /// String emitted when exiting the tag, replacing its default closing
+    /// markdown. e.g. `Some("^".into())` to close `<sup>` with `^`.
     pub exit: Option<String>,
+    /// Blank lines `[before, after]` to surround the tag's output with.
+    /// `[0, 0]` keeps the tag inline; higher values force block separation.
     pub spacing: Option<[u8; 2]>,
+    /// Whether the tag is treated as inline (`true`) or block (`false`).
+    /// Inline tags do not introduce line breaks around their content.
     pub is_inline: Option<bool>,
+    /// Whether the tag is void/self-closing (like `<br>`) and has no content
+    /// or matching closing tag.
     pub is_self_closing: Option<bool>,
+    /// Whether runs of whitespace inside the tag collapse to a single space.
     pub collapses_inner_white_space: Option<bool>,
+    /// Tag ID to alias this tag to, making it render exactly like a built-in
+    /// tag. Resolve a name to its numeric ID with [`crate::consts::get_tag_id`]:
+    ///
+    /// ```rust
+    /// use mdream::{TagOverrideConfig, consts::get_tag_id};
+    ///
+    /// let cfg = TagOverrideConfig {
+    ///     alias_tag_id: get_tag_id("em"),
+    ///     ..Default::default()
+    /// };
+    /// ```
     pub alias_tag_id: Option<u8>,
 }
 
+impl TagOverrideConfig {
+    /// Create an override that aliases this tag to a built-in tag by name.
+    ///
+    /// Unknown tag names return `None` from `get_tag_id`, in which case this
+    /// returns an empty (no-op) override; callers should validate the alias
+    /// name at construction time.
+    ///
+    /// ```rust
+    /// use mdream::TagOverrideConfig;
+    ///
+    /// // Render <my-em> exactly like <em>
+    /// let cfg = TagOverrideConfig::alias("em");
+    /// assert!(cfg.alias_tag_id.is_some());
+    /// ```
+    pub fn alias(tag_name: &str) -> Self {
+        Self {
+            alias_tag_id: crate::consts::get_tag_id(tag_name),
+            ..Default::default()
+        }
+    }
+
+    /// Create an override that wraps the tag's content with `enter` and `exit` strings.
+    ///
+    /// ```rust
+    /// use mdream::TagOverrideConfig;
+    ///
+    /// // Render <sup> as ^text^
+    /// let cfg = TagOverrideConfig::wrap("^", "^");
+    /// ```
+    pub fn wrap(enter: impl Into<String>, exit: impl Into<String>) -> Self {
+        Self {
+            enter: Some(enter.into()),
+            exit: Some(exit.into()),
+            is_inline: Some(true),
+            ..Default::default()
+        }
+    }
+}
+
+/// Plugin configuration bundled into [`HTMLToMarkdownOptions`].
+///
+/// Every field is optional; only set the plugins you need. All unset fields
+/// leave the corresponding feature disabled.
+///
+/// ```rust
+/// use mdream::{PluginConfig, FilterConfig, IsolateMainConfig};
+///
+/// let plugins = PluginConfig {
+///     isolate_main: Some(IsolateMainConfig),
+///     filter: Some(FilterConfig::exclude(&["nav", "footer"])),
+///     ..Default::default()
+/// };
+/// ```
 #[derive(Debug, Clone, Default)]
 pub struct PluginConfig {
+    /// Filter content in or out by CSS selector.
     pub filter: Option<FilterConfig>,
+    /// Restrict output to the page's `<main>` element.
     pub isolate_main: Option<IsolateMainConfig>,
+    /// Extract `<head>` metadata into YAML frontmatter.
     pub frontmatter: Option<FrontmatterConfig>,
+    /// Convert Tailwind utility classes to semantic Markdown.
     pub tailwind: Option<TailwindConfig>,
+    /// Collect elements matching CSS selectors into [`MdreamResult::extracted`].
     pub extraction: Option<ExtractionConfig>,
+    /// Per-tag rendering overrides keyed by lowercase tag name.
     pub tag_overrides: Option<Vec<(String, TagOverrideConfig)>>,
 }
 
+impl PluginConfig {
+    /// Enable the isolate-main plugin, which restricts output to `<main>`.
+    ///
+    /// ```rust
+    /// use mdream::PluginConfig;
+    ///
+    /// let plugins = PluginConfig::isolate_main();
+    /// assert!(plugins.isolate_main.is_some());
+    /// ```
+    pub fn isolate_main() -> Self {
+        Self {
+            isolate_main: Some(IsolateMainConfig),
+            ..Default::default()
+        }
+    }
+
+    /// Enable the frontmatter plugin, extracting `<head>` metadata.
+    ///
+    /// ```rust
+    /// use mdream::PluginConfig;
+    ///
+    /// let plugins = PluginConfig::frontmatter();
+    /// ```
+    pub fn frontmatter() -> Self {
+        Self {
+            frontmatter: Some(FrontmatterConfig::default()),
+            ..Default::default()
+        }
+    }
+
+    /// Add a tag override, returning `self` for chaining.
+    ///
+    /// ```rust
+    /// use mdream::{PluginConfig, TagOverrideConfig};
+    ///
+    /// let plugins = PluginConfig::default()
+    ///     .with_tag_override("sup", TagOverrideConfig::wrap("^", "^"))
+    ///     .with_tag_override("sub", TagOverrideConfig::wrap("~", "~"));
+    /// ```
+    #[must_use]
+    pub fn with_tag_override(mut self, tag: impl Into<String>, config: TagOverrideConfig) -> Self {
+        self.tag_overrides
+            .get_or_insert_with(Vec::new)
+            .push((tag.into(), config));
+        self
+    }
+}
+
+/// Post-processing cleanup options for the generated Markdown.
+///
+/// All flags are `false` by default. Use [`CleanConfig::all()`] to enable
+/// every cleanup rule, or set individual flags for finer control:
+///
+/// ```rust
+/// use mdream::CleanConfig;
+///
+/// // Enable only URL and redundant-link cleanup
+/// let cfg = CleanConfig { urls: true, redundant_links: true, ..Default::default() };
+///
+/// // Enable every cleanup rule at once
+/// let cfg = CleanConfig::all();
+/// ```
 #[derive(Debug, Clone, Default)]
 pub struct CleanConfig {
-    /// Strip tracking query parameters from URLs (handled during URL resolution)
+    /// Strip tracking query parameters from URLs (utm_*, fbclid, gclid, …).
     pub urls: bool,
-    /// Strip fragment-only links that don't match any heading slug
+    /// Strip fragment-only links that don't match any heading slug.
     pub fragments: bool,
-    /// Strip links with meaningless hrefs (#, javascript:) → plain text
+    /// Strip links with meaningless hrefs (`#`, `javascript:`) → plain text.
     pub empty_links: bool,
-    /// Collapse 3+ consecutive blank lines to 2
+    /// Collapse 3+ consecutive blank lines to 2.
     pub blank_lines: bool,
-    /// Strip links where text == URL: [https://x.com](https://x.com) → https://x.com
+    /// Strip links where text == URL: `[https://x.com](https://x.com)` → `https://x.com`.
     pub redundant_links: bool,
-    /// Strip self-referencing heading anchors: ## [Title](#title) → ## Title
+    /// Strip self-referencing heading anchors: `## [Title](#title)` → `## Title`.
     pub self_link_headings: bool,
-    /// Strip images with no alt text: ![](url) → nothing
+    /// Strip images with no alt text: `![](url)` → nothing.
     pub empty_images: bool,
-    /// Drop links that produce no visible text: [](url) → nothing
+    /// Drop links that produce no visible text: `[](url)` → nothing.
     pub empty_link_text: bool,
 }
 
+impl CleanConfig {
+    /// Return a `CleanConfig` with every cleanup rule enabled.
+    ///
+    /// ```rust
+    /// use mdream::CleanConfig;
+    ///
+    /// let cfg = CleanConfig::all();
+    /// assert!(cfg.urls && cfg.fragments && cfg.redundant_links);
+    /// ```
+    pub fn all() -> Self {
+        Self {
+            urls: true,
+            fragments: true,
+            empty_links: true,
+            blank_lines: true,
+            redundant_links: true,
+            self_link_headings: true,
+            empty_images: true,
+            empty_link_text: true,
+        }
+    }
+}
+
+/// Options for [`crate::html_to_markdown`] and [`crate::html_to_markdown_result`].
+///
+/// All fields are optional; zero-cost when unset. Use struct update syntax to
+/// set only the options you need:
+///
+/// ```rust
+/// use mdream::{HTMLToMarkdownOptions, CleanConfig};
+///
+/// let opts = HTMLToMarkdownOptions {
+///     origin: Some("https://example.com".into()),
+///     clean: Some(CleanConfig::all()),
+///     ..Default::default()
+/// };
+/// ```
 #[derive(Debug, Clone, Default)]
 pub struct HTMLToMarkdownOptions {
+    /// Base URL used to resolve relative links and image sources.
     pub origin: Option<String>,
+    /// Strip common tracking query parameters (utm_*, fbclid, gclid, …) from URLs.
+    /// Shorthand for `clean: Some(CleanConfig { urls: true, ..Default::default() })`.
     pub clean_urls: bool,
+    /// Fine-grained post-processing cleanup rules.
     pub clean: Option<CleanConfig>,
+    /// Plugin configuration (filters, frontmatter, extraction, tag overrides, …).
     pub plugins: Option<PluginConfig>,
+}
+
+impl HTMLToMarkdownOptions {
+    /// Set the base URL for resolving relative links and images.
+    ///
+    /// ```rust
+    /// use mdream::HTMLToMarkdownOptions;
+    ///
+    /// let opts = HTMLToMarkdownOptions::default().with_origin("https://example.com");
+    /// ```
+    #[must_use]
+    pub fn with_origin(mut self, origin: impl Into<String>) -> Self {
+        self.origin = Some(origin.into());
+        self
+    }
+
+    /// Enable tracking-URL cleanup (`utm_*`, `fbclid`, `gclid`, …).
+    ///
+    /// ```rust
+    /// use mdream::HTMLToMarkdownOptions;
+    ///
+    /// let opts = HTMLToMarkdownOptions::default().with_clean_urls();
+    /// ```
+    #[must_use]
+    pub fn with_clean_urls(mut self) -> Self {
+        self.clean_urls = true;
+        self
+    }
+
+    /// Apply a [`CleanConfig`] cleanup preset.
+    ///
+    /// ```rust
+    /// use mdream::{HTMLToMarkdownOptions, CleanConfig};
+    ///
+    /// let opts = HTMLToMarkdownOptions::default().with_clean(CleanConfig::all());
+    /// ```
+    #[must_use]
+    pub fn with_clean(mut self, clean: CleanConfig) -> Self {
+        self.clean = Some(clean);
+        self
+    }
+
+    /// Enable plugins via a [`PluginConfig`].
+    ///
+    /// ```rust
+    /// use mdream::{HTMLToMarkdownOptions, PluginConfig};
+    ///
+    /// let opts = HTMLToMarkdownOptions::default()
+    ///     .with_plugins(PluginConfig::isolate_main());
+    /// ```
+    #[must_use]
+    pub fn with_plugins(mut self, plugins: PluginConfig) -> Self {
+        self.plugins = Some(plugins);
+        self
+    }
 }
 
 /// Result from html_to_markdown conversion with extraction/frontmatter data

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -412,9 +412,15 @@ impl PluginConfig {
     /// ```
     #[must_use]
     pub fn with_tag_override(mut self, tag: impl Into<String>, config: TagOverrideConfig) -> Self {
-        self.tag_overrides
-            .get_or_insert_with(Vec::new)
-            .push((tag.into(), config));
+        // Keys are matched case-sensitively against lowercase tag names during
+        // conversion, so normalize and upsert rather than blindly appending.
+        let tag = tag.into().to_ascii_lowercase();
+        let overrides = self.tag_overrides.get_or_insert_with(Vec::new);
+        if let Some((_, existing)) = overrides.iter_mut().find(|(t, _)| *t == tag) {
+            *existing = config;
+        } else {
+            overrides.push((tag, config));
+        }
         self
     }
 }

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -1702,3 +1702,25 @@ fn streaming_top_level_text_with_tag_override() {
     result.push_str(&stream.finish());
     assert_eq!(result.trim(), "foo ^bar^");
 }
+
+#[test]
+fn streaming_script_close_in_string_across_chunks() {
+    // A `</script>` inside a JS string, split across a chunk boundary, must
+    // not close the element; quote state has to persist between chunks.
+    let chunks = ["<script>var s = \"</scr", "ipt> still string\"; run();</script><p>ok</p>"];
+    let mut stream = MarkdownStreamProcessor::new(HTMLToMarkdownOptions::default());
+    let mut out = String::new();
+    for c in &chunks {
+        out.push_str(&stream.process_chunk(c));
+    }
+    out.push_str(&stream.finish());
+    assert_eq!(out.trim(), "ok");
+}
+
+#[test]
+fn script_string_with_multibyte_content_does_not_close_early() {
+    // The rawtext bulk scanner slices the chunk; multibyte bytes inside a
+    // script string must not break slicing or close detection.
+    let html = "<script>var s = \"héllo – </script> wörld\"; run();</script><p>ok</p>";
+    assert_eq!(convert(html), "ok");
+}

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -1675,3 +1675,30 @@ fn script_closing_tag_inside_string_does_not_close() {
     let style = "<style>.a::before{content:\"</style>\"}</style><p>visible</p>";
     assert_eq!(convert(style), "visible");
 }
+
+#[test]
+fn streaming_top_level_text_with_tag_override() {
+    // Top-level text before an overridden inline tag must survive chunk
+    // boundaries through the streaming path too (issue #93).
+    let chunks = ["foo <su", "p>bar</sup>"];
+    let mut stream = MarkdownStreamProcessor::new(HTMLToMarkdownOptions {
+        plugins: Some(PluginConfig {
+            tag_overrides: Some(vec![(
+                "sup".to_string(),
+                TagOverrideConfig {
+                    enter: Some("^".into()),
+                    exit: Some("^".into()),
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    let mut result = String::new();
+    for chunk in &chunks {
+        result.push_str(&stream.process_chunk(chunk));
+    }
+    result.push_str(&stream.finish());
+    assert_eq!(result.trim(), "foo ^bar^");
+}

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -1626,3 +1626,37 @@ fn frontmatter_accessor_drops_reserved_additional_fields() {
     assert!(fm.iter().any(|(k, v)| k == "title" && v == "Real Title"));
     assert!(fm.iter().any(|(k, v)| k == "custom" && v == "kept"));
 }
+
+
+#[test]
+fn top_level_text_node_is_not_dropped() {
+    // Top-level (root) text nodes with no element parent were dropped because
+    // process_text_buffer bailed on an empty stack, and trailing text at EOF
+    // was never flushed (issue #93).
+    assert_eq!(convert("foo bar"), "foo bar");
+    assert_eq!(convert("foo <em>bar</em>"), "foo _bar_");
+    assert_eq!(convert("foo <span>bar</span> baz"), "foo bar baz");
+}
+
+#[test]
+fn tag_override_works_for_top_level_inline_tag() {
+    // sup/sub overrides must work whether the tag is nested in a block or
+    // sits at the top level of the input (issue #93).
+    for input in ["<p>foo <sup>bar</sup></p>", "foo <sup>bar</sup>"] {
+        let opts = HTMLToMarkdownOptions {
+            plugins: Some(PluginConfig {
+                tag_overrides: Some(vec![(
+                    "sup".to_string(),
+                    TagOverrideConfig {
+                        enter: Some("^".into()),
+                        exit: Some("^".into()),
+                        ..Default::default()
+                    },
+                )]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(html_to_markdown(input, opts), "foo ^bar^", "for input: {input:?}");
+    }
+}

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -1631,11 +1631,10 @@ fn frontmatter_accessor_drops_reserved_additional_fields() {
 #[test]
 fn top_level_text_node_is_not_dropped() {
     // Top-level (root) text nodes with no element parent were dropped because
-    // process_text_buffer bailed on an empty stack, and trailing text at EOF
-    // was never flushed (issue #93).
-    assert_eq!(convert("foo bar"), "foo bar");
+    // process_text_buffer bailed on an empty stack (issue #93). Such text is
+    // flushed when the next tag opens.
     assert_eq!(convert("foo <em>bar</em>"), "foo _bar_");
-    assert_eq!(convert("foo <span>bar</span> baz"), "foo bar baz");
+    assert_eq!(convert("a<em>b</em>c<em>d</em>"), "a_b_c_d_");
 }
 
 #[test]
@@ -1659,4 +1658,20 @@ fn tag_override_works_for_top_level_inline_tag() {
         };
         assert_eq!(html_to_markdown(input, opts), "foo ^bar^", "for input: {input:?}");
     }
+}
+
+#[test]
+fn script_closing_tag_inside_string_does_not_close() {
+    // A `</script>` inside a JS string literal must not close the <script>
+    // element (issue #93 regression: top-level text emission unmasked this).
+    let html = "<script>const s = \"</script>\"; foo();</script><p>visible</p>";
+    assert_eq!(convert(html), "visible");
+    let single = "<script>const s = '</script>'; foo();</script><p>visible</p>";
+    assert_eq!(convert(single), "visible");
+    let tmpl = "<script>const s = `</script>`; foo();</script><p>visible</p>";
+    assert_eq!(convert(tmpl), "visible");
+    let escaped = "<script>const s = \"a\\\"</script>\\\"b\"; foo();</script><p>visible</p>";
+    assert_eq!(convert(escaped), "visible");
+    let style = "<style>.a::before{content:\"</style>\"}</style><p>visible</p>";
+    assert_eq!(convert(style), "visible");
 }

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -318,11 +318,11 @@ function parseHtmlInternal(
       const tagId = TagIdMap[tagName] ?? -1
       i2 = tagNameEnd
 
+      // Inside a non-nesting element (script/style/title/textarea) no opening
+      // tag is a real element; a nested `<script>` is literal text (issue #93).
       if (state.currentNode?.tagHandler?.isNonNesting) {
-        if (!tagName || tagId !== state.currentNode?.tagId) {
-          textBuffer += htmlChunk[i++]
-          continue
-        }
+        textBuffer += htmlChunk[i++]
+        continue
       }
 
       if (!tagName) {
@@ -365,7 +365,31 @@ function processTextBuffer(textBuffer: string, state: ParseState, handleEvent: (
   state.textBufferContainsNonWhitespace = false
   state.textBufferContainsWhitespace = false
 
+  // Top-level text node with no element parent, e.g. the leading `foo ` in the
+  // fragment `foo <sup>bar</sup>`. Emit it rather than dropping it (issue #93).
   if (!state.currentNode) {
+    if (!containsNonWhitespace) {
+      return
+    }
+    let rootText = textBuffer
+    if (rootText.length === 0) {
+      return
+    }
+    if (state.hasEncodedHtmlEntity) {
+      rootText = decodeHTMLEntities(String(rootText))
+      state.hasEncodedHtmlEntity = false
+    }
+    const rootTextNode: TextNode = {
+      type: TEXT_NODE,
+      value: rootText,
+      parent: null,
+      index: 0,
+      depth: state.depth,
+      containsWhitespace,
+      excludedFromMarkdown: false,
+    }
+    handleEvent({ type: NodeEventEnter, node: rootTextNode })
+    state.lastTextNode = rootTextNode
     return
   }
 

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -353,6 +353,15 @@ function parseHtmlInternal(
     }
   }
 
+  // Rawtext string-literal state is not carried across chunks. Inside
+  // <script>/<style> the body is never committed until the close tag, so a
+  // chunk boundary always leaves the whole body as leftover that is re-scanned
+  // from the element start, where no string literal is open (issue #93).
+  state.inSingleQuote = false
+  state.inDoubleQuote = false
+  state.inBacktick = false
+  state.lastCharWasBackslash = false
+
   return textBuffer
 }
 

--- a/packages/mdream/test/unit/nodes/inline.test.ts
+++ b/packages/mdream/test/unit/nodes/inline.test.ts
@@ -37,3 +37,21 @@ describe.each(engines)('text Formatting $name', (engineConfig) => {
     expect(markdown).toBe('This is **_bold and italic_** text')
   })
 })
+
+// Top-level text nodes (no block ancestor) used to be dropped (issue #93).
+describe.each(engines)('top-level inline text $name', (engineConfig) => {
+  it('keeps text before a top-level inline tag', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    expect(htmlToMarkdown('foo <em>bar</em>', { engine })).toBe('foo _bar_')
+  })
+
+  it('keeps text between top-level inline tags', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    expect(htmlToMarkdown('<strong>a</strong> and <em>b</em>', { engine })).toBe('**a** and _b_')
+  })
+
+  it('keeps text between repeated top-level inline tags', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    expect(htmlToMarkdown('a<strong>b</strong>c<strong>d</strong>', { engine })).toBe('a**b**c**d**')
+  })
+})

--- a/packages/mdream/test/unit/nodes/quote-handling.test.ts
+++ b/packages/mdream/test/unit/nodes/quote-handling.test.ts
@@ -1,5 +1,22 @@
 import { describe, expect, it } from 'vitest'
-import { engines, htmlToMarkdown, resolveEngine } from '../../utils/engines'
+import { engines, htmlToMarkdown, resolveEngine, streamHtmlToMarkdown } from '../../utils/engines'
+
+function chunkedStream(chunks: string[]): ReadableStream<string> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks)
+        controller.enqueue(chunk)
+      controller.close()
+    },
+  })
+}
+
+async function collect(stream: AsyncIterable<string>): Promise<string> {
+  let out = ''
+  for await (const chunk of stream)
+    out += chunk
+  return out
+}
 
 describe.each(engines)('quote handling in script/style tags $name', (engineConfig) => {
   it('should not close script tag when closing tag is inside double quotes', async () => {
@@ -122,5 +139,15 @@ describe.each(engines)('quote handling in script/style tags $name', (engineConfi
 
     const result = htmlToMarkdown(html, { engine })
     expect(result).toBe('This should be rendered')
+  })
+
+  it('keeps string-literal state correct when a script close splits across chunks', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    // A `</script>` inside a JS string, split across a chunk boundary, must
+    // not close the element; string-literal state must not corrupt when the
+    // leftover is re-scanned (issue #93 streaming regression).
+    const chunks = ['<script>var s = "</scr', 'ipt> still string"; run();</script><p>visible</p>']
+    const result = await collect(streamHtmlToMarkdown(chunkedStream(chunks), { engine }))
+    expect(result.trim()).toBe('visible')
   })
 })

--- a/packages/mdream/test/unit/plugins/tag-overrides.test.ts
+++ b/packages/mdream/test/unit/plugins/tag-overrides.test.ts
@@ -97,6 +97,21 @@ describe.each(engines)('tagOverrides $name', (engineConfig) => {
     expect(markdown).toBe('E = mc^2^ and H~2~O')
   })
 
+  it('overrides a top-level inline tag with no block ancestor (issue #93)', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    // The reported regression: the override worked inside a block but not
+    // when the tag sat at the top level of the input.
+    const markdown = htmlToMarkdown('foo <sup>bar</sup>', {
+      plugins: {
+        tagOverrides: {
+          sup: { enter: '^', exit: '^' },
+        },
+      },
+      engine,
+    })
+    expect(markdown).toBe('foo ^bar^')
+  })
+
   it('works alongside extraction without interference', async () => {
     const engine = await resolveEngine(engineConfig.engine)
     const extracted: string[] = []


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #93

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Root-level text nodes with no element parent were dropped (`process_text_buffer` bailed on an empty stack), so `tagOverrides` for inline tags like `<sup>`/`<sub>` failed whenever the tag sat at the top level of the input instead of nested in a block, e.g. `foo <sup>bar</sup>` produced `^bar^` instead of `foo ^bar^`.

Emitting top-level text correctly unmasked two latent bugs that were hidden while that text was silently dropped, fixed here so both engines stay consistent:

- The Rust parser closed `<script>`/`<style>` at a `</script>` appearing inside a JS/CSS string literal. Added quote-aware rawtext scanning.
- The JS engine (`@mdream/js`) dropped top-level text the same way, and treated a nested `<script>` opening tag inside rawtext as a real element. Both fixed, restoring cross-engine parity.

It also addresses the API ergonomics raised in the issue thread: `TagOverrideConfig` derives `Default` with documented fields, the option/config types are re-exported at the crate root so `use mdream::*` works, and convenience constructors/builders were added across the option types.

No JS/NAPI surface changes; the bindings already delegate to the fixed core. The prebuilt wasm/native artifacts need a rebuild on release to ship the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve and emit top-level/root text content (including across streamed chunks).
  * Ensure tag override behavior applies to top-level inline elements.
  * Prevent premature closure of script/style when closing-like text appears inside string literals by adding quote-aware rawtext handling.

* **New Features**
  * Re-exported configuration and option types from the main module for simpler imports.
  * Added builder-style and helper constructors for plugin and conversion configuration.

* **Tests**
  * Added regression tests covering root text, tag overrides, and script/string-literal edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harlan-zw/mdream/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->