### PR TITLE
feat: render bare <pre> as a fenced code block (#97)

### DIFF
--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -153,6 +153,17 @@ pub struct ConvertState {
     /// Per-`<li>` contribution width stack, parallel to `list_indent`. Used to
     /// truncate the correct number of bytes on close without re-walking ancestors.
     list_indent_widths: Vec<u8>,
+
+    /// `<pre>` fenced-code deferral (issue #97). A bare `<pre>` (no `<code>`
+    /// child) becomes a fenced code block, but the opening fence is deferred
+    /// until the first non-whitespace child so empty/whitespace-only blocks emit
+    /// nothing. `pre_fence_pending`: inside a `<pre>` whose fence is undecided.
+    /// `pre_fence_lang`: language resolved from the `<pre>`'s own class.
+    /// `pre_own_fence`: the `<pre>` opened its own fence (so a nested `<code>`
+    /// must not, and the `<pre>` exit emits the closing fence).
+    pre_fence_pending: bool,
+    pre_fence_lang: String,
+    pre_own_fence: bool,
 }
 
 impl ConvertState {
@@ -234,6 +245,10 @@ impl ConvertState {
 
             list_indent: String::new(),
             list_indent_widths: Vec::with_capacity(8),
+
+            pre_fence_pending: false,
+            pre_fence_lang: String::new(),
+            pre_own_fence: false,
         };
         // Resolve clean config into bitmask
         let effective_clean_urls;

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -9,6 +9,27 @@ impl ConvertState {
         let stack_len = self.stack.len();
         if stack_len == 0 { return; }
 
+        // Deferred <pre> code fence (issue #97): open a bare <pre>'s fence right
+        // before its first non-whitespace child. A direct <code> child keeps
+        // fence ownership; a deeper/other first child opens the <pre>'s own fence.
+        if self.pre_fence_pending {
+            let tid = self.stack[stack_len - 1].tag_id;
+            if tid == Some(TAG_CODE)
+                && stack_len >= 2 && self.stack[stack_len - 2].tag_id == Some(TAG_PRE) {
+                self.pre_fence_pending = false;
+            } else if tid != Some(TAG_PRE) {
+                self.flush_pre_fence();
+            }
+        }
+        // Arm the deferral when entering a <pre>; the fence (with this <pre>'s own
+        // language) is emitted lazily above for the no-<code> case.
+        if self.stack[stack_len - 1].tag_id == Some(TAG_PRE) {
+            let lang = Self::get_language_from_class(self.stack[stack_len - 1].attributes.get("class")).to_string();
+            self.pre_fence_pending = true;
+            self.pre_own_fence = false;
+            self.pre_fence_lang = lang;
+        }
+
         // Phase 1: read from node + compute output (borrows self.stack immutably)
         let tag_id: Option<u8>;
         let is_inline: bool;
@@ -357,6 +378,12 @@ impl ConvertState {
 
         self.write_output(false, is_inline, configured_new_lines, effective, false);
 
+        // Reset <pre> fence deferral once the element closes (issue #97).
+        if tag_id == Some(TAG_PRE) {
+            self.pre_fence_pending = false;
+            self.pre_own_fence = false;
+        }
+
         // Record fragment link position for deferred fixup (no String alloc)
         if self.clean_flags & CLEAN_FRAGMENTS != 0 && tag_id == Some(TAG_A)
             && let Some(href) = node.attributes.get("href")
@@ -367,8 +394,33 @@ impl ConvertState {
 
     /// Emit markdown for a text node (no TextNode allocation).
     #[inline]
+    /// Emit a bare <pre>'s opening code fence (issue #97). Mirrors the
+    /// <code>-in-<pre> enter formatting: indented and newline-padded inside a
+    /// list item, otherwise a plain ```lang opener. Marks the <pre> as owning
+    /// the fence so a nested <code> does not double up and the <pre> exit emits
+    /// the matching closing fence.
+    fn flush_pre_fence(&mut self) {
+        self.pre_fence_pending = false;
+        self.pre_own_fence = true;
+        let li_depth = self.depth_map[TAG_LI as usize];
+        let fence = if li_depth > 0 {
+            format!("\n\n{0}```{1}\n{0}", self.list_indent, self.pre_fence_lang)
+        } else {
+            format!("```{}\n", self.pre_fence_lang)
+        };
+        self.last_content_cache_len = fence.len();
+        self.buffer.push_str(&fence);
+        self.last_node_is_inline = false;
+    }
+
     pub(crate) fn emit_text(&mut self, text: &str, contains_whitespace: bool, depth: usize, index: usize) {
         if text.is_empty() { return; }
+
+        // Open a deferred <pre> fence before its first non-whitespace text.
+        if self.pre_fence_pending
+            && text.as_bytes().iter().any(|&b| b != b' ' && b != b'\t' && b != b'\n' && b != b'\r') {
+            self.flush_pre_fence();
+        }
 
         let buf_bytes = self.buffer.as_bytes();
         let buf_len = buf_bytes.len();
@@ -523,6 +575,11 @@ impl ConvertState {
             }
             TAG_CODE => {
                 if self.depth_map[TAG_PRE as usize] > 0 {
+                    // The enclosing <pre> already opened its own fence (mixed
+                    // text + <code> children); don't emit a nested fence.
+                    if self.pre_own_fence {
+                        return None;
+                    }
                     let lang = Self::get_language_from_class(node.attributes.get("class"));
                     let li_depth = self.depth_map[TAG_LI as usize] as usize;
                     if li_depth > 0 {
@@ -680,6 +737,10 @@ impl ConvertState {
             TAG_INS => Some(Cow::Borrowed("</ins>")),
             TAG_CODE => {
                 if self.depth_map[TAG_PRE as usize] > 0 {
+                    // The enclosing <pre> owns the fence; this <code> opened none.
+                    if self.pre_own_fence {
+                        return None;
+                    }
                     let li_depth = self.depth_map[TAG_LI as usize] as usize;
                     if li_depth > 0 {
                         let indent = self.list_indent.as_str();
@@ -694,6 +755,26 @@ impl ConvertState {
                     }
                 } else {
                     Some(Cow::Borrowed(MARKDOWN_INLINE_CODE))
+                }
+            }
+            // Bare <pre> (no <code> child) closing fence (issue #97). Only emitted
+            // when the <pre> opened its own fence; otherwise a <code> child or an
+            // empty/whitespace-only <pre> means there is nothing to close.
+            TAG_PRE => {
+                if !self.pre_own_fence {
+                    return None;
+                }
+                let li_depth = self.depth_map[TAG_LI as usize] as usize;
+                if li_depth > 0 {
+                    let indent = self.list_indent.as_str();
+                    let mut s = String::with_capacity(1 + indent.len() * 2 + 5);
+                    s.push('\n');
+                    s.push_str(indent);
+                    s.push_str("```\n\n");
+                    s.push_str(indent);
+                    Some(Cow::Owned(s))
+                } else {
+                    Some(Cow::Borrowed("\n```"))
                 }
             }
             TAG_UL => {

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -421,6 +421,12 @@ impl ConvertState {
             && text.as_bytes().iter().any(|&b| b != b' ' && b != b'\t' && b != b'\n' && b != b'\r') {
             self.flush_pre_fence();
         }
+        // Still pending means this <pre> has only seen whitespace so far; drop it
+        // so an empty/whitespace-only <pre> emits nothing and never leaks between
+        // surrounding blocks (issue #97).
+        if self.pre_fence_pending {
+            return;
+        }
 
         let buf_bytes = self.buffer.as_bytes();
         let buf_len = buf_bytes.len();

--- a/crates/core/src/tags.rs
+++ b/crates/core/src/tags.rs
@@ -106,7 +106,9 @@ static TAG_HANDLERS: [Option<TagHandler>; MAX_TAG_ID] = {
     t[TAG_HEADER as usize] = Some(BLOCK);
     t[TAG_MAIN as usize] = Some(BLOCK);
     t[TAG_FIGURE as usize] = Some(BLOCK);
-    t[TAG_PRE as usize] = Some(BLOCK);
+    // needs_attributes so a bare <pre class="language-x"> can resolve its fence
+    // language for the deferred code block (issue #97).
+    t[TAG_PRE as usize] = Some(TagHandler { needs_attributes: true, ..NONE });
 
     // Inline elements
     t[TAG_SPAN as usize] = Some(INLINE_COLLAPSE);

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -626,6 +626,63 @@ fn strips_style() {
 }
 
 #[test]
+fn bare_pre_becomes_code_block() {
+    // A <pre> without a <code> child becomes a fenced code block (issue #97).
+    assert_eq!(convert("<pre>const x = 1</pre>"), "```\nconst x = 1\n```");
+    assert_eq!(
+        convert("<pre>line1\nline2\n  indented</pre>"),
+        "```\nline1\nline2\n  indented\n```"
+    );
+}
+
+#[test]
+fn bare_pre_reads_language_from_class() {
+    assert_eq!(
+        convert("<pre class=\"language-js\">const x = 1</pre>"),
+        "```js\nconst x = 1\n```"
+    );
+}
+
+#[test]
+fn pre_code_block_unchanged() {
+    // The existing <pre><code> path is untouched.
+    assert_eq!(convert("<pre><code>const x = 1</code></pre>"), "```\nconst x = 1\n```");
+    assert_eq!(
+        convert("<pre><code class=\"language-js\">const x = 1</code></pre>"),
+        "```js\nconst x = 1\n```"
+    );
+}
+
+#[test]
+fn empty_and_whitespace_pre_emit_no_fence() {
+    assert_eq!(convert("<pre></pre>"), "");
+    assert_eq!(convert("<pre>   \n  </pre>"), "");
+    assert_eq!(convert("<p>a</p><pre></pre><p>b</p>"), "a\n\nb");
+}
+
+#[test]
+fn pre_with_text_and_code_child_single_fence() {
+    // Mixed text + <code> must not double-fence.
+    assert_eq!(
+        convert("<pre>text<code>codepart</code>more</pre>"),
+        "```\ntextcodepartmore\n```"
+    );
+    // Whitespace around a sole <code> child keeps the <code> as fence owner.
+    assert_eq!(
+        convert("<pre> <code>spaced code</code> </pre>"),
+        "```\nspaced code\n```"
+    );
+}
+
+#[test]
+fn bare_pre_in_list_item_is_indented() {
+    assert_eq!(
+        convert("<ul><li>item<pre>code\nblock</pre></li></ul>"),
+        "- item\n\n  ```\n  code\n  block\n  ```"
+    );
+}
+
+#[test]
 fn escaped_backslash_in_script() {
     let html = r#"<script>var x = "a]\\\\\\\\b";</script><p>Visible content</p>"#;
     let result = convert(html);

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -658,6 +658,8 @@ fn empty_and_whitespace_pre_emit_no_fence() {
     assert_eq!(convert("<pre></pre>"), "");
     assert_eq!(convert("<pre>   \n  </pre>"), "");
     assert_eq!(convert("<p>a</p><pre></pre><p>b</p>"), "a\n\nb");
+    // A whitespace-only <pre> must not leak its whitespace between blocks.
+    assert_eq!(convert("<p>a</p><pre>   \n  </pre><p>b</p>"), "a\n\nb");
 }
 
 #[test]

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -3,11 +3,13 @@ import type { ElementNode, EngineOptions, HandlerContext, NodeEvent, PluginConte
 import {
   DEFAULT_BLOCK_SPACING,
   ELEMENT_NODE,
+  MARKDOWN_CODE_BLOCK,
   MAX_TAG_ID,
   NO_SPACING,
   NodeEventEnter,
   NodeEventExit,
   TAG_BLOCKQUOTE,
+  TAG_CODE,
   TAG_DIV,
   TAG_H1,
   TAG_H6,
@@ -54,6 +56,17 @@ export interface MarkdownState {
   listIndent: string
   /** Per-`<li>` contribution widths, parallel stack to listIndent. */
   listIndentWidths: number[]
+  /**
+   * <pre> fenced-code deferral (issue #97). A bare <pre> (no <code> child)
+   * becomes a fenced code block, but the opening fence is deferred until the
+   * first non-whitespace content so empty/whitespace-only blocks emit nothing.
+   * `preFencePending`: inside a <pre> whose fence is not yet decided.
+   * `preFenceLang`: language resolved from the <pre>'s own class.
+   * `preOwnFence`: the <pre> opened its own fence (so a nested <code> must not).
+   */
+  preFencePending?: boolean
+  preFenceLang?: string
+  preOwnFence?: boolean
 }
 
 /**
@@ -176,6 +189,38 @@ function calculateNewLineConfig(node: ElementNode): readonly [number, number] {
 }
 
 /**
+ * Whether a string contains any non-whitespace character (space, tab, CR, LF).
+ * Used to decide if a <pre>'s content warrants opening a fenced code block.
+ */
+function hasNonWhitespace(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    const c = value.charCodeAt(i)
+    if (c !== 32 && c !== 9 && c !== 10 && c !== 13) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Emit a bare <pre>'s opening code fence (issue #97). Mirrors the <code>-in-<pre>
+ * enter formatting in tags.ts: indented and newline-padded inside a list item,
+ * otherwise a plain ```lang opener. Marks the <pre> as owning the fence so a
+ * nested <code> does not double up and the <pre> exit emits the closing fence.
+ */
+function flushPreFence(state: MarkdownState): void {
+  state.preFencePending = false
+  state.preOwnFence = true
+  const lang = state.preFenceLang || ''
+  const liDepth = state.depthMap[TAG_LI] || 0
+  const fence = liDepth > 0
+    ? `\n\n${state.listIndent}${MARKDOWN_CODE_BLOCK}${lang}\n${state.listIndent}`
+    : `${MARKDOWN_CODE_BLOCK}${lang}\n`
+  state.buffer.push(fence)
+  state.lastContentCache = fence
+}
+
+/**
  * Creates a markdown processor that consumes DOM events and generates markdown
  */
 export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlugins: TransformPlugin[] = [], tagOverrideHandlers?: Map<string, TagHandler>) {
@@ -200,6 +245,27 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
     // Update depth for plugin access
     state.depth = node.depth
     const buff = state.buffer
+
+    // Deferred <pre> code fence (issue #97). A bare <pre> opens its fence right
+    // before its first non-whitespace child so empty/whitespace-only blocks emit
+    // nothing. A direct <code> child keeps fence ownership (handled in tags.ts).
+    // Runs before lastChar is read so the fence is reflected in spacing checks.
+    if (state.preFencePending && eventType === NodeEventEnter) {
+      if (node.type === ELEMENT_NODE) {
+        const el = node as ElementNode
+        if (el.tagId === TAG_CODE && el.parent?.tagId === TAG_PRE) {
+          // <pre><code>…</code></pre>: let the <code> handler emit the fence.
+          state.preFencePending = false
+        }
+        else if (el.tagId !== TAG_PRE) {
+          flushPreFence(state)
+        }
+      }
+      else if (node.type === TEXT_NODE && hasNonWhitespace((node as TextNode).value)) {
+        flushPreFence(state)
+      }
+    }
+
     const lastBuffEntry = buff.at(-1)!
     const lastChar = lastBuffEntry?.charAt(lastBuffEntry.length - 1) || ''
 

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -291,6 +291,14 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
           return
         }
 
+        // A <pre> whose fence is still pending has only seen whitespace so far
+        // (non-whitespace would have opened the fence in the hook above). Drop
+        // that whitespace so an empty/whitespace-only <pre> emits nothing and
+        // never leaks between surrounding blocks (issue #97).
+        if (state.preFencePending) {
+          return
+        }
+
         // Skip leading spaces after newlines
         if (textNode.value === ' ' && lastChar === '\n') {
           return

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -345,9 +345,43 @@ export const tagHandlers: Record<number, TagHandler> = {
     },
     spacing: BLOCKQUOTE_SPACING,
   },
+  // A bare <pre> (no <code> child) becomes a fenced code block (issue #97).
+  // The opening fence is deferred to the first non-whitespace child by the
+  // processor (flushPreFence) so empty/whitespace-only blocks emit nothing and a
+  // <pre><code> keeps its existing fence. Only the closing fence lives here.
+  [TAG_PRE]: {
+    enter: ({ node, state }) => {
+      state.preFencePending = true
+      state.preOwnFence = false
+      state.preFenceLang = getLanguageFromClass(node.attributes?.class)
+    },
+    exit: ({ node, state }) => {
+      const ownFence = state.preOwnFence
+      state.preFencePending = false
+      state.preOwnFence = false
+      // No own fence means a <code> child emitted it, or the <pre> had no
+      // non-whitespace content (empty block stripped) — nothing to close.
+      if (!ownFence) {
+        return undefined
+      }
+      const liDepth = node.depthMap[TAG_LI] || 0
+      if (liDepth > 0) {
+        const indent = state.listIndent
+        return `\n${indent}${MARKDOWN_CODE_BLOCK}\n\n${indent}`
+      }
+      return `\n${MARKDOWN_CODE_BLOCK}`
+    },
+  },
   [TAG_CODE]: {
     enter: ({ node, state }) => {
       if ((node.depthMap[TAG_PRE] || 0) > 0) {
+        // The enclosing <pre> already opened its own fence (e.g. <pre> with
+        // mixed text and <code> children); don't emit a nested fence.
+        if (state.preOwnFence) {
+          return undefined
+        }
+        // This <code> owns the <pre>'s fence; cancel the deferred pre fence.
+        state.preFencePending = false
         const language = getLanguageFromClass(node.attributes?.class)
         const liDepth = node.depthMap[TAG_LI] || 0
         if (liDepth > 0) {
@@ -377,6 +411,10 @@ export const tagHandlers: Record<number, TagHandler> = {
     },
     exit: ({ node, state }) => {
       if ((node.depthMap[TAG_PRE] || 0) > 0) {
+        // The enclosing <pre> owns the fence; this <code> emitted no opener.
+        if (state.preOwnFence) {
+          return undefined
+        }
         const liDepth = node.depthMap[TAG_LI] || 0
         if (liDepth > 0) {
           const indent = state.listIndent

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -290,6 +290,13 @@ export interface MdreamRuntimeState extends Partial<MdreamProcessingState> {
    */
   listIndent?: string
   listIndentWidths?: number[]
+
+  /**
+   * <pre> fenced-code deferral (issue #97). See MarkdownState for semantics.
+   */
+  preFencePending?: boolean
+  preFenceLang?: string
+  preOwnFence?: boolean
 }
 
 type NodeEventEnter = 0

--- a/packages/mdream/test/unit/nodes/pre-code-block.test.ts
+++ b/packages/mdream/test/unit/nodes/pre-code-block.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { engines, htmlToMarkdown, resolveEngine, streamHtmlToMarkdown } from '../../utils/engines'
+
+function chunkedStream(chunks: string[]): ReadableStream<string> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks)
+        controller.enqueue(chunk)
+      controller.close()
+    },
+  })
+}
+
+async function collect(stream: AsyncIterable<string>): Promise<string> {
+  let out = ''
+  for await (const chunk of stream)
+    out += chunk
+  return out
+}
+
+// A bare <pre> (no <code> child) becomes a fenced code block (issue #97).
+describe.each(engines)('pre as fenced code block $name', (engineConfig) => {
+  it('fences a bare <pre>', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    expect(htmlToMarkdown('<pre>const x = 1</pre>', { engine })).toBe('```\nconst x = 1\n```')
+  })
+
+  it('reads the language from the <pre> class', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    expect(htmlToMarkdown('<pre class="language-js">const x = 1</pre>', { engine })).toBe('```js\nconst x = 1\n```')
+  })
+
+  it('preserves multi-line whitespace inside the block', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    expect(htmlToMarkdown('<pre>line1\nline2\n  indented</pre>', { engine })).toBe('```\nline1\nline2\n  indented\n```')
+  })
+
+  it('leaves the existing <pre><code> behaviour unchanged', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    expect(htmlToMarkdown('<pre><code>const x = 1</code></pre>', { engine })).toBe('```\nconst x = 1\n```')
+    expect(htmlToMarkdown('<pre><code class="language-js">const x = 1</code></pre>', { engine })).toBe('```js\nconst x = 1\n```')
+  })
+
+  it('strips an empty <pre> (no fence)', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    expect(htmlToMarkdown('<pre></pre>', { engine })).toBe('')
+  })
+
+  it('strips a whitespace-only <pre> (no fence)', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    expect(htmlToMarkdown('<pre>   \n  </pre>', { engine })).toBe('')
+  })
+
+  it('does not double-fence a <pre> with both text and a <code> child', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    expect(htmlToMarkdown('<pre>text<code>codepart</code>more</pre>', { engine })).toBe('```\ntextcodepartmore\n```')
+  })
+
+  it('lets a <code> child own the fence when surrounded by whitespace', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    expect(htmlToMarkdown('<pre> <code>spaced code</code> </pre>', { engine })).toBe('```\nspaced code\n```')
+  })
+
+  it('separates a bare <pre> from surrounding blocks', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    expect(htmlToMarkdown('<p>before</p><pre>x = 1</pre><p>after</p>', { engine })).toBe('before\n\n```\nx = 1\n```\n\nafter')
+  })
+
+  it('indents a bare <pre> inside a list item', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    expect(htmlToMarkdown('<ul><li>item<pre>code\nblock</pre></li></ul>', { engine })).toBe('- item\n\n  ```\n  code\n  block\n  ```')
+  })
+
+  it('fences a bare <pre> split across stream chunks', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const chunks = ['<p>A</p><pre>line one\n', 'line two</pre><p>B</p>']
+    const result = await collect(streamHtmlToMarkdown(chunkedStream(chunks), { engine }))
+    expect(result.trim()).toBe('A\n\n```\nline one\nline two\n```\n\nB')
+  })
+})

--- a/packages/mdream/test/unit/nodes/pre-code-block.test.ts
+++ b/packages/mdream/test/unit/nodes/pre-code-block.test.ts
@@ -51,6 +51,11 @@ describe.each(engines)('pre as fenced code block $name', (engineConfig) => {
     expect(htmlToMarkdown('<pre>   \n  </pre>', { engine })).toBe('')
   })
 
+  it('does not leak a whitespace-only <pre> between surrounding blocks', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    expect(htmlToMarkdown('<p>a</p><pre>   \n  </pre><p>b</p>', { engine })).toBe('a\n\nb')
+  })
+
   it('does not double-fence a <pre> with both text and a <code> child', async () => {
     const engine = await resolveEngine(engineConfig.engine)
     expect(htmlToMarkdown('<pre>text<code>codepart</code>more</pre>', { engine })).toBe('```\ntextcodepartmore\n```')


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #97

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`<pre><code>` already produced a fenced code block, but a bare `<pre>` leaked as raw text. A `<pre>` without a `<code>` child now becomes a fenced code block too.

The opening fence is deferred until the `<pre>`'s first non-whitespace child, which keeps the existing `<pre><code>` path byte-identical (a direct `<code>` child keeps fence ownership) and means empty or whitespace-only `<pre>` emits nothing instead of an empty block. Language is read from `<pre class="language-x">` when present. Implemented in both engines (`packages/js/src/markdown-processor.ts` + `crates/core/src/convert/`), with list-item indentation and streaming handled.

One Rust-specific fix: `<pre>` now sets `needs_attributes` so its language class is parsed (the parser skips attributes for handlers that do not opt in).

Tests: `packages/mdream/test/unit/nodes/pre-code-block.test.ts` (11 cases x both engines) and 6 Rust tests in `conversion.rs`. JS/Rust output parity verified across empty, whitespace-only, language-on-pre, language-on-code, mixed text+code, list-item, and streaming cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bare <pre> elements now render as fenced code blocks; language is detected from class names.
  * Opening fence is deferred until meaningful content appears, preserving multi-line whitespace and proper list-item indentation.
  * <pre>/<code> mixed cases now avoid double-fencing; <code> can take ownership when appropriate.
* **Bug Fixes**
  * Empty or whitespace-only <pre> now emit no output.
* **Tests**
  * Added regression and unit tests (including streamed/chunked HTML) covering these behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->