### PR TITLE
fix: exclude inert <template> content from output (#101)

### DIFF
--- a/crates/core/src/tags.rs
+++ b/crates/core/src/tags.rs
@@ -170,7 +170,9 @@ static TAG_HANDLERS: [Option<TagHandler>; MAX_TAG_ID] = {
     t[TAG_DIALOG as usize] = Some(BLOCK_NO_SPACING);
     t[TAG_METER as usize] = Some(BLOCK_NO_SPACING);
     t[TAG_PROGRESS as usize] = Some(BLOCK_NO_SPACING);
-    t[TAG_TEMPLATE as usize] = Some(BLOCK_NO_SPACING);
+    // <template> content is inert (browsers never render it). Treat the whole
+    // body as raw text and exclude it from output, mirroring script/style.
+    t[TAG_TEMPLATE as usize] = Some(TagHandler { is_non_nesting: true, excludes_text_nodes: true, spacing: Some(NO_SPACING), ..NONE });
 
     // Non-nesting elements
     t[TAG_TEXTAREA as usize] = Some(NON_NESTING_NO_SPACING);

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -626,6 +626,35 @@ fn strips_style() {
 }
 
 #[test]
+fn strips_template_text() {
+    // <template> content is inert and must never leak into output (issue #101).
+    assert_eq!(
+        convert("<p>Visible</p><template>Hidden keyword stuffing text</template><p>After</p>"),
+        "Visible\n\nAfter"
+    );
+}
+
+#[test]
+fn strips_template_nested_elements() {
+    assert_eq!(
+        convert("<p>Visible</p><template><p>Nested hidden</p><span>more</span></template><p>After</p>"),
+        "Visible\n\nAfter"
+    );
+}
+
+#[test]
+fn template_with_quotes_closes_correctly() {
+    assert_eq!(
+        convert("<p>A</p><template>It's a \"quoted\" keyword</template><p>B</p>"),
+        "A\n\nB"
+    );
+    assert_eq!(
+        convert("<p>A</p><template><a href=\"x\">it's</a></template><p>B</p>"),
+        "A\n\nB"
+    );
+}
+
+#[test]
 fn escaped_backslash_in_script() {
     let html = r#"<script>var x = "a]\\\\\\\\b";</script><p>Visible content</p>"#;
     let result = convert(html);

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -8,6 +8,8 @@ import {
   TAG_BLOCKQUOTE,
   TAG_CODE,
   TAG_PRE,
+  TAG_SCRIPT,
+  TAG_STYLE,
   TAG_TABLE,
   TagIdMap,
   TEXT_NODE,
@@ -67,6 +69,13 @@ export interface ParseState {
   inSingleQuote?: boolean
   inDoubleQuote?: boolean
   inBacktick?: boolean
+  /**
+   * Whether the current non-nesting tag is quote-aware rawtext (script/style only).
+   * For these, a `</script>`/`</style>` inside a JS/CSS string literal must not close
+   * the tag. Other non-nesting tags (template, textarea, ...) hold literal HTML/text
+   * where apostrophes are not string delimiters, so their closing tag always wins.
+   */
+  inRawTextQuoteAware?: boolean
   /** Backslash escaping state tracking - avoids checking previous character */
   lastCharWasBackslash?: boolean
   /** Resolved plugin instances for event processing */
@@ -210,8 +219,8 @@ function parseHtmlInternal(
           textBuffer += htmlChunk[i]
         }
 
-        // Track quote state for non-nesting tags
-        if (state.currentNode?.tagHandler?.isNonNesting) {
+        // Track quote state for quote-aware rawtext tags (script/style only)
+        if (state.inRawTextQuoteAware) {
           if (!state.lastCharWasBackslash) {
             if (currentCharCode === APOS_CHAR && !state.inDoubleQuote && !state.inBacktick) {
               state.inSingleQuote = !state.inSingleQuote
@@ -288,7 +297,7 @@ function parseHtmlInternal(
     // CLOSING TAG
     else if (nextCharCode === SLASH_CHAR) {
       if (state.currentNode?.tagHandler?.isNonNesting) {
-        const inQuotes = state.inSingleQuote || state.inDoubleQuote || state.inBacktick
+        const inQuotes = state.inRawTextQuoteAware && (state.inSingleQuote || state.inDoubleQuote || state.inBacktick)
         if (inQuotes) {
           textBuffer += htmlChunk[i]
           i++
@@ -391,6 +400,10 @@ function parseHtmlInternal(
   state.inDoubleQuote = false
   state.inBacktick = false
   state.lastCharWasBackslash = false
+  // NB: inRawTextQuoteAware is intentionally not reset here. The non-nesting body
+  // is re-scanned from the element start on the next chunk while currentNode is
+  // still the script/style element, so quote-awareness must persist across the
+  // chunk boundary (issue #93).
 
   return textBuffer
 }
@@ -590,6 +603,7 @@ function closeNode(node: ElementNode | null, state: ParseState, handleEvent: (ev
     state.inDoubleQuote = false
     state.inBacktick = false
     state.lastCharWasBackslash = false
+    state.inRawTextQuoteAware = false
   }
 
   state.depth--
@@ -783,6 +797,8 @@ function processOpeningTag(
     state.inDoubleQuote = false
     state.inBacktick = false
     state.lastCharWasBackslash = false
+    // Only script/style hold quote-aware rawtext (JS/CSS string literals).
+    state.inRawTextQuoteAware = tag.tagId === TAG_SCRIPT || tag.tagId === TAG_STYLE
   }
 
   if (result.selfClosing) {

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -755,6 +755,10 @@ export const tagHandlers: Record<number, TagHandler> = {
     spacing: NO_SPACING,
   },
   [TAG_TEMPLATE]: {
+    // <template> content is inert (browsers never render it). Treat the whole
+    // body as raw text and exclude it from output, mirroring script/style.
+    isNonNesting: true,
+    excludesTextNodes: true,
     spacing: NO_SPACING,
   },
   [TAG_ABBR]: {

--- a/packages/mdream/test/unit/nodes/template.test.ts
+++ b/packages/mdream/test/unit/nodes/template.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { engines, htmlToMarkdown, resolveEngine } from '../../utils/engines'
+
+// <template> content is inert: browsers never render it, so it must never leak
+// into the Markdown output (issue #101 - "modern keyword stuffing").
+describe.each(engines)('template tag handling $name', (engineConfig) => {
+  it('excludes direct text content', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const html = '<p>Visible</p><template>Hidden keyword stuffing text</template><p>After</p>'
+    expect(htmlToMarkdown(html, { engine })).toBe('Visible\n\nAfter')
+  })
+
+  it('excludes nested element content', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const html = '<p>Visible</p><template><p>Nested hidden</p><span>more</span></template><p>After</p>'
+    expect(htmlToMarkdown(html, { engine })).toBe('Visible\n\nAfter')
+  })
+
+  it('is not confused by apostrophes or quotes in template content', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const html = `<p>A</p><template>It's a "quoted" keyword</template><p>B</p>`
+    expect(htmlToMarkdown(html, { engine })).toBe('A\n\nB')
+  })
+
+  it('closes correctly with an unbalanced quote inside', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const html = `<p>A</p><template>one ' unbalanced</template><p>B</p>`
+    expect(htmlToMarkdown(html, { engine })).toBe('A\n\nB')
+  })
+
+  it('excludes content with attribute quotes in nested markup', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const html = `<p>A</p><template><a href="x">it's</a></template><p>B</p>`
+    expect(htmlToMarkdown(html, { engine })).toBe('A\n\nB')
+  })
+
+  it('still renders script/style quote-aware content after a template', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const html = `<template>hidden</template><script>var x = "</p>"; var y = 'q';</script><p>B</p>`
+    expect(htmlToMarkdown(html, { engine })).toBe('B')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #101

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Browsers never render `<template>` content, but mdream emitted it as plain text, leaking hidden markup (the "modern keyword stuffing" case from the issue) into the output. `<template>` is now marked `isNonNesting` + `excludesTextNodes` in both the JS (`packages/js/src/tags.ts`) and Rust (`crates/core/src/tags.rs`) engines, so the whole body is treated as inert and dropped (direct text and nested elements alike).

While fixing it I found a latent JS-only bug: quote-aware close-tag suppression ran for every non-nesting tag, so an apostrophe in `<template>`/`<textarea>`/`<option>`/`<iframe>` content could swallow the closing tag and eat the rest of the document. Gated that quote-awareness to `<script>`/`<style>` via a new `inRawTextQuoteAware` flag, matching what the Rust core already did. The cross-chunk streaming behaviour for `<script>` (#93) is preserved.

Tests: `packages/mdream/test/unit/nodes/template.test.ts` (6 cases x both engines) and 3 Rust tests in `conversion.rs`. Full suite green on both engines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Template element contents are now treated as inert and excluded from Markdown output.
  * Parsing for script/style raw text is now quote-aware across input boundaries, preventing stray/incorrect output near quoted content.

* **Tests**
  * Added regression and unit tests to verify template handling and quote-aware script/style parsing across multiple edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->