### PR TITLE
feat(crawl): add silent option and pluggable logger (#100)

### DIFF
--- a/packages/crawl/src/cli.ts
+++ b/packages/crawl/src/cli.ts
@@ -1,4 +1,5 @@
 import type { CrawlProgress } from './crawl.js'
+import type { CrawlLogger } from './logger.js'
 import type { CrawlOptions } from './types.js'
 import { accessSync, constants, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
@@ -8,6 +9,12 @@ import { withHttps } from 'ufo'
 import { loadMdreamConfig } from './config.js'
 import { crawlAndGenerate } from './crawl.js'
 import { parseUrlPattern, validateGlobPattern } from './glob-utils.js'
+import { resolveLogger } from './logger.js'
+
+/** Detect the quiet flag from raw argv (used before options are fully parsed). */
+function isSilentArgv(args: string[]): boolean {
+  return args.includes('--silent') || args.includes('--quiet') || args.includes('-q')
+}
 // playwright-utils is dynamically imported only when Playwright driver is used
 // to avoid requiring crawlee for HTTP-only users
 
@@ -228,7 +235,7 @@ async function interactiveCrawl(): Promise<CrawlOptions | null> {
 
 interface LatencyStats { total: number, min: number, max: number, count: number }
 
-async function showCrawlResults(successful: number, failed: number, outputDir: string, generatedFiles: string[], durationSeconds: number, latency?: LatencyStats) {
+async function showCrawlResults(logger: CrawlLogger, successful: number, failed: number, outputDir: string, generatedFiles: string[], durationSeconds: number, latency?: LatencyStats) {
   const durationStr = `${durationSeconds.toFixed(1)}s`
 
   let line = `${successful} pages in ${durationStr}`
@@ -241,12 +248,14 @@ async function showCrawlResults(successful: number, failed: number, outputDir: s
     line += ` \u00B7 HTTP Latency: avg ${avg}ms, min ${min}ms, max ${max}ms`
   }
 
-  p.log.success(line)
-  p.log.info(`${generatedFiles.join(', ')} \u2192 ${relative(process.cwd(), outputDir) || '.'}`)
+  logger.success(line)
+  logger.info(`${generatedFiles.join(', ')} \u2192 ${relative(process.cwd(), outputDir) || '.'}`)
 }
 
 function parseCliArgs(): CrawlOptions | null {
   const args = process.argv.slice(2)
+  const silent = isSilentArgv(args)
+  const logger = resolveLogger({ silent })
 
   if (args.includes('--help') || args.includes('-h')) {
     console.log(`
@@ -274,6 +283,7 @@ Options:
   --skip-sitemap              Skip sitemap.xml and robots.txt discovery
   --allow-subdomains          Crawl across subdomains of the same root domain
   -v, --verbose               Enable verbose logging
+  -q, --quiet, --silent       Suppress all logs (clean stdout for JSON-RPC/MCP)
   -h, --help                  Show this help message
   --version                   Show version number
 
@@ -325,15 +335,15 @@ Examples:
 
   // If arguments were provided but no URL, this is an error
   if (!url) {
-    p.log.error('Error: URL is required when using CLI arguments')
-    p.log.info('Use --help for usage information or run without arguments for interactive mode')
+    logger.error('Error: URL is required when using CLI arguments')
+    logger.info('Use --help for usage information or run without arguments for interactive mode')
     process.exit(1)
   }
 
   // Validate URL pattern
   const globError = validateGlobPattern(url)
   if (globError) {
-    p.log.error(`Error: ${globError}`)
+    logger.error(`Error: ${globError}`)
     process.exit(1)
   }
 
@@ -342,7 +352,7 @@ Examples:
     parsed = parseUrlPattern(url)
   }
   catch (error) {
-    p.log.error(`Error: ${error instanceof Error ? error.message : 'Invalid URL pattern'}`)
+    logger.error(`Error: ${error instanceof Error ? error.message : 'Invalid URL pattern'}`)
     process.exit(1)
   }
 
@@ -352,7 +362,7 @@ Examples:
       new URL(withHttps(url))
     }
     catch {
-      p.log.error(`Error: Invalid URL: ${withHttps(url)}`)
+      logger.error(`Error: Invalid URL: ${withHttps(url)}`)
       process.exit(1)
     }
   }
@@ -362,7 +372,7 @@ Examples:
   for (const pattern of excludePatterns) {
     const excludeError = validateGlobPattern(pattern)
     if (excludeError) {
-      p.log.error(`Error in exclude pattern: ${excludeError}`)
+      logger.error(`Error in exclude pattern: ${excludeError}`)
       process.exit(1)
     }
   }
@@ -372,14 +382,14 @@ Examples:
   const depthStr = singlePage ? '0' : (getArgValue('--depth') || getArgValue('-d') || '3')
   const depth = Number(depthStr)
   if (!Number.isInteger(depth) || depth < 0 || depth > 10) {
-    p.log.error('Error: Depth must be an integer between 0 and 10')
+    logger.error('Error: Depth must be an integer between 0 and 10')
     process.exit(1)
   }
 
   // Validate driver
   const driver = getArgValue('--driver')
   if (driver && driver !== 'http' && driver !== 'playwright') {
-    p.log.error('Error: Driver must be either "http" or "playwright"')
+    logger.error('Error: Driver must be either "http" or "playwright"')
     process.exit(1)
   }
 
@@ -388,7 +398,7 @@ Examples:
   if (maxPagesStr) {
     const maxPages = Number.parseInt(maxPagesStr)
     if (Number.isNaN(maxPages) || maxPages < 1) {
-      p.log.error('Error: Max pages must be a positive number')
+      logger.error('Error: Max pages must be a positive number')
       process.exit(1)
     }
   }
@@ -398,7 +408,7 @@ Examples:
   if (crawlDelayStr) {
     const crawlDelay = Number.parseInt(crawlDelayStr)
     if (Number.isNaN(crawlDelay) || crawlDelay < 0) {
-      p.log.error('Error: Crawl delay must be a non-negative number')
+      logger.error('Error: Crawl delay must be a non-negative number')
       process.exit(1)
     }
   }
@@ -411,7 +421,7 @@ Examples:
   const validArtifacts = ['llms.txt', 'llms-full.txt', 'markdown']
   for (const artifact of artifacts) {
     if (!validArtifacts.includes(artifact)) {
-      p.log.error(`Error: Invalid artifact '${artifact}'. Valid options: ${validArtifacts.join(', ')}`)
+      logger.error(`Error: Invalid artifact '${artifact}'. Valid options: ${validArtifacts.join(', ')}`)
       process.exit(1)
     }
   }
@@ -447,7 +457,7 @@ Examples:
 
   // Warn if using skip-sitemap with wildcard URLs
   if (skipSitemap && parsed.isGlob) {
-    p.log.warn('Warning: Using --skip-sitemap with glob URLs may not discover all matching pages.')
+    logger.warn('Warning: Using --skip-sitemap with glob URLs may not discover all matching pages.')
   }
 
   return {
@@ -469,6 +479,7 @@ Examples:
     verbose,
     skipSitemap,
     allowSubdomains,
+    silent,
   }
 }
 
@@ -478,6 +489,12 @@ async function main() {
 
   // Load config file (mdream.config.ts)
   const fileConfig = await loadMdreamConfig()
+
+  // Single logging seam for the whole CLI run. Resolved from the CLI flag or
+  // config so a quiet run keeps stdout clean (issue #100). Interactive mode is
+  // never silent.
+  const silent = (cliOptions?.silent ?? false) || (fileConfig.silent ?? false)
+  const logger = resolveLogger({ silent })
 
   let options: CrawlOptions | null
 
@@ -493,6 +510,7 @@ async function main() {
       skipSitemap: cliOptions.skipSitemap || fileConfig.skipSitemap || false,
       allowSubdomains: cliOptions.allowSubdomains || fileConfig.allowSubdomains || false,
       verbose: cliOptions.verbose || fileConfig.verbose || false,
+      silent,
       exclude: configExclude.length > 0 || cliExclude.length > 0
         ? [...configExclude, ...cliExclude]
         : undefined,
@@ -500,7 +518,7 @@ async function main() {
     }
 
     // Show non-interactive summary when using CLI args
-    p.intro(`☁️  mdream v${version}`)
+    logger.intro(`☁️  mdream v${version}`)
 
     const formats = []
     if (options.generateLlmsTxt)
@@ -521,7 +539,7 @@ async function main() {
       options.verbose && `Verbose: Enabled`,
     ].filter(Boolean)
 
-    p.note(summary.join('\n'), 'Configuration')
+    logger.note(summary.join('\n'), 'Configuration')
   }
   else {
     // Fall back to interactive mode
@@ -535,9 +553,9 @@ async function main() {
   // Check output directory permissions before proceeding
   const permCheck = checkOutputDirectoryPermissions(options.outputDir)
   if (!permCheck.success) {
-    p.log.error(permCheck.error!)
+    logger.error(permCheck.error!)
     if (permCheck.error?.includes('Permission denied')) {
-      p.log.info('Tip: Try running with elevated privileges (e.g., sudo) or change the output directory permissions.')
+      logger.info('Tip: Try running with elevated privileges (e.g., sudo) or change the output directory permissions.')
     }
     process.exit(1)
   }
@@ -549,7 +567,7 @@ async function main() {
       await import('crawlee')
     }
     catch {
-      p.log.error('The Playwright driver requires crawlee. Install it with: npm install crawlee')
+      logger.error('The Playwright driver requires crawlee. Install it with: npm install crawlee')
       process.exit(1)
     }
 
@@ -558,19 +576,19 @@ async function main() {
     const chromeSupported = await isUseChromeSupported()
     if (chromeSupported) {
       options.useChrome = true
-      p.log.info('System Chrome detected and enabled.')
+      logger.info('System Chrome detected and enabled.')
     }
     else {
-      const playwrightInstalled = await ensurePlaywrightInstalled()
+      const playwrightInstalled = await ensurePlaywrightInstalled(logger)
       if (!playwrightInstalled) {
-        p.log.error('Cannot proceed without Playwright. Please install it manually or use the HTTP driver instead.')
+        logger.error('Cannot proceed without Playwright. Please install it manually or use the HTTP driver instead.')
         process.exit(1)
       }
-      p.log.info('Using global playwright instance.')
+      logger.info('Using global playwright instance.')
     }
   }
 
-  const s = p.spinner()
+  const s = logger.spinner()
   s.start('Discovering sitemaps')
 
   const startTime = Date.now()
@@ -622,9 +640,9 @@ async function main() {
 
   // Show failed results details if any
   if (failed > 0 && cliOptions) {
-    p.log.error('Failed URLs:')
+    logger.error('Failed URLs:')
     failedResults.forEach((result) => {
-      p.log.error(`  ${result.url}: ${result.error || 'Unknown error'}`)
+      logger.error(`  ${result.url}: ${result.error || 'Unknown error'}`)
     })
   }
   else if (failed > 0) {
@@ -646,23 +664,25 @@ async function main() {
   }
 
   // Only show interactive results for interactive mode
-  await showCrawlResults(successful, failed, options.outputDir, generatedFiles, durationSeconds, lastProgress?.crawling.latency)
+  await showCrawlResults(logger, successful, failed, options.outputDir, generatedFiles, durationSeconds, lastProgress?.crawling.latency)
   process.exit(0)
 }
 
 // Run the CLI
 main().catch((error) => {
+  // Resolve the logger from raw argv since this runs outside main's scope.
+  const logger = resolveLogger({ silent: isSilentArgv(process.argv.slice(2)) })
   const msg = error instanceof Error ? error.message : String(error)
   // Surface a clear hint when the error is the Windows wmic.exe removal
   if (msg.includes('wmic') || (msg.includes('ENOENT') && process.platform === 'win32')) {
-    p.log.error(
+    logger.error(
       'Crawlee failed because wmic.exe is not available on this system. '
       + 'Windows 11 removed wmic.exe, which older crawlee versions depend on for memory monitoring.\n'
       + 'Fix: upgrade crawlee to >=3.16.0 or switch to the HTTP driver (--driver http).',
     )
   }
   else {
-    p.log.error(`Unexpected error: ${msg}`)
+    logger.error(`Unexpected error: ${msg}`)
   }
   process.exit(1)
 })

--- a/packages/crawl/src/cli.ts
+++ b/packages/crawl/src/cli.ts
@@ -15,6 +15,11 @@ import { resolveLogger } from './logger.js'
 function isSilentArgv(args: string[]): boolean {
   return args.includes('--silent') || args.includes('--quiet') || args.includes('-q')
 }
+
+// The run-wide logger. Seeded from argv so the top-level error handler can
+// report even before config loads, then upgraded by main() once config-driven
+// silent is known (a `silent: true` in mdream.config must also mute crashes).
+let runLogger = resolveLogger({ silent: isSilentArgv(process.argv.slice(2)) })
 // playwright-utils is dynamically imported only when Playwright driver is used
 // to avoid requiring crawlee for HTTP-only users
 
@@ -495,6 +500,9 @@ async function main() {
   // never silent.
   const silent = (cliOptions?.silent ?? false) || (fileConfig.silent ?? false)
   const logger = resolveLogger({ silent })
+  // Upgrade the run-wide logger now that config-driven silent is resolved, so an
+  // unhandled error below is muted too when silent is set via config (not argv).
+  runLogger = logger
 
   let options: CrawlOptions | null
 
@@ -670,8 +678,9 @@ async function main() {
 
 // Run the CLI
 main().catch((error) => {
-  // Resolve the logger from raw argv since this runs outside main's scope.
-  const logger = resolveLogger({ silent: isSilentArgv(process.argv.slice(2)) })
+  // runLogger honors config-driven silent once main() has resolved it, and
+  // falls back to the argv-seeded logger if main throws before that point.
+  const logger = runLogger
   const msg = error instanceof Error ? error.message : String(error)
   // Surface a clear hint when the error is the Windows wmic.exe removal
   if (msg.includes('wmic') || (msg.includes('ENOENT') && process.platform === 'win32')) {

--- a/packages/crawl/src/cli.ts
+++ b/packages/crawl/src/cli.ts
@@ -11,9 +11,11 @@ import { crawlAndGenerate } from './crawl.js'
 import { parseUrlPattern, validateGlobPattern } from './glob-utils.js'
 import { resolveLogger } from './logger.js'
 
+const QUIET_FLAGS = new Set(['--silent', '--quiet', '-q'])
+
 /** Detect the quiet flag from raw argv (used before options are fully parsed). */
 function isSilentArgv(args: string[]): boolean {
-  return args.includes('--silent') || args.includes('--quiet') || args.includes('-q')
+  return args.some(arg => QUIET_FLAGS.has(arg))
 }
 
 // The run-wide logger. Seeded from argv so the top-level error handler can

--- a/packages/crawl/src/crawl.ts
+++ b/packages/crawl/src/crawl.ts
@@ -3,7 +3,6 @@ import type { PlaywrightCrawlerOptions } from 'crawlee'
 import type { CrawlHooks, CrawlOptions, CrawlResult, PageData, PageMetadata } from './types.ts'
 import { mkdirSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
-import * as p from '@clack/prompts'
 import { generateLlmsTxtArtifacts } from '@mdream/js/llms-txt'
 import { createHooks } from 'hookable'
 import { htmlToMarkdown } from 'mdream'
@@ -11,6 +10,7 @@ import { ofetch } from 'ofetch'
 import { dirname, join, normalize, resolve } from 'pathe'
 import { withHttps } from 'ufo'
 import { getRegistrableDomain, getStartingUrl, isUrlExcluded, isValidSitemapXml, matchesGlobPattern, parseUrlPattern } from './glob-utils.js'
+import { resolveLogger } from './logger.js'
 
 const SITEMAP_INDEX_LOC_RE = /<sitemap[^>]*>.*?<loc>(.*?)<\/loc>.*?<\/sitemap>/gs
 const SITEMAP_URL_LOC_RE = /<url[^>]*>.*?<loc>(.*?)<\/loc>.*?<\/url>/gs
@@ -296,6 +296,9 @@ export async function crawlAndGenerate(options: CrawlOptions, onProgress?: (prog
     onPage,
   } = options
 
+  // Single seam for all diagnostic/progress output (issue #100).
+  const logger = resolveLogger(options)
+
   // Set up hooks
   const hooks = createHooks<CrawlHooks>()
   if (hooksConfig)
@@ -353,7 +356,7 @@ export async function crawlAndGenerate(options: CrawlOptions, onProgress?: (prog
       const crawlDelayMatch = robotsContent.match(ROBOTS_CRAWL_DELAY_RE)
       if (crawlDelayMatch) {
         crawlDelay = Number.parseFloat(crawlDelayMatch[1])
-        p.log.info(`[ROBOTS] Crawl-delay: ${crawlDelay}s`)
+        logger.info(`[ROBOTS] Crawl-delay: ${crawlDelay}s`)
       }
     }
 
@@ -460,13 +463,13 @@ export async function crawlAndGenerate(options: CrawlOptions, onProgress?: (prog
 
     if (successfulSitemaps.length > 0 && progress.sitemap.processed > 0) {
       sitemapProvidedUrls = true
-      p.log.info(`Sitemap: ${progress.sitemap.processed} URLs from ${successfulSitemaps[0].url}`)
+      logger.info(`Sitemap: ${progress.sitemap.processed} URLs from ${successfulSitemaps[0].url}`)
     }
     else if (successfulSitemaps.length > 0) {
-      p.log.info(`Sitemap: found but no URLs matched filters`)
+      logger.info(`Sitemap: found but no URLs matched filters`)
     }
     else if (failedSitemaps.length > 0) {
-      p.log.info(`Sitemap: not found, discovering pages via crawler`)
+      logger.info(`Sitemap: not found, discovering pages via crawler`)
     }
 
     // Always include home page for metadata extraction

--- a/packages/crawl/src/index.ts
+++ b/packages/crawl/src/index.ts
@@ -1,3 +1,5 @@
 export { crawlAndGenerate } from './crawl.js'
+export { createClackLogger, resolveLogger, silentLogger } from './logger.js'
+export type { CrawlLogger, CrawlSpinner } from './logger.js'
 export { defineConfig } from './types.js'
 export type { CrawlHooks, CrawlOptions, CrawlResult, MdreamCrawlConfig, PageData } from './types.js'

--- a/packages/crawl/src/logger.ts
+++ b/packages/crawl/src/logger.ts
@@ -1,0 +1,83 @@
+import * as p from '@clack/prompts'
+
+/**
+ * Minimal spinner surface used by the crawler. Mirrors the subset of
+ * `@clack/prompts` spinner methods the package relies on.
+ */
+export interface CrawlSpinner {
+  start: (message?: string) => void
+  message: (message?: string) => void
+  stop: (message?: string, code?: number) => void
+}
+
+/**
+ * Diagnostic/progress sink for the crawler. All human-facing, non-data output
+ * (the messages that would otherwise pollute stdout) flows through this single
+ * seam so it can be silenced or redirected. It deliberately excludes the
+ * interactive prompts (`select`, `text`, `confirm`, ...) which are input
+ * control flow, not log output, and only run in the interactive CLI.
+ *
+ * Provide a custom implementation via `CrawlOptions.logger` to route messages
+ * anywhere (e.g. stderr for an MCP server), or set `CrawlOptions.silent` to
+ * drop them entirely. See issue #100.
+ */
+export interface CrawlLogger {
+  intro: (title?: string) => void
+  note: (message: string, title?: string) => void
+  cancel: (message?: string) => void
+  info: (message: string) => void
+  warn: (message: string) => void
+  error: (message: string) => void
+  success: (message: string) => void
+  spinner: () => CrawlSpinner
+}
+
+const noopSpinner: CrawlSpinner = {
+  start() {},
+  message() {},
+  stop() {},
+}
+
+/**
+ * A logger that drops every message. Used when `silent` is set so a library
+ * consumer (e.g. an MCP server) gets a clean stdout.
+ */
+export const silentLogger: CrawlLogger = {
+  intro() {},
+  note() {},
+  cancel() {},
+  info() {},
+  warn() {},
+  error() {},
+  success() {},
+  spinner: () => noopSpinner,
+}
+
+/**
+ * The default logger, backed by `@clack/prompts` (writes to stdout). Preserves
+ * the existing CLI output exactly.
+ */
+export function createClackLogger(): CrawlLogger {
+  return {
+    intro: title => p.intro(title),
+    note: (message, title) => p.note(message, title),
+    cancel: message => p.cancel(message),
+    info: message => p.log.info(message),
+    warn: message => p.log.warn(message),
+    error: message => p.log.error(message),
+    success: message => p.log.success(message),
+    spinner: () => p.spinner(),
+  }
+}
+
+/**
+ * Resolve the effective logger from crawl options. An explicit `logger` wins;
+ * otherwise `silent` selects the no-op sink, and the default is the clack
+ * logger. Pure: same inputs, same logger.
+ */
+export function resolveLogger(options: { silent?: boolean, logger?: CrawlLogger }): CrawlLogger {
+  if (options.logger) {
+    return options.logger
+  }
+  return options.silent ? silentLogger : createClackLogger()
+}

--- a/packages/crawl/src/playwright-utils.ts
+++ b/packages/crawl/src/playwright-utils.ts
@@ -1,5 +1,7 @@
+import type { CrawlLogger } from './logger.ts'
 import * as p from '@clack/prompts'
 import { addDependency } from 'nypm'
+import { createClackLogger } from './logger.js'
 
 export async function checkPlaywrightInstallation(): Promise<boolean> {
   try {
@@ -12,7 +14,9 @@ export async function checkPlaywrightInstallation(): Promise<boolean> {
   }
 }
 
-export async function promptPlaywrightInstall(): Promise<boolean> {
+export async function promptPlaywrightInstall(logger: CrawlLogger = createClackLogger()): Promise<boolean> {
+  // The confirm prompt is interactive input (not log output), so it stays on
+  // clack regardless of the logger.
   const shouldInstall = await p.confirm({
     message: 'Playwright is required for the Playwright driver. Install it now?',
     initialValue: true,
@@ -22,7 +26,7 @@ export async function promptPlaywrightInstall(): Promise<boolean> {
     return false
   }
 
-  const s = p.spinner()
+  const s = logger.spinner()
   s.start('Installing Playwright globally...')
 
   try {
@@ -34,23 +38,23 @@ export async function promptPlaywrightInstall(): Promise<boolean> {
   catch (fallbackError) {
     // Fallback: try without workspace flag
     s.stop('Failed to install Playwright')
-    p.log.error(`Installation failed: ${fallbackError}`)
+    logger.error(`Installation failed: ${fallbackError}`)
     return false
   }
 }
 
-export async function ensurePlaywrightInstalled(): Promise<boolean> {
+export async function ensurePlaywrightInstalled(logger: CrawlLogger = createClackLogger()): Promise<boolean> {
   const isInstalled = await checkPlaywrightInstallation()
 
   if (isInstalled) {
     return true
   }
 
-  p.log.warn('Playwright driver selected but Playwright is not installed.')
+  logger.warn('Playwright driver selected but Playwright is not installed.')
 
-  const installed = await promptPlaywrightInstall()
+  const installed = await promptPlaywrightInstall(logger)
   if (!installed) {
-    p.log.error('Cannot proceed with Playwright driver without Playwright installed.')
+    logger.error('Cannot proceed with Playwright driver without Playwright installed.')
     return false
   }
 

--- a/packages/crawl/src/playwright-utils.ts
+++ b/packages/crawl/src/playwright-utils.ts
@@ -38,7 +38,8 @@ export async function promptPlaywrightInstall(logger: CrawlLogger = createClackL
   catch (fallbackError) {
     // Fallback: try without workspace flag
     s.stop('Failed to install Playwright')
-    logger.error(`Installation failed: ${fallbackError}`)
+    const reason = fallbackError instanceof Error ? fallbackError.message : String(fallbackError)
+    logger.error(`Installation failed: ${reason}`)
     return false
   }
 }

--- a/packages/crawl/src/types.ts
+++ b/packages/crawl/src/types.ts
@@ -1,3 +1,5 @@
+import type { CrawlLogger } from './logger.ts'
+
 export interface PageData {
   url: string
   html: string
@@ -35,6 +37,17 @@ export interface CrawlOptions {
   verbose?: boolean
   skipSitemap?: boolean
   allowSubdomains?: boolean
+  /**
+   * Suppress all diagnostic/progress logging. Use when stdout must stay clean,
+   * e.g. an MCP server that only emits JSON-RPC (issue #100). Ignored when an
+   * explicit `logger` is provided.
+   */
+  silent?: boolean
+  /**
+   * Custom sink for diagnostic/progress messages. Route logs anywhere (e.g.
+   * stderr) instead of the default `@clack/prompts` stdout output.
+   */
+  logger?: CrawlLogger
   hooks?: Partial<{ [K in keyof CrawlHooks]: CrawlHooks[K] | CrawlHooks[K][] }>
   onPage?: (page: PageData) => Promise<void> | void
 }
@@ -48,6 +61,8 @@ export interface MdreamCrawlConfig {
   skipSitemap?: boolean
   allowSubdomains?: boolean
   verbose?: boolean
+  /** Suppress all diagnostic/progress logging (issue #100). */
+  silent?: boolean
   artifacts?: ('llms.txt' | 'llms-full.txt' | 'markdown')[]
   hooks?: Partial<{ [K in keyof CrawlHooks]: CrawlHooks[K] | CrawlHooks[K][] }>
 }

--- a/packages/crawl/test/unit/logger.test.ts
+++ b/packages/crawl/test/unit/logger.test.ts
@@ -1,0 +1,56 @@
+import type { CrawlLogger } from '../../src/logger.ts'
+import { describe, expect, it, vi } from 'vitest'
+import { createClackLogger, resolveLogger, silentLogger } from '../../src/logger.ts'
+
+describe('resolveLogger', () => {
+  it('returns the silent logger when silent is set', () => {
+    expect(resolveLogger({ silent: true })).toBe(silentLogger)
+  })
+
+  it('returns the clack logger by default', () => {
+    const logger = resolveLogger({})
+    expect(logger).not.toBe(silentLogger)
+    expect(typeof logger.info).toBe('function')
+  })
+
+  it('prefers an explicit logger over silent', () => {
+    const custom: CrawlLogger = {
+      ...silentLogger,
+      info: vi.fn(),
+    }
+    expect(resolveLogger({ silent: true, logger: custom })).toBe(custom)
+    expect(resolveLogger({ logger: custom })).toBe(custom)
+  })
+})
+
+describe('silentLogger', () => {
+  it('drops every message without throwing or writing', () => {
+    const write = vi.spyOn(process.stdout, 'write').mockReturnValue(true)
+    try {
+      silentLogger.intro('hi')
+      silentLogger.note('body', 'title')
+      silentLogger.cancel('nope')
+      silentLogger.info('info')
+      silentLogger.warn('warn')
+      silentLogger.error('error')
+      silentLogger.success('done')
+      const s = silentLogger.spinner()
+      s.start('start')
+      s.message('msg')
+      s.stop('stop')
+      expect(write).not.toHaveBeenCalled()
+    }
+    finally {
+      write.mockRestore()
+    }
+  })
+})
+
+describe('createClackLogger', () => {
+  it('exposes the full logger surface', () => {
+    const logger = createClackLogger()
+    for (const key of ['intro', 'note', 'cancel', 'info', 'warn', 'error', 'success', 'spinner'] as const) {
+      expect(typeof logger[key]).toBe('function')
+    }
+  })
+})

--- a/packages/crawl/test/unit/silent-logging.test.ts
+++ b/packages/crawl/test/unit/silent-logging.test.ts
@@ -1,0 +1,96 @@
+import type { CrawlLogger } from '../../src/logger.ts'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+
+// Mock network so the crawl runs offline. The sitemap 404 makes the library
+// emit its "Sitemap: not found" info log, which is what issue #100 is about.
+vi.mock('ofetch', () => {
+  const mockOfetch = Object.assign(
+    async (url: string) => {
+      if (url.endsWith('/robots.txt'))
+        return ''
+      if (url.includes('sitemap'))
+        throw new Error('404')
+      return '<html><head><title>Test</title></head><body><p>Hello</p></body></html>'
+    },
+    {
+      raw: async (url: string) => ({
+        _data: `<html><head><title>Page</title></head><body><p>Content for ${url}</p></body></html>`,
+        headers: new Headers({ 'content-type': 'text/html' }),
+      }),
+    },
+  )
+  return { ofetch: mockOfetch }
+})
+
+vi.mock('mdream', () => ({
+  htmlToMarkdown: (html: string) => `# Converted\n\n${html.slice(0, 50)}`,
+}))
+
+vi.mock('@mdream/js/llms-txt', () => ({
+  generateLlmsTxtArtifacts: async () => ({ llmsTxt: '# llms.txt', llmsFullTxt: '' }),
+}))
+
+// Fail the test loudly if the library ever falls back to clack (stdout) output.
+const clackInfo = vi.fn()
+vi.mock('@clack/prompts', () => ({
+  log: { info: clackInfo, warn: vi.fn(), error: vi.fn(), success: vi.fn() },
+  intro: vi.fn(),
+  note: vi.fn(),
+  cancel: vi.fn(),
+  spinner: () => ({ start: vi.fn(), stop: vi.fn(), message: vi.fn() }),
+}))
+
+const { crawlAndGenerate } = await import('../../src/crawl.ts')
+
+function tmpOut(): string {
+  return join(tmpdir(), `mdream-silent-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+}
+
+function recordingLogger(messages: string[]): CrawlLogger {
+  const push = (m: string) => messages.push(m)
+  return {
+    intro: push,
+    note: push,
+    cancel: push,
+    info: push,
+    warn: push,
+    error: push,
+    success: push,
+    spinner: () => ({ start: () => {}, message: () => {}, stop: () => {} }),
+  }
+}
+
+describe('crawl logging (issue #100)', () => {
+  it('routes library logs through a custom logger', async () => {
+    const messages: string[] = []
+    await crawlAndGenerate({
+      urls: ['https://example.com/'],
+      outputDir: tmpOut(),
+      maxDepth: 1,
+      generateLlmsTxt: false,
+      generateLlmsFullTxt: false,
+      generateIndividualMd: false,
+      logger: recordingLogger(messages),
+    })
+
+    expect(messages.some(m => m.includes('Sitemap'))).toBe(true)
+  })
+
+  it('emits no clack output when silent is set', async () => {
+    clackInfo.mockClear()
+    const results = await crawlAndGenerate({
+      urls: ['https://example.com/'],
+      outputDir: tmpOut(),
+      maxDepth: 1,
+      generateLlmsTxt: false,
+      generateLlmsFullTxt: false,
+      generateIndividualMd: false,
+      silent: true,
+    })
+
+    expect(clackInfo).not.toHaveBeenCalled()
+    expect(results.length).toBeGreaterThanOrEqual(1)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #100

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`@mdream/crawl` emitted `@clack/prompts` logs to stdout, which breaks consumers that need a clean stdout, such as an MCP server speaking JSON-RPC (the issue's use case). 

Added a `CrawlLogger` abstraction (`packages/crawl/src/logger.ts`) as the single seam for all diagnostic/progress output, plus two `CrawlOptions`: `silent` to drop logs entirely, and `logger` to route them anywhere (e.g. stderr). The CLI gains a `-q`/`--quiet`/`--silent` flag. The default path is unchanged (still clack to stdout). As part of this the scattered `p.log.*` calls across `crawl.ts`, `cli.ts`, and `playwright-utils.ts` now go through the logger; interactive CLI prompts (`select`, `text`, `confirm`, ...) stay on clack since they are input, not log output.

Verified end to end: `--quiet` produces empty stdout where the default prints clack output. Tests: `logger.test.ts` (resolver precedence, silent no-ops do not write to stdout) and `silent-logging.test.ts` (library logs flow through a custom logger; `silent: true` makes the mocked clack log receive zero calls).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global silent flags (--silent/--quiet/-q) and documented them in CLI help.
  * Centralized, pluggable logging with a no-op silent mode and consistent routing for CLI and crawler output, spinners, and completion summaries.

* **Behavior**
  * Non-interactive runs and error paths now emit messages through the new logger (suppressible), reducing prompt-driven console output.

* **Tests**
  * Added unit tests covering logger selection, silent behavior, and logging integration during crawls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->