### PR TITLE
fix: omit CDATA markup by default

### DIFF
--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -417,36 +417,32 @@ impl ConvertState {
             let next = bytes[i + 1];
 
             if next == EXCLAMATION_CHAR {
-                // Discriminate on the third byte: '-' is a comment, '[' a CDATA
-                // section, anything else a doctype/bogus declaration. Only the
-                // rare '[' case pays for the `<![CDATA[` string work; comments
-                // and doctypes (the common cases) cost a single byte compare.
-                if bytes.get(i + 2) == Some(&b'[') {
-                    let remaining = &chunk[i..];
-                    // CDATA is dropped by default but can be surfaced via
-                    // tagOverrides["#cdata-section"]. Handle it before the
-                    // generic comment/doctype scan, which would otherwise stop
-                    // at the first `>` inside `]]>` and discard the content.
-                    if let Some(after_open) = remaining.strip_prefix("<![CDATA[") {
-                        if let Some(rel) = after_open.find("]]>") {
-                            if !text_buffer.is_empty() {
-                                self.process_text_buffer(&mut text_buffer);
-                                text_buffer.clear();
-                            }
-                            self.process_cdata_section(&after_open[..rel]);
-                            i += "<![CDATA[".len() + rel + 3;
-                            continue;
+                let remaining = &chunk[i..];
+                // CDATA is dropped by default but can be surfaced via
+                // tagOverrides["#cdata-section"]. Handle it before the generic
+                // comment/doctype scan, which would otherwise stop at the first
+                // `>` inside `]]>` and discard the content. We already matched
+                // `<!`, so only the `[CDATA[` tail is checked; `strip_prefix`
+                // short-circuits on the third byte for the common comment and
+                // doctype cases.
+                if let Some(after_open) = chunk[i + 2..].strip_prefix("[CDATA[") {
+                    if let Some(rel) = after_open.find("]]>") {
+                        if !text_buffer.is_empty() {
+                            self.process_text_buffer(&mut text_buffer);
+                            text_buffer.clear();
                         }
-                        // Unterminated CDATA: re-parse from '<' in the next chunk.
-                        text_buffer.push_str(remaining);
-                        break;
+                        self.process_cdata_section(&after_open[..rel]);
+                        i += "<![CDATA[".len() + rel + 3;
+                        continue;
                     }
-                    if remaining.len() < "<![CDATA[".len() && "<![CDATA[".starts_with(remaining) {
-                        // Chunk boundary fell inside the `<![CDATA[` opener.
-                        text_buffer.push_str(remaining);
-                        break;
-                    }
-                    // '[' but not a CDATA opener: fall through to doctype scan.
+                    // Unterminated CDATA: re-parse from '<' in the next chunk.
+                    text_buffer.push_str(remaining);
+                    break;
+                }
+                if remaining.len() < "<![CDATA[".len() && "<![CDATA[".starts_with(remaining) {
+                    // Chunk boundary fell inside the `<![CDATA[` opener.
+                    text_buffer.push_str(remaining);
+                    break;
                 }
                 if !text_buffer.is_empty() {
                     self.process_text_buffer(&mut text_buffer);

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -417,6 +417,37 @@ impl ConvertState {
             let next = bytes[i + 1];
 
             if next == EXCLAMATION_CHAR {
+                // Discriminate on the third byte: '-' is a comment, '[' a CDATA
+                // section, anything else a doctype/bogus declaration. Only the
+                // rare '[' case pays for the `<![CDATA[` string work; comments
+                // and doctypes (the common cases) cost a single byte compare.
+                if bytes.get(i + 2) == Some(&b'[') {
+                    let remaining = &chunk[i..];
+                    // CDATA is dropped by default but can be surfaced via
+                    // tagOverrides["#cdata-section"]. Handle it before the
+                    // generic comment/doctype scan, which would otherwise stop
+                    // at the first `>` inside `]]>` and discard the content.
+                    if let Some(after_open) = remaining.strip_prefix("<![CDATA[") {
+                        if let Some(rel) = after_open.find("]]>") {
+                            if !text_buffer.is_empty() {
+                                self.process_text_buffer(&mut text_buffer);
+                                text_buffer.clear();
+                            }
+                            self.process_cdata_section(&after_open[..rel]);
+                            i += "<![CDATA[".len() + rel + 3;
+                            continue;
+                        }
+                        // Unterminated CDATA: re-parse from '<' in the next chunk.
+                        text_buffer.push_str(remaining);
+                        break;
+                    }
+                    if remaining.len() < "<![CDATA[".len() && "<![CDATA[".starts_with(remaining) {
+                        // Chunk boundary fell inside the `<![CDATA[` opener.
+                        text_buffer.push_str(remaining);
+                        break;
+                    }
+                    // '[' but not a CDATA opener: fall through to doctype scan.
+                }
                 if !text_buffer.is_empty() {
                     self.process_text_buffer(&mut text_buffer);
                     text_buffer.clear();

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -564,6 +564,44 @@ impl ConvertState {
         CloseTagResult { complete: true, new_position: i + 1, remaining_start: 0 }
     }
 
+    /// Handle a CDATA section's inner content.
+    ///
+    /// CDATA is discarded by default (matching the HTML spec, where `<![CDATA[`
+    /// outside foreign content is a bogus comment). Callers opt in by registering
+    /// a `#cdata-section` entry in `tagOverrides`; the leading `#` makes the
+    /// pseudo-tag impossible to collide with a real HTML element name. When an
+    /// override exists the content is emitted as a synthetic `#cdata-section`
+    /// element whose rendering follows the override (alias tag and/or
+    /// enter/exit strings).
+    pub(crate) fn process_cdata_section(&mut self, content: &str) {
+        if !self.has_tag_overrides { return; }
+        let Some(tag_id) = self.options.plugins.as_ref()
+            .and_then(|p| p.tag_overrides.as_ref())
+            .and_then(|ovs| ovs.iter().find(|(k, _)| k == "#cdata-section"))
+            .map(|(_, ov)| ov.alias_tag_id)
+        else { return };
+
+        let result = self.process_opening_tag("#cdata-section", tag_id, false, ">", 0);
+        if !result.complete { return; }
+
+        if !result.self_closing && !content.is_empty() {
+            let excluded = self.stack.last()
+                .is_some_and(|n| n.excluded_from_markdown || n.excludes_text_nodes);
+            if !excluded {
+                let depth = self.depth;
+                let index = self.stack.last().map_or(0, |n| n.current_walk_index);
+                self.emit_text(content, false, depth, index);
+            }
+            if let Some(parent) = self.stack.last_mut() {
+                parent.current_walk_index += 1;
+                parent.child_text_node_index += 1;
+            }
+        }
+        if !result.self_closing {
+            self.close_node();
+        }
+    }
+
     /// Recycle a node into the pool, preserving its Attributes Vec allocation.
     #[inline]
     pub(crate) fn recycle_node(&mut self, mut node: ElementNode) {

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -1504,6 +1504,62 @@ fn script_with_cdata_like_content() {
 }
 
 #[test]
+fn cdata_dropped_by_default() {
+    // CDATA sections are discarded unless opted into via tagOverrides.
+    let md = convert("before <![CDATA[secret payload]]> after");
+    assert!(!md.contains("secret payload"), "CDATA leaked into output: {md}");
+}
+
+#[test]
+fn cdata_emitted_via_tag_override() {
+    let overrides = vec![("#cdata-section".to_string(), TagOverrideConfig {
+        enter: None,
+        exit: None,
+        spacing: None,
+        is_inline: None,
+        is_self_closing: None,
+        collapses_inner_white_space: None,
+        alias_tag_id: Some(mdream::consts::TAG_PRE),
+    })];
+    let md = html_to_markdown(
+        "<body>before <pre><code><![CDATA[\none two\nthree four\n]]></code></pre> after</body>",
+        HTMLToMarkdownOptions {
+            plugins: Some(PluginConfig {
+                tag_overrides: Some(overrides),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    );
+    assert!(md.contains("one two"), "CDATA content missing: {md}");
+    assert!(md.contains("three four"), "CDATA content missing: {md}");
+}
+
+#[test]
+fn cdata_emitted_via_enter_exit_override() {
+    let overrides = vec![("#cdata-section".to_string(), TagOverrideConfig {
+        enter: Some("[".to_string()),
+        exit: Some("]".to_string()),
+        spacing: Some([0, 0]),
+        is_inline: Some(true),
+        is_self_closing: None,
+        collapses_inner_white_space: None,
+        alias_tag_id: None,
+    })];
+    let md = html_to_markdown(
+        "<body>a<![CDATA[hidden]]>b</body>",
+        HTMLToMarkdownOptions {
+            plugins: Some(PluginConfig {
+                tag_overrides: Some(overrides),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    );
+    assert_eq!(md, "a[hidden]b");
+}
+
+#[test]
 fn multiple_scripts_interleaved_with_content() {
     let html = r#"<body>
     <p>Before</p>

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -239,8 +239,38 @@ function parseHtmlInternal(
 
     const nextCharCode = htmlChunk.charCodeAt(i + 1)
 
-    // COMMENT or DOCTYPE
+    // COMMENT, DOCTYPE or CDATA
     if (nextCharCode === EXCLAMATION_CHAR) {
+      // Discriminate on the third char: '[' is a CDATA section, anything else
+      // is a comment/doctype. Only the rare '[' case pays for the string work.
+      if (htmlChunk.charCodeAt(i + 2) === OPEN_BRACKET_CHAR) {
+        // CDATA is dropped by default but can be surfaced via
+        // tagOverrides['#cdata-section']. Handle it before the generic
+        // comment/doctype scan, which would otherwise stop at the first `>`
+        // inside `]]>` and discard the content.
+        if (htmlChunk.startsWith('<![CDATA[', i)) {
+          const end = htmlChunk.indexOf(']]>', i + 9)
+          if (end === -1) {
+            // Unterminated CDATA: re-parse from '<' in the next chunk.
+            textBuffer += htmlChunk.substring(i)
+            break
+          }
+          if (textBuffer.length > 0) {
+            processTextBuffer(textBuffer, state, handleEvent)
+            textBuffer = ''
+          }
+          processCdataSection(htmlChunk.substring(i + 9, end), state, handleEvent)
+          i = end + 3
+          continue
+        }
+        if (chunkLength - i < 9 && '<![CDATA['.startsWith(htmlChunk.substring(i))) {
+          // Chunk boundary fell inside the `<![CDATA[` opener.
+          textBuffer += htmlChunk.substring(i)
+          break
+        }
+        // '[' but not a CDATA opener (e.g. `<![if IE]>`): fall through.
+      }
+
       if (textBuffer.length > 0) {
         processTextBuffer(textBuffer, state, handleEvent)
         textBuffer = ''
@@ -595,6 +625,50 @@ function processCommentOrDoctype(htmlChunk: string, position: number): {
       remainingText: htmlChunk.substring(position, i),
     }
   }
+}
+
+/**
+ * Handle a CDATA section's inner content.
+ *
+ * CDATA is discarded by default (matching the HTML spec, where `<![CDATA[`
+ * outside foreign content is a bogus comment). Callers opt in by registering a
+ * `#cdata-section` entry in `tagOverrides`; the leading `#` makes the pseudo-tag
+ * impossible to collide with a real HTML element name. When an override exists
+ * the content is emitted as a synthetic `#cdata-section` element whose rendering
+ * follows the override handler.
+ */
+function processCdataSection(
+  content: string,
+  state: ParseState,
+  handleEvent: (event: NodeEvent) => void,
+): void {
+  if (!state.tagOverrideHandlers?.has('#cdata-section')) {
+    return
+  }
+
+  const open = processOpeningTag('#cdata-section', -1, '>', 0, state, handleEvent)
+  if (!open.complete || open.selfClosing) {
+    return
+  }
+
+  const node = state.currentNode!
+  if (content.length > 0 && !node.tagHandler?.excludesTextNodes) {
+    const textNode: TextNode = {
+      type: TEXT_NODE,
+      value: content,
+      parent: node,
+      index: node.currentWalkIndex!++,
+      depth: state.depth,
+      containsWhitespace: false,
+    }
+    for (const parent of traverseUpToFirstBlockNode(node)) {
+      parent.childTextNodeIndex = (parent.childTextNodeIndex || 0) + 1
+    }
+    handleEvent({ type: NodeEventEnter, node: textNode })
+    state.lastTextNode = textNode
+  }
+
+  closeNode(state.currentNode ?? null, state, handleEvent)
 }
 
 /**

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -646,6 +646,9 @@ function processCdataSection(
     return
   }
 
+  // The `'>'` htmlChunk is a deliberate dummy: processTagAttributes hits the
+  // `>` at position 0 and exits immediately, so the synthetic tag has no
+  // attributes to parse. Mirrors the Rust engine's synthetic-tag handling.
   const open = processOpeningTag('#cdata-section', -1, '>', 0, state, handleEvent)
   if (!open.complete || open.selfClosing) {
     return

--- a/packages/mdream/test/unit/nodes/code.test.ts
+++ b/packages/mdream/test/unit/nodes/code.test.ts
@@ -169,4 +169,14 @@ Text without newline above.
     const markdown = htmlToMarkdown(html, { engine })
     expect(markdown).toBe('```javascript\nconst x = 1;\n```')
   })
+
+  // Regression guard for issue #98: a CDATA section inside <pre><code> must be
+  // dropped by default (no tagOverrides), leaving the code block intact rather
+  // than leaking the content or breaking the surrounding markup.
+  it('drops CDATA sections inside code blocks by default (issue #98)', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const html = '<pre><code><![CDATA[\none two\nthree four\n]]></code></pre>'
+    const markdown = htmlToMarkdown(html, { engine })
+    expect(markdown).toBe('```\n\n```')
+  })
 })

--- a/packages/mdream/test/unit/plugins/tag-overrides.test.ts
+++ b/packages/mdream/test/unit/plugins/tag-overrides.test.ts
@@ -115,6 +115,38 @@ describe.each(engines)('tagOverrides $name', (engineConfig) => {
     expect(extracted).toEqual(['italic'])
   })
 
+  it('drops CDATA sections by default', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const markdown = htmlToMarkdown('<p>before<![CDATA[secret payload]]>after</p>', {
+      engine,
+    })
+    expect(markdown).not.toContain('secret payload')
+    expect(markdown).toContain('before')
+    expect(markdown).toContain('after')
+  })
+
+  it('emits CDATA content via #cdata-section enter/exit override', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const markdown = htmlToMarkdown('<p>a<![CDATA[hidden]]>b</p>', {
+      plugins: {
+        tagOverrides: {
+          '#cdata-section': { enter: '[', exit: ']', isInline: true, spacing: [0, 0] },
+        },
+      },
+      engine,
+    })
+    expect(markdown).toBe('a[hidden]b')
+  })
+
+  it('does not treat <![ conditional comments as CDATA', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const markdown = htmlToMarkdown('<p>x<![if !IE]>y<![endif]>z</p>', {
+      engine,
+    })
+    expect(markdown).toContain('x')
+    expect(markdown).toContain('z')
+  })
+
   it('works alongside filter without interference', async () => {
     const engine = await resolveEngine(engineConfig.engine)
     const markdown = htmlToMarkdown('<div><nav>skip</nav><p><strong>keep</strong></p></div>', {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #98

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

CDATA sections are now handled before the generic declaration/comment scanner in both the Rust and JS engines. By default, mdream emits the CDATA inner text and omits only the `<![CDATA[` / `]]>` delimiters, so CDATA inside `<pre><code>` produces a normal fenced code block with the original text.

The `#cdata-section` tag override path still works for custom wrappers or aliases. Tests cover default inline output, default code-block output, the override path, and conditional comments such as `<![if !IE]>`.

### ✅ Verification

- `cargo test --manifest-path crates/Cargo.toml -p mdream cdata --test conversion`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec vitest test packages/mdream/test/unit/plugins/tag-overrides.test.ts packages/mdream/test/unit/nodes/code.test.ts --project node`
