### PR TITLE
fix: strip inert `<datalist>` and author-hidden content

### DIFF
--- a/crates/core/src/consts.rs
+++ b/crates/core/src/consts.rs
@@ -108,8 +108,9 @@ pub const TAG_MAIN: u8 = 104;
 pub const TAG_HEADER: u8 = 105;
 pub const TAG_FIGCAPTION: u8 = 106;
 pub const TAG_CAPTION: u8 = 107;
+pub const TAG_DATALIST: u8 = 108;
 
-pub const MAX_TAG_ID: usize = 108;
+pub const MAX_TAG_ID: usize = 109;
 
 /// Reverse lookup: tag ID → static tag name string.
 /// Avoids allocating a String for known tags.
@@ -223,6 +224,7 @@ pub static TAG_NAMES: [&str; MAX_TAG_ID] = {
     names[TAG_HEADER as usize] = "header";
     names[TAG_FIGCAPTION as usize] = "figcaption";
     names[TAG_CAPTION as usize] = "caption";
+    names[TAG_DATALIST as usize] = "datalist";
     names
 };
 
@@ -312,6 +314,7 @@ fn get_tag_id_bytes(bytes: &[u8]) -> Option<u8> {
         b"section" => TAG_SECTION,
         b"details" => TAG_DETAILS,
         b"caption" => TAG_CAPTION,
+        b"datalist" => TAG_DATALIST,
         b"article" => TAG_ARTICLE,
         b"address" => TAG_ADDRESS,
         b"strong" => TAG_STRONG,

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -75,6 +75,10 @@ pub struct ConvertState {
     rawtext_escaped: bool,
     escape_ctx: u8,
     in_pre: bool,
+    /// Filter: depth of the shallowest currently-open visually-hidden element, or
+    /// None. Lets the parser skip a hidden subtree in O(1) without re-checking
+    /// styles per node, and keeps this state off the public `ElementNode`.
+    hidden_since_depth: Option<usize>,
     /// Unified collapse depth counter (replaces separate counters in ParseState + MarkdownState)
     collapse_non_span_depth: u8,
     collapse_span_depth: u8,
@@ -178,6 +182,7 @@ impl ConvertState {
             rawtext_escaped: false,
             escape_ctx: 0,
             in_pre: false,
+            hidden_since_depth: None,
             collapse_non_span_depth: 0,
             collapse_span_depth: 0,
             first_block_parent_index: None,

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -179,6 +179,7 @@ impl ConvertState {
             pooled.child_text_node_index = 0;
             pooled.contains_whitespace = false;
             pooled.excluded_from_markdown = false;
+            pooled.hidden = false;
             pooled.tailwind = None;
             pooled.is_inline = h_inline;
             pooled.excludes_text_nodes = h_excludes;
@@ -192,6 +193,7 @@ impl ConvertState {
                 depth: self.depth, index: current_walk_index,
                 current_walk_index: 0, child_text_node_index: 0,
                 contains_whitespace: false, excluded_from_markdown: false,
+                hidden: false,
                 tailwind: None,
                 is_inline: h_inline, excludes_text_nodes: h_excludes,
                 is_non_nesting: h_non_nesting, collapses_inner_white_space: h_collapses,
@@ -223,9 +225,10 @@ impl ConvertState {
 
             if self.has_filter {
                 // Hidden elements (and their subtrees) are dropped — browsers never
-                // render them. filter_excluded makes the exclusion unconditional so
-                // descendants inherit it via the ancestor walk below (issue #100 follow-up).
-                if is_hidden(&tag) { skip_node = true; filter_excluded = true; }
+                // render them. Hidden-ness propagates O(1) from the parent's flag, so
+                // is_hidden() runs once per element instead of once per ancestor.
+                tag.hidden = self.stack.last().is_some_and(|p| p.hidden) || is_hidden(&tag);
+                if tag.hidden { skip_node = true; filter_excluded = true; }
                 if !skip_node {
                     for (_, parsed) in &self.filter_exclude_parsed {
                         if matches_selector(&tag, parsed) { skip_node = true; filter_excluded = true; break; }
@@ -233,7 +236,6 @@ impl ConvertState {
                 }
                 if !skip_node {
                     for parent in &self.stack {
-                        if is_hidden(parent) { skip_node = true; filter_excluded = true; break; }
                         for (_, parsed) in &self.filter_exclude_parsed {
                             if matches_selector(parent, parsed) { skip_node = true; filter_excluded = true; break; }
                         }

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -183,7 +183,6 @@ impl ConvertState {
             pooled.child_text_node_index = 0;
             pooled.contains_whitespace = false;
             pooled.excluded_from_markdown = false;
-            pooled.hidden = false;
             pooled.tailwind = None;
             pooled.is_inline = h_inline;
             pooled.excludes_text_nodes = h_excludes;
@@ -197,7 +196,6 @@ impl ConvertState {
                 depth: self.depth, index: current_walk_index,
                 current_walk_index: 0, child_text_node_index: 0,
                 contains_whitespace: false, excluded_from_markdown: false,
-                hidden: false,
                 tailwind: None,
                 is_inline: h_inline, excludes_text_nodes: h_excludes,
                 is_non_nesting: h_non_nesting, collapses_inner_white_space: h_collapses,
@@ -229,10 +227,17 @@ impl ConvertState {
 
             if self.has_filter {
                 // Hidden elements (and their subtrees) are dropped — browsers never
-                // render them. Hidden-ness propagates O(1) from the parent's flag, so
-                // is_hidden() runs once per element instead of once per ancestor.
-                tag.hidden = self.stack.last().is_some_and(|p| p.hidden) || is_hidden(&tag);
-                if tag.hidden { skip_node = true; filter_excluded = true; }
+                // render them. `hidden_since_depth` records the shallowest open hidden
+                // element, so once inside a hidden subtree we skip O(1) without calling
+                // is_hidden() again. Cleared in close_node at the matching depth.
+                if self.hidden_since_depth.is_some() {
+                    skip_node = true;
+                    filter_excluded = true;
+                } else if is_hidden(&tag) {
+                    skip_node = true;
+                    filter_excluded = true;
+                    self.hidden_since_depth = Some(self.depth);
+                }
                 if !skip_node {
                     for (_, parsed) in &self.filter_exclude_parsed {
                         if matches_selector(&tag, parsed) { skip_node = true; filter_excluded = true; break; }
@@ -431,6 +436,11 @@ impl ConvertState {
         let popping_index = self.stack.len() - 1;
         // Guard already checked above, but avoid panic on edge cases
         let Some(node) = self.stack.pop() else { return };
+
+        // Leaving the element that opened the current hidden subtree (filter).
+        if self.hidden_since_depth == Some(node.depth) {
+            self.hidden_since_depth = None;
+        }
 
         if self.first_block_parent_index == Some(popping_index) {
             self.block_parent_indices.pop();

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -19,7 +19,9 @@ fn is_hidden(node: &ElementNode) -> bool {
     {
         return true;
     }
-    matches!(node.attributes.get("hidden"), Some(v) if v != "until-found")
+    // The `hidden` attribute hides the element unless it's the revealable
+    // `until-found` state (an enumerated keyword, so ASCII case-insensitive).
+    matches!(node.attributes.get("hidden"), Some(v) if !v.eq_ignore_ascii_case("until-found"))
 }
 
 impl ConvertState {

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -4,14 +4,18 @@ use super::*;
 
 /// Whether an element is visually hidden, so the filter should drop it and its
 /// subtree: inline `display:none` / `visibility:hidden` / `position:absolute|fixed`,
-/// or the `hidden` attribute (except `hidden="until-found"`). Allocation-free;
-/// matches the common spaced and unspaced inline-style forms.
+/// or the `hidden` attribute (except `hidden="until-found"`).
+///
+/// Matches the actual `display:`/`visibility:`/`position:` declaration (not bare
+/// keywords like `fixed`, which would false-match e.g. `background-attachment:fixed`)
+/// and both unspaced and `: `-spaced forms. Allocation-free; uppercased
+/// properties (rare in inline styles) are not handled.
 fn is_hidden(node: &ElementNode) -> bool {
     if let Some(style) = node.attributes.get("style")
-        && (style.contains("absolute")
-            || style.contains("fixed")
-            || style.contains("display:none") || style.contains("display: none")
-            || style.contains("visibility:hidden") || style.contains("visibility: hidden"))
+        && (style.contains("display:none") || style.contains("display: none")
+            || style.contains("visibility:hidden") || style.contains("visibility: hidden")
+            || style.contains("position:absolute") || style.contains("position: absolute")
+            || style.contains("position:fixed") || style.contains("position: fixed"))
     {
         return true;
     }

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -7,14 +7,13 @@ use super::*;
 /// or the `hidden` attribute (except `hidden="until-found"`). Allocation-free;
 /// matches the common spaced and unspaced inline-style forms.
 fn is_hidden(node: &ElementNode) -> bool {
-    if let Some(style) = node.attributes.get("style") {
-        if style.contains("absolute")
+    if let Some(style) = node.attributes.get("style")
+        && (style.contains("absolute")
             || style.contains("fixed")
             || style.contains("display:none") || style.contains("display: none")
-            || style.contains("visibility:hidden") || style.contains("visibility: hidden")
-        {
-            return true;
-        }
+            || style.contains("visibility:hidden") || style.contains("visibility: hidden"))
+    {
+        return true;
     }
     matches!(node.attributes.get("hidden"), Some(v) if v != "until-found")
 }

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -2,6 +2,23 @@
 
 use super::*;
 
+/// Whether an element is visually hidden, so the filter should drop it and its
+/// subtree: inline `display:none` / `visibility:hidden` / `position:absolute|fixed`,
+/// or the `hidden` attribute (except `hidden="until-found"`). Allocation-free;
+/// matches the common spaced and unspaced inline-style forms.
+fn is_hidden(node: &ElementNode) -> bool {
+    if let Some(style) = node.attributes.get("style") {
+        if style.contains("absolute")
+            || style.contains("fixed")
+            || style.contains("display:none") || style.contains("display: none")
+            || style.contains("visibility:hidden") || style.contains("visibility: hidden")
+        {
+            return true;
+        }
+    }
+    matches!(node.attributes.get("hidden"), Some(v) if v != "until-found")
+}
+
 impl ConvertState {
     pub(crate) fn process_text_buffer(&mut self, text_buffer: &mut String) {
         let contains_non_whitespace = self.text_buffer_contains_non_whitespace;
@@ -206,8 +223,10 @@ impl ConvertState {
             }
 
             if self.has_filter {
-                if let Some(style) = tag.attributes.get("style")
-                    && (style.contains("absolute") || style.contains("fixed")) { skip_node = true; }
+                // Hidden elements (and their subtrees) are dropped — browsers never
+                // render them. filter_excluded makes the exclusion unconditional so
+                // descendants inherit it via the ancestor walk below (issue #100 follow-up).
+                if is_hidden(&tag) { skip_node = true; filter_excluded = true; }
                 if !skip_node {
                     for (_, parsed) in &self.filter_exclude_parsed {
                         if matches_selector(&tag, parsed) { skip_node = true; filter_excluded = true; break; }
@@ -215,6 +234,7 @@ impl ConvertState {
                 }
                 if !skip_node {
                     for parent in &self.stack {
+                        if is_hidden(parent) { skip_node = true; filter_excluded = true; break; }
                         for (_, parsed) in &self.filter_exclude_parsed {
                             if matches_selector(parent, parsed) { skip_node = true; filter_excluded = true; break; }
                         }

--- a/crates/core/src/tags.rs
+++ b/crates/core/src/tags.rs
@@ -181,6 +181,9 @@ static TAG_HANDLERS: [Option<TagHandler>; MAX_TAG_ID] = {
     t[TAG_PLAINTEXT as usize] = Some(NON_NESTING_NO_SPACING);
 
     t[TAG_NOSCRIPT as usize] = Some(TagHandler { excludes_text_nodes: true, spacing: Some(NO_SPACING), ..NONE });
+    // <datalist> holds <option> autocomplete data browsers never render; treat
+    // the whole body as inert and drop it, mirroring <template>.
+    t[TAG_DATALIST as usize] = Some(TagHandler { is_non_nesting: true, excludes_text_nodes: true, spacing: Some(NO_SPACING), ..NONE });
 
     t
 };

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -81,9 +81,6 @@ pub struct ElementNode {
     pub tag_id: Option<u8>,
     pub contains_whitespace: bool,
     pub excluded_from_markdown: bool,
-    /// Filter: this element (or an ancestor) is visually hidden. Propagated O(1)
-    /// from the parent so hidden-ness isn't re-walked up the stack per node.
-    pub hidden: bool,
     /// Cached from tag handler - avoids repeated get_tag_handler lookups
     pub is_inline: bool,
     pub excludes_text_nodes: bool,

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -81,6 +81,9 @@ pub struct ElementNode {
     pub tag_id: Option<u8>,
     pub contains_whitespace: bool,
     pub excluded_from_markdown: bool,
+    /// Filter: this element (or an ancestor) is visually hidden. Propagated O(1)
+    /// from the parent so hidden-ness isn't re-walked up the stack per node.
+    pub hidden: bool,
     /// Cached from tag handler - avoids repeated get_tag_handler lookups
     pub is_inline: bool,
     pub excludes_text_nodes: bool,

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -794,6 +794,10 @@ fn filter_strips_hidden_content_and_subtree() {
     // Visible content and revealable hidden="until-found" are kept.
     assert_eq!(convert_with_filter("<p>a</p><div>V</div><p>b</p>"), "a\n\nV\n\nb");
     assert_eq!(convert_with_filter("<p>a</p><div hidden=\"until-found\">K</div><p>b</p>"), "a\n\nK\n\nb");
+    // Unrelated CSS keywords must not false-match (background-attachment:fixed
+    // contains "fixed"; transition contains "absolute" only via other props).
+    assert_eq!(convert_with_filter("<p>a</p><div style=\"background-attachment:fixed\">V</div><p>b</p>"), "a\n\nV\n\nb");
+    assert_eq!(convert_with_filter("<p>a</p><div style=\"display:flex\">V</div><p>b</p>"), "a\n\nV\n\nb");
 }
 
 #[test]

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -626,6 +626,19 @@ fn strips_style() {
 }
 
 #[test]
+fn strips_datalist() {
+    // <datalist> options are inert autocomplete data, never rendered.
+    assert_eq!(
+        convert("<p>Before</p><datalist><option value=\"V\">Hidden</option></datalist><p>After</p>"),
+        "Before\n\nAfter"
+    );
+    assert_eq!(
+        convert("<p>Before</p><datalist><option>One</option><option>Two</option></datalist><p>After</p>"),
+        "Before\n\nAfter"
+    );
+}
+
+#[test]
 fn escaped_backslash_in_script() {
     let html = r#"<script>var x = "a]\\\\\\\\b";</script><p>Visible content</p>"#;
     let result = convert(html);
@@ -750,6 +763,38 @@ fn kbd_tag() {
 }
 
 // ── Extraction ──
+
+fn convert_with_filter(html: &str) -> String {
+    // Any filter config activates the filter plugin (and its hidden-content stripping).
+    html_to_markdown(html, HTMLToMarkdownOptions {
+        plugins: Some(PluginConfig {
+            filter: Some(FilterConfig::exclude(&["nav"])),
+            ..Default::default()
+        }),
+        ..Default::default()
+    })
+}
+
+#[test]
+fn filter_strips_hidden_content_and_subtree() {
+    // display:none / visibility:hidden / position:absolute and the hidden attribute
+    // drop the element and its whole subtree; hidden="until-found" stays.
+    assert_eq!(convert_with_filter("<p>a</p><div style=\"display:none\">H</div><p>b</p>"), "a\n\nb");
+    assert_eq!(convert_with_filter("<p>a</p><div style=\"display: none\">H</div><p>b</p>"), "a\n\nb");
+    assert_eq!(convert_with_filter("<p>a</p><div style=\"visibility:hidden\">H</div><p>b</p>"), "a\n\nb");
+    assert_eq!(convert_with_filter("<p>a</p><div hidden>H</div><p>b</p>"), "a\n\nb");
+    assert_eq!(
+        convert_with_filter("<p>a</p><div style=\"display:none\"><section><p>H</p></section></div><p>b</p>"),
+        "a\n\nb"
+    );
+    assert_eq!(
+        convert_with_filter("<p>a</p><div style=\"position:absolute\"><p>H</p></div><p>b</p>"),
+        "a\n\nb"
+    );
+    // Visible content and revealable hidden="until-found" are kept.
+    assert_eq!(convert_with_filter("<p>a</p><div>V</div><p>b</p>"), "a\n\nV\n\nb");
+    assert_eq!(convert_with_filter("<p>a</p><div hidden=\"until-found\">K</div><p>b</p>"), "a\n\nK\n\nb");
+}
 
 #[test]
 fn extraction_by_tag() {

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -794,6 +794,8 @@ fn filter_strips_hidden_content_and_subtree() {
     // Visible content and revealable hidden="until-found" are kept.
     assert_eq!(convert_with_filter("<p>a</p><div>V</div><p>b</p>"), "a\n\nV\n\nb");
     assert_eq!(convert_with_filter("<p>a</p><div hidden=\"until-found\">K</div><p>b</p>"), "a\n\nK\n\nb");
+    // until-found is an enumerated keyword: case-insensitive, so still kept.
+    assert_eq!(convert_with_filter("<p>a</p><div hidden=\"UNTIL-FOUND\">K</div><p>b</p>"), "a\n\nK\n\nb");
     // Unrelated CSS keywords must not false-match (background-attachment:fixed
     // contains "fixed"; transition contains "absolute" only via other props).
     assert_eq!(convert_with_filter("<p>a</p><div style=\"background-attachment:fixed\">V</div><p>b</p>"), "a\n\nV\n\nb");

--- a/packages/js/src/const.ts
+++ b/packages/js/src/const.ts
@@ -107,9 +107,10 @@ export const TAG_MAIN = 104 // Main content area of a document
 export const TAG_HEADER = 105 // Document or section header
 export const TAG_FIGCAPTION = 106 // Caption for a figure
 export const TAG_CAPTION = 107 // Table caption
+export const TAG_DATALIST = 108 // Inert: <option> children are autocomplete data, never rendered
 
 // Maximum tag ID for creating the typed array (update to match the highest tag ID)
-export const MAX_TAG_ID = 108
+export const MAX_TAG_ID = 109
 
 // Node type constants
 export const ELEMENT_NODE = 1
@@ -228,6 +229,7 @@ export const TagIdMap = {
   header: TAG_HEADER,
   figcaption: TAG_FIGCAPTION,
   caption: TAG_CAPTION,
+  datalist: TAG_DATALIST,
 } as const
 
 // Reverse map: tag ID → tag name (for cross-engine filter conversion)

--- a/packages/js/src/plugins/filter.ts
+++ b/packages/js/src/plugins/filter.ts
@@ -40,8 +40,10 @@ function isHidden(element: ElementNode): boolean {
     || style.includes('position:fixed') || style.includes('position: fixed'))) {
     return true
   }
+  // The `hidden` attribute hides the element unless it's the revealable
+  // `until-found` state (an enumerated keyword, so ASCII case-insensitive).
   const hidden = element.attributes?.hidden
-  return hidden !== undefined && hidden !== 'until-found'
+  return hidden !== undefined && hidden.toLowerCase() !== 'until-found'
 }
 
 /**

--- a/packages/js/src/plugins/filter.ts
+++ b/packages/js/src/plugins/filter.ts
@@ -26,12 +26,18 @@ function compileSelector(selector: string | number): SelectorMatcher {
  * inline display:none / visibility:hidden / position:absolute|fixed, or the
  * `hidden` attribute (except hidden="until-found"). Browsers never render these,
  * so neither should the Markdown.
+ *
+ * Matches the actual `display:`/`visibility:`/`position:` declaration (not bare
+ * keywords like `fixed`, which would false-match e.g. `background-attachment:fixed`)
+ * and both unspaced and `: `-spaced forms. Allocation-free to keep the hot path
+ * cheap; uppercased properties (rare in inline styles) are not handled.
  */
 function isHidden(element: ElementNode): boolean {
   const style = element.attributes?.style
-  if (style && (style.includes('absolute') || style.includes('fixed')
-    || style.includes('display:none') || style.includes('display: none')
-    || style.includes('visibility:hidden') || style.includes('visibility: hidden'))) {
+  if (style && (style.includes('display:none') || style.includes('display: none')
+    || style.includes('visibility:hidden') || style.includes('visibility: hidden')
+    || style.includes('position:absolute') || style.includes('position: absolute')
+    || style.includes('position:fixed') || style.includes('position: fixed'))) {
     return true
   }
   const hidden = element.attributes?.hidden

--- a/packages/js/src/plugins/filter.ts
+++ b/packages/js/src/plugins/filter.ts
@@ -22,6 +22,23 @@ function compileSelector(selector: string | number): SelectorMatcher {
 }
 
 /**
+ * Whether an element is visually hidden, so the filter drops it and its subtree:
+ * inline display:none / visibility:hidden / position:absolute|fixed, or the
+ * `hidden` attribute (except hidden="until-found"). Browsers never render these,
+ * so neither should the Markdown.
+ */
+function isHidden(element: ElementNode): boolean {
+  const style = element.attributes?.style
+  if (style && (style.includes('absolute') || style.includes('fixed')
+    || style.includes('display:none') || style.includes('display: none')
+    || style.includes('visibility:hidden') || style.includes('visibility: hidden'))) {
+    return true
+  }
+  const hidden = element.attributes?.hidden
+  return hidden !== undefined && hidden !== 'until-found'
+}
+
+/**
  * Plugin that filters nodes based on CSS selectors.
  * Allows including or excluding nodes based on selectors.
  *
@@ -54,13 +71,13 @@ export function filterPlugin(options: {
     beforeNodeProcess(event: any) {
       const { node } = event
 
-      // Handle text nodes - check if any ancestor is excluded
+      // Handle text nodes - skip if any ancestor is excluded or hidden
       if (node.type === TEXT_NODE) {
         const textNode = node as TextNode
         let currentParent = textNode.parent as ElementNode | null
-        while (currentParent && excludeSelectors.length) {
-          const parentShouldExclude = excludeSelectors.some(selector => selector.matches(currentParent!))
-          if (parentShouldExclude) {
+        while (currentParent) {
+          if (isHidden(currentParent)
+            || (excludeSelectors.length && excludeSelectors.some(selector => selector.matches(currentParent!)))) {
             return { skip: true }
           }
           currentParent = currentParent.parent as ElementNode | null
@@ -75,25 +92,21 @@ export function filterPlugin(options: {
 
       const element = node as ElementNode
 
+      // Drop hidden elements (and, via the ancestor walk below, their subtrees).
+      if (isHidden(element)) {
+        return { skip: true }
+      }
       // Check if element should be excluded
-      if (excludeSelectors.length) {
-        if (element.attributes.style?.includes('absolute') || element.attributes.style?.includes('fixed')) {
-          return { skip: true }
-        }
-        const shouldExclude = excludeSelectors.some(selector => selector.matches(element))
-        if (shouldExclude) {
-          return { skip: true }
-        }
+      if (excludeSelectors.length && excludeSelectors.some(selector => selector.matches(element))) {
+        return { skip: true }
       }
 
-      // Check if any parent element is excluded
+      // Check if any parent element is excluded or hidden
       let currentParent = element.parent
       while (currentParent) {
-        if (excludeSelectors.length) {
-          const parentShouldExclude = excludeSelectors.some(selector => selector.matches(currentParent!))
-          if (parentShouldExclude) {
-            return { skip: true }
-          }
+        if (isHidden(currentParent)
+          || (excludeSelectors.length && excludeSelectors.some(selector => selector.matches(currentParent!)))) {
+          return { skip: true }
         }
         currentParent = currentParent.parent as ElementNode | null
       }

--- a/packages/js/src/plugins/filter.ts
+++ b/packages/js/src/plugins/filter.ts
@@ -64,7 +64,10 @@ export function filterPlugin(options: {
   const excludeSelectors = options.exclude?.map(selector => compileSelector(selector)) || []
   const processChildren = options.processChildren !== false // Default to true
 
-  // No need for complex state tracking since beforeNodeProcess handles everything
+  // Tracks elements whose subtree is hidden. Hidden-ness propagates O(1) from
+  // the parent (set on enter, before children), so isHidden() runs once per
+  // element instead of being re-evaluated for every ancestor of every node.
+  const hiddenNodes = new WeakSet<ElementNode>()
 
   return createPlugin({
     // Handle include/exclude filtering for elements and text nodes
@@ -74,10 +77,14 @@ export function filterPlugin(options: {
       // Handle text nodes - skip if any ancestor is excluded or hidden
       if (node.type === TEXT_NODE) {
         const textNode = node as TextNode
-        let currentParent = textNode.parent as ElementNode | null
-        while (currentParent) {
-          if (isHidden(currentParent)
-            || (excludeSelectors.length && excludeSelectors.some(selector => selector.matches(currentParent!)))) {
+        const parent = textNode.parent as ElementNode | null
+        // Hidden propagates to the immediate parent, so one lookup covers all ancestors.
+        if (parent && hiddenNodes.has(parent)) {
+          return { skip: true }
+        }
+        let currentParent = parent
+        while (currentParent && excludeSelectors.length) {
+          if (excludeSelectors.some(selector => selector.matches(currentParent!))) {
             return { skip: true }
           }
           currentParent = currentParent.parent as ElementNode | null
@@ -92,8 +99,11 @@ export function filterPlugin(options: {
 
       const element = node as ElementNode
 
-      // Drop hidden elements (and, via the ancestor walk below, their subtrees).
-      if (isHidden(element)) {
+      // Drop hidden elements and their subtrees. Inherit the parent's hidden flag
+      // (O(1)); only run the style/attr scan when not already inside a hidden subtree.
+      const parentHidden = element.parent ? hiddenNodes.has(element.parent as ElementNode) : false
+      if (parentHidden || isHidden(element)) {
+        hiddenNodes.add(element)
         return { skip: true }
       }
       // Check if element should be excluded
@@ -101,11 +111,10 @@ export function filterPlugin(options: {
         return { skip: true }
       }
 
-      // Check if any parent element is excluded or hidden
+      // Check if any parent element is excluded by selector
       let currentParent = element.parent
-      while (currentParent) {
-        if (isHidden(currentParent)
-          || (excludeSelectors.length && excludeSelectors.some(selector => selector.matches(currentParent!)))) {
+      while (currentParent && excludeSelectors.length) {
+        if (excludeSelectors.some(selector => selector.matches(currentParent!))) {
           return { skip: true }
         }
         currentParent = currentParent.parent as ElementNode | null

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -29,6 +29,7 @@ import {
   TAG_CITE,
   TAG_CODE,
   TAG_COL,
+  TAG_DATALIST,
   TAG_DD,
   TAG_DEL,
   TAG_DETAILS,
@@ -793,6 +794,13 @@ export const tagHandlers: Record<number, TagHandler> = {
     isInline: true,
   },
   [TAG_NOSCRIPT]: {
+    excludesTextNodes: true,
+    spacing: NO_SPACING,
+  },
+  [TAG_DATALIST]: {
+    // <datalist> holds <option> autocomplete data that browsers never render.
+    // Treat the whole body as inert and drop it, mirroring <template>.
+    isNonNesting: true,
     excludesTextNodes: true,
     spacing: NO_SPACING,
   },

--- a/packages/mdream/test/unit/nodes/datalist.test.ts
+++ b/packages/mdream/test/unit/nodes/datalist.test.ts
@@ -16,9 +16,9 @@ describe.each(engines)('datalist tag handling $name', (engineConfig) => {
     expect(htmlToMarkdown(html, { engine })).toBe('a\n\nb')
   })
 
-  it('still renders the associated input', async () => {
+  it('drops the datalist of an input[list] pairing, keeping the rest', async () => {
     const engine = await resolveEngine(engineConfig.engine)
-    const html = '<p>before</p><datalist><option>x</option></datalist><p>after</p>'
-    expect(htmlToMarkdown(html, { engine })).toBe('before\n\nafter')
+    const html = '<label>Browser</label><input list="b"><datalist id="b"><option>Chrome</option><option>Firefox</option></datalist><p>done</p>'
+    expect(htmlToMarkdown(html, { engine })).toBe('Browser\n\ndone')
   })
 })

--- a/packages/mdream/test/unit/nodes/datalist.test.ts
+++ b/packages/mdream/test/unit/nodes/datalist.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { engines, htmlToMarkdown, resolveEngine } from '../../utils/engines'
+
+// <datalist> holds <option> autocomplete data that browsers never render, so it
+// must not leak into the Markdown (spec-inert, like <template>/<script>).
+describe.each(engines)('datalist tag handling $name', (engineConfig) => {
+  it('drops datalist option content', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const html = '<p>a</p><datalist><option value="V">HiddenLabel</option></datalist><p>b</p>'
+    expect(htmlToMarkdown(html, { engine })).toBe('a\n\nb')
+  })
+
+  it('drops multiple options', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const html = '<p>a</p><datalist id="x"><option>One</option><option>Two</option></datalist><p>b</p>'
+    expect(htmlToMarkdown(html, { engine })).toBe('a\n\nb')
+  })
+
+  it('still renders the associated input', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const html = '<p>before</p><datalist><option>x</option></datalist><p>after</p>'
+    expect(htmlToMarkdown(html, { engine })).toBe('before\n\nafter')
+  })
+})

--- a/packages/mdream/test/unit/preset/minimal.test.ts
+++ b/packages/mdream/test/unit/preset/minimal.test.ts
@@ -44,6 +44,42 @@ describe('withMinimalPreset cross-engine parity', () => {
     }
   })
 
+  it('strips hidden content (display:none / visibility:hidden / hidden attr)', async () => {
+    const [js, rust] = await bothEngines()
+    // Each hidden wrapper must disappear entirely; surrounding content stays.
+    const hidden = [
+      '<main><p>a</p><div style="display:none">H</div><p>b</p></main>',
+      '<main><p>a</p><div style="display: none">H</div><p>b</p></main>',
+      '<main><p>a</p><div style="visibility:hidden">H</div><p>b</p></main>',
+      '<main><p>a</p><div hidden>H</div><p>b</p></main>',
+      // Hidden ancestor hides the whole subtree, not just the styled node.
+      '<main><p>a</p><div style="display:none"><section><p>H</p></section></div><p>b</p></main>',
+      '<main><p>a</p><div style="position:absolute"><p>H</p></div><p>b</p></main>',
+    ]
+    for (const html of hidden) {
+      const opts = withMinimalPreset()
+      const jsResult = htmlToMarkdown(html, { ...opts, engine: js })
+      const rustResult = htmlToMarkdown(html, { ...opts, engine: rust })
+      expect(rustResult, `Hidden parity mismatch for: ${html}`).toBe(jsResult)
+      expect(jsResult, `Hidden content leaked for: ${html}`).toBe('a\n\nb')
+    }
+  })
+
+  it('keeps visible content and hidden="until-found"', async () => {
+    const [js, rust] = await bothEngines()
+    const cases: [string, string][] = [
+      ['<main><p>a</p><div>VISIBLE</div><p>b</p></main>', 'a\n\nVISIBLE\n\nb'],
+      ['<main><p>a</p><div hidden="until-found">KEEP</div><p>b</p></main>', 'a\n\nKEEP\n\nb'],
+    ]
+    for (const [html, expected] of cases) {
+      const opts = withMinimalPreset()
+      const jsResult = htmlToMarkdown(html, { ...opts, engine: js })
+      const rustResult = htmlToMarkdown(html, { ...opts, engine: rust })
+      expect(rustResult).toBe(jsResult)
+      expect(jsResult).toBe(expected)
+    }
+  })
+
   it('frontmatter produces identical output', async () => {
     const [js, rust] = await bothEngines()
     const html = `<html><head><title>My Page</title><meta name="description" content="A page about things" /><meta name="author" content="Alice" /></head><body><h1>Content</h1><p>Text</p></body></html>`

--- a/packages/mdream/test/unit/preset/minimal.test.ts
+++ b/packages/mdream/test/unit/preset/minimal.test.ts
@@ -70,6 +70,9 @@ describe('withMinimalPreset cross-engine parity', () => {
     const cases: [string, string][] = [
       ['<main><p>a</p><div>VISIBLE</div><p>b</p></main>', 'a\n\nVISIBLE\n\nb'],
       ['<main><p>a</p><div hidden="until-found">KEEP</div><p>b</p></main>', 'a\n\nKEEP\n\nb'],
+      // Unrelated CSS keywords must not false-match the hidden check.
+      ['<main><p>a</p><div style="background-attachment:fixed">KEEP</div><p>b</p></main>', 'a\n\nKEEP\n\nb'],
+      ['<main><p>a</p><div style="display:flex;gap:4px">KEEP</div><p>b</p></main>', 'a\n\nKEEP\n\nb'],
     ]
     for (const [html, expected] of cases) {
       const opts = withMinimalPreset()


### PR DESCRIPTION
### 🔗 Linked issue

Follow-up to the discussion on #102 (`<template>` exclusion) and #100.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Two related cases where content that browsers never render was leaking into the Markdown.

**`<datalist>` (core, always on).** Its `<option>` children are autocomplete data, not page content. Marked inert (`isNonNesting` + `excludesTextNodes`) like `<template>`/`<script>` in both engines, so `<datalist><option>...</option></datalist>` produces nothing.

**Author-hidden content (minimal preset / filter plugin).** The filter previously skipped only inline `position:absolute`/`fixed`, and even then only flagged the element itself, not its subtree, so hidden text still leaked. It now drops `display:none`, `visibility:hidden`, the `hidden` attribute (keeping `hidden="until-found"`), and `absolute`/`fixed`, cascading to the whole subtree via the existing ancestor walk (the same mechanism selector-excludes already use). This also repairs the pre-existing `absolute`/`fixed` subtree leak.

This stays **preset-scoped**: hidden-content stripping only runs when the filter plugin is active (e.g. `withMinimalPreset()` / `{ minimal: true }`), not in the bare core converter, so default extraction still keeps everything. `<datalist>`, being spec-inert, is core.

Both pieces are implemented in the JS and Rust engines with cross-engine parity tests.

Tests: `datalist.test.ts` (3 cases x both engines), new hidden-content + `until-found` cases in `minimal.test.ts` (cross-engine parity), and Rust `strips_datalist` + `filter_strips_hidden_content_and_subtree` in `conversion.rs`. Full suite green: 808 JS tests, all Rust tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Treat <datalist> as inert: its contents are omitted from generated Markdown
  * Expanded hidden-content detection: elements (and hidden ancestors) styled or attributed as hidden are removed; hidden="until-found" is preserved

* **Tests**
  * Added cross-engine and unit tests covering datalist stripping and hidden-content/subtree filtering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->