### PR TITLE
feat: support `wrapWidth` option

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -223,11 +223,11 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "mdream"
-version = "1.2.2"
+version = "1.3.0"
 
 [[package]]
 name = "mdream-edge"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "js-sys",
  "mdream",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "mdream-node"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "mdream",
  "napi",

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -132,6 +132,10 @@ pub struct ConvertState {
     // Streaming
     last_yielded_length: usize,
 
+    /// Hard-wrap width in characters; 0 disables wrapping (zero-cost in the text
+    /// hot path — a single integer compare). Code/tables/headings are exempt.
+    wrap_width: usize,
+
     // Clean mode — bitmask for zero-cost when disabled
     clean_flags: u8,
     /// Set when current TAG_A has a meaningless href and should be rendered as plain text
@@ -178,6 +182,8 @@ impl ConvertState {
     }
 
     pub fn new(options: HTMLToMarkdownOptions, capacity: usize) -> Self {
+        // Read wrap width before `options` is moved into the struct below.
+        let options_wrap_width = options.wrap_width.unwrap_or(0);
         let mut s = Self {
             depth_map: [0; MAX_TAG_ID],
             depth: 0,
@@ -240,6 +246,7 @@ impl ConvertState {
             last_node_is_inline: false,
             last_yielded_length: 0,
 
+            wrap_width: options_wrap_width,
             clean_flags: 0,
             skip_current_link: false,
             link_bracket_pos: 0,

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -527,21 +527,29 @@ impl ConvertState {
     }
 
     /// Continuation prefix re-emitted at the start of each wrapped line so the
-    /// wrapped text stays inside its block context (blockquote markers and/or
-    /// list-item indentation).
+    /// wrapped text stays inside its block context. Built by walking the open
+    /// ancestor stack outermost-first so blockquote markers (`> `) and list-item
+    /// indentation interleave in the real nesting order: `<li><blockquote>` →
+    /// `  > `, `<blockquote><li>` → `>   `. A flat "all quotes then all indent"
+    /// prefix would corrupt the Markdown structure of nested blocks.
     fn wrap_continuation_prefix(&self) -> String {
-        let bq = self.depth_map[TAG_BLOCKQUOTE as usize] as usize;
         let mut p = String::new();
-        if bq > 0 {
-            if bq < BQ_PREFIXES.len() {
-                p.push_str(BQ_PREFIXES[bq]);
-            } else {
-                for _ in 0..bq {
-                    p.push_str("> ");
+        let mut li_idx = 0usize;
+        for node in &self.stack {
+            match node.tag_id {
+                Some(TAG_BLOCKQUOTE) => p.push_str("> "),
+                Some(TAG_LI) => {
+                    // Each open <li> contributes its marker-width of spaces, in
+                    // the same order they were pushed onto list_indent_widths.
+                    let w = self.list_indent_widths.get(li_idx).copied().unwrap_or(2) as usize;
+                    for _ in 0..w {
+                        p.push(' ');
+                    }
+                    li_idx += 1;
                 }
+                _ => {}
             }
         }
-        p.push_str(&self.list_indent);
         p
     }
 

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -479,7 +479,9 @@ impl ConvertState {
             text
         };
 
-        if self.should_add_spacing_before_text(last_char, text) {
+        if self.wrap_width != 0 && self.can_wrap_here() {
+            self.push_text_wrapped(text, last_char);
+        } else if self.should_add_spacing_before_text(last_char, text) {
             self.buffer.push(' ');
             self.last_content_cache_len = text.len() + 1;
             self.buffer.push_str(text);
@@ -493,6 +495,102 @@ impl ConvertState {
         self.last_text_node_depth = depth;
         self.last_text_node_index = index;
         self.last_node_is_inline = false;
+    }
+
+    /// Whether prose at the current position may be hard-wrapped. Code blocks
+    /// (`<pre>`/`<code>`), table cells, and headings are emitted verbatim so
+    /// wrapping never corrupts fences, table rows, or heading lines.
+    #[inline]
+    fn can_wrap_here(&self) -> bool {
+        self.depth_map[TAG_PRE as usize] == 0
+            && self.depth_map[TAG_CODE as usize] == 0
+            && !self.in_table_cell()
+            && self.depth_map[TAG_H1 as usize] == 0
+            && self.depth_map[TAG_H2 as usize] == 0
+            && self.depth_map[TAG_H3 as usize] == 0
+            && self.depth_map[TAG_H4 as usize] == 0
+            && self.depth_map[TAG_H5 as usize] == 0
+            && self.depth_map[TAG_H6 as usize] == 0
+    }
+
+    /// Character count of the current (unterminated) buffer line, i.e. since the
+    /// last `\n`. This is the live output column, including any block prefix
+    /// (`> `, list indent) already written for the line.
+    #[inline]
+    fn current_column(&self) -> usize {
+        let bytes = self.buffer.as_bytes();
+        let mut i = bytes.len();
+        while i > 0 && bytes[i - 1] != b'\n' {
+            i -= 1;
+        }
+        self.buffer[i..].chars().count()
+    }
+
+    /// Continuation prefix re-emitted at the start of each wrapped line so the
+    /// wrapped text stays inside its block context (blockquote markers and/or
+    /// list-item indentation).
+    fn wrap_continuation_prefix(&self) -> String {
+        let bq = self.depth_map[TAG_BLOCKQUOTE as usize] as usize;
+        let mut p = String::new();
+        if bq > 0 {
+            if bq < BQ_PREFIXES.len() {
+                p.push_str(BQ_PREFIXES[bq]);
+            } else {
+                for _ in 0..bq {
+                    p.push_str("> ");
+                }
+            }
+        }
+        p.push_str(&self.list_indent);
+        p
+    }
+
+    /// Push `text` into the buffer, hard-wrapping on spaces so no output line
+    /// exceeds `self.wrap_width` characters. Words are never split, so a single
+    /// token longer than the width (e.g. a URL) overflows rather than breaking.
+    /// A break only ever replaces an inter-word space, so words joined across
+    /// inline boundaries (e.g. `foo**bar**`) stay intact.
+    fn push_text_wrapped(&mut self, text: &str, last_char: u8) {
+        let width = self.wrap_width;
+        // A leading/trailing space in `text` is significant inter-word separation
+        // across an inline boundary (e.g. `… </a> now`); the non-wrap path keeps
+        // it by pushing `text` verbatim, so preserve it here too. `split(' ')`
+        // would otherwise discard it as an empty segment.
+        let leading_space = text.starts_with(' ');
+        let trailing_space = text.ends_with(' ');
+        let first_needs_space = leading_space || self.should_add_spacing_before_text(last_char, text);
+        let prefix = self.wrap_continuation_prefix();
+        let prefix_len = prefix.chars().count();
+        let buf_start = self.buffer.len();
+        let mut col = self.current_column();
+        let mut first = true;
+
+        for word in text.split(' ') {
+            if word.is_empty() {
+                continue;
+            }
+            let word_len = word.chars().count();
+            let need_space = if first { first_needs_space } else { true };
+
+            if need_space && col > prefix_len && col + 1 + word_len > width {
+                self.buffer.push('\n');
+                self.buffer.push_str(&prefix);
+                col = prefix_len;
+            } else if need_space {
+                self.buffer.push(' ');
+                col += 1;
+            }
+            self.buffer.push_str(word);
+            col += word_len;
+            first = false;
+        }
+
+        // Preserve a trailing separator space (unless we emitted nothing or the
+        // line already ends in whitespace) so the next inline run stays separated.
+        if trailing_space && !matches!(self.buffer.as_bytes().last(), Some(b' ' | b'\n') | None) {
+            self.buffer.push(' ');
+        }
+        self.last_content_cache_len = self.buffer.len() - buf_start;
     }
 
     /// Emit frontmatter content.

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -507,6 +507,12 @@ pub struct HTMLToMarkdownOptions {
     pub clean: Option<CleanConfig>,
     /// Plugin configuration (filters, frontmatter, extraction, tag overrides, …).
     pub plugins: Option<PluginConfig>,
+    /// Hard-wrap prose at this many characters, breaking on word boundaries.
+    ///
+    /// Applied inline during conversion (no extra pass), so it is zero-cost when
+    /// unset. `Some(0)` and `None` both disable wrapping. Code (`<pre>`/`<code>`),
+    /// tables, and headings are never wrapped.
+    pub wrap_width: Option<usize>,
 }
 
 impl HTMLToMarkdownOptions {
@@ -560,6 +566,19 @@ impl HTMLToMarkdownOptions {
     #[must_use]
     pub fn with_plugins(mut self, plugins: PluginConfig) -> Self {
         self.plugins = Some(plugins);
+        self
+    }
+
+    /// Hard-wrap prose at `width` characters on word boundaries.
+    ///
+    /// ```rust
+    /// use mdream::HTMLToMarkdownOptions;
+    ///
+    /// let opts = HTMLToMarkdownOptions::default().with_wrap_width(80);
+    /// ```
+    #[must_use]
+    pub fn with_wrap_width(mut self, width: usize) -> Self {
+        self.wrap_width = Some(width);
         self
     }
 }

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -2019,3 +2019,35 @@ fn wrap_works_across_streaming_chunks() {
     out.push_str(&stream.finish());
     assert_eq!(out.trim_end(), oneshot);
 }
+
+#[test]
+fn wrap_nested_blockquote_in_list_keeps_structure() {
+    // Continuation prefix must follow the real nesting order: a blockquote
+    // inside a list item indents (list) then quotes (`  > `), keeping the
+    // quoted content within the list item's column.
+    let out = convert_wrapped(
+        "<ul><li><blockquote><p>The quick brown fox jumps over the lazy dog every day</p></blockquote></li></ul>",
+        30,
+    );
+    for line in out.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        // Every quoted line stays inside the list item: indent before the `>`.
+        assert!(line.starts_with("- ") || line.starts_with("  > "), "wrong nesting prefix: {line:?}");
+    }
+}
+
+#[test]
+fn wrap_nested_list_in_blockquote_keeps_structure() {
+    // A list inside a blockquote quotes first, then indents (`>   `).
+    let out = convert_wrapped(
+        "<blockquote><ul><li>The quick brown fox jumps over the lazy dog every day</li></ul></blockquote>",
+        30,
+    );
+    let mut lines = out.lines();
+    assert!(lines.next().unwrap().starts_with("> - "));
+    for line in lines {
+        assert!(line.starts_with(">   "), "list continuation left the blockquote: {line:?}");
+    }
+}

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -1920,3 +1920,102 @@ fn script_string_with_multibyte_content_does_not_close_early() {
     let html = "<script>var s = \"héllo – </script> wörld\"; run();</script><p>ok</p>";
     assert_eq!(convert(html), "ok");
 }
+
+// ── Wrap width (issue #106) ──
+
+fn convert_wrapped(html: &str, width: usize) -> String {
+    html_to_markdown(html, HTMLToMarkdownOptions::default().with_wrap_width(width))
+}
+
+#[test]
+fn wrap_disabled_by_default_is_byte_identical() {
+    let html = "<p>The quick brown fox jumps over the lazy dog and then keeps on running well past the edge.</p>";
+    assert_eq!(convert(html), html_to_markdown(html, HTMLToMarkdownOptions::default()));
+    // Some(0) is also a no-op.
+    assert_eq!(convert(html), convert_wrapped(html, 0));
+}
+
+#[test]
+fn wrap_breaks_prose_on_word_boundaries() {
+    let out = convert_wrapped(
+        "<p>The quick brown fox jumps over the lazy dog and then keeps on running well past the edge.</p>",
+        40,
+    );
+    assert_eq!(
+        out,
+        "The quick brown fox jumps over the lazy\ndog and then keeps on running well past\nthe edge.",
+    );
+    for line in out.lines() {
+        assert!(line.chars().count() <= 40, "line exceeds width: {line:?}");
+    }
+}
+
+#[test]
+fn wrap_preserves_inline_spacing() {
+    // Boundary spaces around inline elements must survive wrapping.
+    assert_eq!(
+        convert_wrapped("<p>see <em>this</em> word and more words after the emphasis here please now</p>", 40),
+        "see _this_ word and more words after the\nemphasis here please now",
+    );
+}
+
+#[test]
+fn wrap_never_splits_a_long_token() {
+    let out = convert_wrapped(
+        "<p>A superlongunbreakabletokenthatislongerthanthewrapwidthsoitoverflows end.</p>",
+        40,
+    );
+    // The oversized word lands alone on its own line, intact.
+    assert!(out.contains("superlongunbreakabletokenthatislongerthanthewrapwidthsoitoverflows"));
+}
+
+#[test]
+fn wrap_skips_code_tables_and_headings() {
+    // Fenced code is emitted verbatim.
+    let code = convert_wrapped(
+        "<pre><code>the quick brown fox jumps over the lazy dog and keeps going forever no wrap here</code></pre>",
+        40,
+    );
+    assert!(code.contains("the quick brown fox jumps over the lazy dog and keeps going forever no wrap here"));
+    // Headings are not wrapped.
+    let heading = convert_wrapped("<h1>The quick brown fox jumps over the lazy dog and never stops</h1>", 40);
+    assert_eq!(heading, "# The quick brown fox jumps over the lazy dog and never stops");
+    // Table rows are not wrapped (would corrupt the row).
+    let table = convert_wrapped("<table><tr><th>The quick brown fox jumps over the lazy dog header</th></tr></table>", 40);
+    assert_eq!(table.lines().next().unwrap(), "| The quick brown fox jumps over the lazy dog header |");
+}
+
+#[test]
+fn wrap_indents_blockquote_and_list_continuations() {
+    let bq = convert_wrapped(
+        "<blockquote><p>The quick brown fox jumps over the lazy dog and runs further still each day.</p></blockquote>",
+        40,
+    );
+    for line in bq.lines() {
+        assert!(line.starts_with("> "), "blockquote continuation lost prefix: {line:?}");
+    }
+    let list = convert_wrapped(
+        "<ul><li>The quick brown fox jumps over the lazy dog repeatedly without ever getting tired</li></ul>",
+        40,
+    );
+    let mut lines = list.lines();
+    assert!(lines.next().unwrap().starts_with("- "));
+    for line in lines {
+        assert!(line.starts_with("  "), "list continuation lost indent: {line:?}");
+    }
+}
+
+#[test]
+fn wrap_works_across_streaming_chunks() {
+    // A single long paragraph split mid-word across chunks must still wrap
+    // identically to the one-shot conversion (no double spaces, correct breaks).
+    let html = "<p>The quick brown fox jumps over the lazy dog and then keeps on running well past the edge of the field.</p>";
+    let oneshot = convert_wrapped(html, 40);
+    let mut stream = MarkdownStreamProcessor::new(HTMLToMarkdownOptions::default().with_wrap_width(40));
+    let mut out = String::new();
+    let mid = html.len() / 2;
+    out.push_str(&stream.process_chunk(&html[..mid]));
+    out.push_str(&stream.process_chunk(&html[mid..]));
+    out.push_str(&stream.finish());
+    assert_eq!(out.trim_end(), oneshot);
+}

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -85,7 +85,10 @@ fn parse_options(options: &JsValue) -> mdream::types::HTMLToMarkdownOptions {
         Some(parse_plugins(&plugins_val))
     };
 
-    let wrap_width = get_prop(options, "wrapWidth").as_f64().map(|n| n as usize);
+    let wrap_width = get_prop(options, "wrapWidth")
+        .as_f64()
+        .filter(|n| n.is_finite() && *n >= 0.0)
+        .map(|n| n as usize);
 
     mdream::types::HTMLToMarkdownOptions {
         origin,

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -85,11 +85,14 @@ fn parse_options(options: &JsValue) -> mdream::types::HTMLToMarkdownOptions {
         Some(parse_plugins(&plugins_val))
     };
 
+    let wrap_width = get_prop(options, "wrapWidth").as_f64().map(|n| n as usize);
+
     mdream::types::HTMLToMarkdownOptions {
         origin,
         clean_urls,
         clean: None,
         plugins,
+        wrap_width,
     }
 }
 

--- a/crates/node/index.d.ts
+++ b/crates/node/index.d.ts
@@ -62,6 +62,7 @@ export interface HtmlToMarkdownOptions {
   cleanUrls?: boolean
   clean?: CleanOptionsNapi
   plugins?: PluginOptions
+  wrapWidth?: number
 }
 
 export interface MarkdownChunkNapi {

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -101,6 +101,8 @@ pub struct HtmlToMarkdownOptions {
     pub clean_urls: Option<bool>,
     pub clean: Option<CleanOptionsNapi>,
     pub plugins: Option<PluginOptions>,
+    #[napi(js_name = "wrapWidth")]
+    pub wrap_width: Option<u32>,
 }
 
 // ── Type conversion (NAPI → core) ──
@@ -120,6 +122,7 @@ fn to_core_opts(options: Option<HtmlToMarkdownOptions>) -> mdream::types::HTMLTo
         origin: options.as_ref().and_then(|o| o.origin.clone()),
         clean_urls: options.as_ref().and_then(|o| o.clean_urls).unwrap_or(false),
         clean,
+        wrap_width: options.as_ref().and_then(|o| o.wrap_width).map(|w| w as usize),
         plugins: options.and_then(|o| {
             o.plugins.map(|p| mdream::types::PluginConfig {
                 filter: p.filter.map(|f| mdream::types::FilterConfig {

--- a/packages/js/src/cli.ts
+++ b/packages/js/src/cli.ts
@@ -11,11 +11,13 @@ import { withMinimalPreset } from './preset/minimal'
 interface CliOptions {
   origin?: string
   preset?: string
+  wrapWidth?: number
 }
 
 async function streamingConvert(options: CliOptions = {}) {
   let conversionOptions: Partial<MdreamOptions> = {
     origin: options.origin,
+    wrapWidth: options.wrapWidth ? Number(options.wrapWidth) || undefined : undefined,
   }
 
   if (options.preset === 'minimal') {
@@ -40,6 +42,7 @@ const cli = cac()
 cli.command('[options]', 'Convert HTML from stdin to Markdown on stdout (JS engine)')
   .option('--origin <url>', 'Origin URL for resolving relative image paths')
   .option('--preset <preset>', 'Conversion presets: minimal')
+  .option('--wrap-width <n>', 'Hard-wrap prose at <n> characters on word boundaries')
   .action(async (_, opts) => {
     await streamingConvert(opts)
   })

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -171,7 +171,7 @@ function canWrapHere(depthMap: Uint8Array): boolean {
 function currentColumn(buffer: string[]): number {
   let col = 0
   for (let i = buffer.length - 1; i >= 0; i--) {
-    const s = buffer[i]
+    const s = buffer[i]!
     const nl = s.lastIndexOf('\n')
     if (nl >= 0) {
       return col + [...s.slice(nl + 1)].length

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -147,6 +147,103 @@ function shouldAddSpacingBeforeText(lastChar: string, lastNode: ElementNode | Te
 }
 
 /**
+ * Whether prose at the current position may be hard-wrapped. Code blocks
+ * (`<pre>`/`<code>`), table cells, and headings are emitted verbatim so wrapping
+ * never corrupts fences, table rows, or heading lines. Parity with the Rust
+ * engine's `can_wrap_here`.
+ */
+function canWrapHere(depthMap: Uint8Array): boolean {
+  if (depthMap[TAG_PRE] || depthMap[TAG_CODE] || depthMap[TAG_TD] || depthMap[TAG_TH]) {
+    return false
+  }
+  for (let h = TAG_H1; h <= TAG_H6; h++) {
+    if (depthMap[h])
+      return false
+  }
+  return true
+}
+
+/**
+ * Character count (code points) of the current unterminated output line, i.e.
+ * since the last newline across the buffer chunks. Includes any block prefix
+ * (`> `, list indent) already written for the line.
+ */
+function currentColumn(buffer: string[]): number {
+  let col = 0
+  for (let i = buffer.length - 1; i >= 0; i--) {
+    const s = buffer[i]
+    const nl = s.lastIndexOf('\n')
+    if (nl >= 0) {
+      return col + [...s.slice(nl + 1)].length
+    }
+    col += [...s].length
+  }
+  return col
+}
+
+/**
+ * Continuation prefix re-emitted at the start of each wrapped line so wrapped
+ * text stays inside its block context (blockquote markers + list indentation).
+ */
+function wrapContinuationPrefix(state: MarkdownState): string {
+  let p = ''
+  const bq = state.depthMap[TAG_BLOCKQUOTE] || 0
+  for (let i = 0; i < bq; i++) {
+    p += '> '
+  }
+  p += state.listIndent
+  return p
+}
+
+/**
+ * Hard-wrap `value` on spaces so no output line exceeds `width` code points.
+ * Words are never split, so an oversized token (e.g. a URL) overflows rather
+ * than breaking, and a break only ever replaces an inter-word space. `value`
+ * already carries any significant leading/trailing space (added upstream), so
+ * those boundary spaces are preserved. Parity with the Rust `push_text_wrapped`.
+ */
+function wrapText(value: string, col: number, width: number, prefix: string): string {
+  const leading = value.charCodeAt(0) === 32
+  const trailing = value.charCodeAt(value.length - 1) === 32
+  const prefixLen = [...prefix].length
+  let out = ''
+  let first = true
+  let i = 0
+  const len = value.length
+  while (i < len) {
+    // Manual split on single spaces to avoid an intermediate array allocation.
+    let next = value.indexOf(' ', i)
+    if (next === -1)
+      next = len
+    if (next > i) {
+      const word = value.slice(i, next)
+      const wordLen = [...word].length
+      const needSpace = first ? leading : true
+      if (needSpace && col > prefixLen && col + 1 + wordLen > width) {
+        out += `\n${prefix}`
+        col = prefixLen
+      }
+      else if (needSpace) {
+        out += ' '
+        col += 1
+      }
+      out += word
+      col += wordLen
+      first = false
+    }
+    i = next + 1
+  }
+  if (trailing && out !== '' && !out.endsWith(' ') && !out.endsWith('\n')) {
+    out += ' '
+  }
+  // Whitespace-only value collapses to a single separator space.
+  if (out === '' && (leading || trailing)) {
+    out = ' '
+  }
+  return out
+}
+
+/**
  * Calculate newline configuration based on tag handler spacing config
  */
 function calculateNewLineConfig(node: ElementNode): readonly [number, number] {
@@ -328,8 +425,16 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
           textNode.value = value
         }
 
-        state.buffer.push(textNode.value)
-        state.lastContentCache = textNode.value
+        const wrapWidth = state.options?.wrapWidth
+        if (wrapWidth && canWrapHere(state.depthMap)) {
+          const wrapped = wrapText(textNode.value, currentColumn(state.buffer), wrapWidth, wrapContinuationPrefix(state))
+          state.buffer.push(wrapped)
+          state.lastContentCache = wrapped
+        }
+        else {
+          state.buffer.push(textNode.value)
+          state.lastContentCache = textNode.value
+        }
       }
       state.lastTextNode = textNode
       return

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -183,15 +183,34 @@ function currentColumn(buffer: string[]): number {
 
 /**
  * Continuation prefix re-emitted at the start of each wrapped line so wrapped
- * text stays inside its block context (blockquote markers + list indentation).
+ * text stays inside its block context. Built by walking the node's open
+ * ancestors outermost-first so blockquote markers (`> `) and list-item
+ * indentation interleave in the real nesting order: `<li><blockquote>` → `  > `,
+ * `<blockquote><li>` → `>   `. A flat "all quotes then all indent" prefix would
+ * corrupt the Markdown structure of nested blocks.
  */
-function wrapContinuationPrefix(state: MarkdownState): string {
-  let p = ''
-  const bq = state.depthMap[TAG_BLOCKQUOTE] || 0
-  for (let i = 0; i < bq; i++) {
-    p += '> '
+function wrapContinuationPrefix(state: MarkdownState, node: TextNode): string {
+  const chain: ElementNode[] = []
+  let cur = node.parent
+  while (cur) {
+    chain.push(cur)
+    cur = cur.parent
   }
-  p += state.listIndent
+  let p = ''
+  // chain is innermost-first; consume list widths from the end so the outermost
+  // <li> maps to listIndentWidths[0], matching the push order.
+  let liIdx = 0
+  for (let i = chain.length - 1; i >= 0; i--) {
+    const tagId = chain[i]!.tagId
+    if (tagId === TAG_BLOCKQUOTE) {
+      p += '> '
+    }
+    else if (tagId === TAG_LI) {
+      const w = state.listIndentWidths[liIdx] ?? 2
+      p += ' '.repeat(w)
+      liIdx++
+    }
+  }
   return p
 }
 
@@ -427,7 +446,7 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
 
         const wrapWidth = state.options?.wrapWidth
         if (wrapWidth && canWrapHere(state.depthMap)) {
-          const wrapped = wrapText(textNode.value, currentColumn(state.buffer), wrapWidth, wrapContinuationPrefix(state))
+          const wrapped = wrapText(textNode.value, currentColumn(state.buffer), wrapWidth, wrapContinuationPrefix(state, textNode))
           state.buffer.push(wrapped)
           state.lastContentCache = wrapped
         }

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -136,6 +136,14 @@ export interface EngineOptions {
    * final markdown (sync API only for `fragments`).
    */
   clean?: boolean | CleanOptions
+
+  /**
+   * Hard-wrap prose at this many characters, breaking on word boundaries.
+   * Applied inline during conversion (zero-cost when unset). Code blocks
+   * (`<pre>`/`<code>`), tables, and headings are never wrapped. `0` disables
+   * wrapping.
+   */
+  wrapWidth?: number
 }
 
 // Standard DOM node types

--- a/packages/js/test/unit/wrap-width.test.ts
+++ b/packages/js/test/unit/wrap-width.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { htmlToMarkdown } from '../../src/index'
+import { streamHtmlToMarkdown } from '../../src/stream'
+
+const wrap = (html: string, width: number) => htmlToMarkdown(html, { wrapWidth: width })
+
+describe('wrap width (issue #106)', () => {
+  it('is a no-op when unset or zero', () => {
+    const html = '<p>The quick brown fox jumps over the lazy dog and then keeps on running well past the edge.</p>'
+    expect(wrap(html, 0)).toBe(htmlToMarkdown(html))
+    expect(htmlToMarkdown(html, {})).toBe(htmlToMarkdown(html))
+  })
+
+  it('breaks prose on word boundaries within the width', () => {
+    const out = wrap('<p>The quick brown fox jumps over the lazy dog and then keeps on running well past the edge.</p>', 40)
+    expect(out).toBe('The quick brown fox jumps over the lazy\ndog and then keeps on running well past\nthe edge.')
+    for (const line of out.split('\n'))
+      expect([...line].length).toBeLessThanOrEqual(40)
+  })
+
+  it('preserves inline spacing around emphasis', () => {
+    expect(wrap('<p>see <em>this</em> word and more words after the emphasis here please now</p>', 40))
+      .toBe('see _this_ word and more words after the\nemphasis here please now')
+  })
+
+  it('never splits an oversized token', () => {
+    const out = wrap('<p>A superlongunbreakabletokenthatislongerthanthewrapwidthsoitoverflows end.</p>', 40)
+    expect(out).toContain('superlongunbreakabletokenthatislongerthanthewrapwidthsoitoverflows')
+  })
+
+  it('does not wrap code blocks, tables, or headings', () => {
+    expect(wrap('<pre><code>the quick brown fox jumps over the lazy dog keeps going forever no wrap here</code></pre>', 40))
+      .toContain('the quick brown fox jumps over the lazy dog keeps going forever no wrap here')
+    expect(wrap('<h1>The quick brown fox jumps over the lazy dog and never stops</h1>', 40))
+      .toBe('# The quick brown fox jumps over the lazy dog and never stops')
+    expect(wrap('<table><tr><th>The quick brown fox jumps over the lazy dog header</th></tr></table>', 40).split('\n')[0])
+      .toBe('| The quick brown fox jumps over the lazy dog header |')
+  })
+
+  it('indents blockquote and list continuation lines', () => {
+    for (const line of wrap('<blockquote><p>The quick brown fox jumps over the lazy dog and runs further still each day.</p></blockquote>', 40).split('\n'))
+      expect(line.startsWith('> ')).toBe(true)
+    const list = wrap('<ul><li>The quick brown fox jumps over the lazy dog repeatedly without ever getting tired</li></ul>', 40).split('\n')
+    expect(list[0].startsWith('- ')).toBe(true)
+    for (const line of list.slice(1))
+      expect(line.startsWith('  ')).toBe(true)
+  })
+
+  it('wraps identically across streaming chunks', async () => {
+    const html = '<p>The quick brown fox jumps over the lazy dog and then keeps on running well past the edge of the field.</p>'
+    const oneshot = wrap(html, 40)
+    const mid = Math.floor(html.length / 2)
+    const stream = new ReadableStream<string>({
+      start(controller) {
+        controller.enqueue(html.slice(0, mid))
+        controller.enqueue(html.slice(mid))
+        controller.close()
+      },
+    })
+    let out = ''
+    for await (const chunk of streamHtmlToMarkdown(stream, { wrapWidth: 40 }))
+      out += chunk
+    expect(out.trimEnd()).toBe(oneshot)
+  })
+})

--- a/packages/js/test/unit/wrap-width.test.ts
+++ b/packages/js/test/unit/wrap-width.test.ts
@@ -41,7 +41,7 @@ describe('wrap width (issue #106)', () => {
     for (const line of wrap('<blockquote><p>The quick brown fox jumps over the lazy dog and runs further still each day.</p></blockquote>', 40).split('\n'))
       expect(line.startsWith('> ')).toBe(true)
     const list = wrap('<ul><li>The quick brown fox jumps over the lazy dog repeatedly without ever getting tired</li></ul>', 40).split('\n')
-    expect(list[0].startsWith('- ')).toBe(true)
+    expect(list[0]!.startsWith('- ')).toBe(true)
     for (const line of list.slice(1))
       expect(line.startsWith('  ')).toBe(true)
   })

--- a/packages/js/test/unit/wrap-width.test.ts
+++ b/packages/js/test/unit/wrap-width.test.ts
@@ -46,6 +46,24 @@ describe('wrap width (issue #106)', () => {
       expect(line.startsWith('  ')).toBe(true)
   })
 
+  it('keeps nested blockquote-in-list structure when wrapping', () => {
+    // Continuation prefix must follow real nesting order: indent (list) then
+    // quote (`  > `), keeping quoted content inside the list item.
+    const out = wrap('<ul><li><blockquote><p>The quick brown fox jumps over the lazy dog every day</p></blockquote></li></ul>', 30)
+    for (const line of out.split('\n')) {
+      if (line.trim() === '')
+        continue
+      expect(line.startsWith('- ') || line.startsWith('  > ')).toBe(true)
+    }
+  })
+
+  it('keeps nested list-in-blockquote structure when wrapping', () => {
+    const lines = wrap('<blockquote><ul><li>The quick brown fox jumps over the lazy dog every day</li></ul></blockquote>', 30).split('\n')
+    expect(lines[0]!.startsWith('> - ')).toBe(true)
+    for (const line of lines.slice(1))
+      expect(line.startsWith('>   ')).toBe(true)
+  })
+
   it('wraps identically across streaming chunks', async () => {
     const html = '<p>The quick brown fox jumps over the lazy dog and then keeps on running well past the edge of the field.</p>'
     const oneshot = wrap(html, 40)

--- a/packages/mdream/README.md
+++ b/packages/mdream/README.md
@@ -213,6 +213,13 @@ interface MdreamOptions {
 
   /** Override tag rendering behavior. String values act as aliases. */
   tagOverrides?: Record<string, TagOverride | string>
+
+  /**
+   * Hard-wrap prose at this many characters, breaking on word boundaries.
+   * Applied inline during conversion (zero-cost when unset). Code blocks,
+   * tables, and headings are never wrapped. `0` (or unset) disables wrapping.
+   */
+  wrapWidth?: number
 }
 ```
 
@@ -230,6 +237,13 @@ interface EngineOptions {
   origin?: string
   clean?: boolean | CleanOptions
   plugins?: BuiltinPlugins
+
+  /**
+   * Hard-wrap prose at this many characters, breaking on word boundaries.
+   * Code blocks, tables, and headings are never wrapped. `0` (or unset)
+   * disables wrapping.
+   */
+  wrapWidth?: number
 }
 
 interface BuiltinPlugins {
@@ -872,6 +886,7 @@ cat index.html \
 |--------|-------------|
 | `--origin <url>` | Base URL for resolving relative links and images |
 | `--preset minimal` | Enable the minimal preset |
+| `--wrap-width <n>` | Hard-wrap prose at `n` characters (code, tables, and headings are never wrapped) |
 | `-h`, `--help` | Display help information |
 
 The CLI reads HTML from stdin and writes Markdown to stdout. It uses the streaming API internally.

--- a/packages/mdream/bin/mdream.mjs
+++ b/packages/mdream/bin/mdream.mjs
@@ -5,6 +5,7 @@ import { streamHtmlToMarkdown } from 'mdream'
 const args = process.argv.slice(2)
 let origin
 let preset
+let wrapWidth
 for (let i = 0; i < args.length; i++) {
   if (args[i] === '--origin' && args[i + 1]) {
     origin = args[++i]
@@ -12,13 +13,16 @@ for (let i = 0; i < args.length; i++) {
   else if (args[i] === '--preset' && args[i + 1]) {
     preset = args[++i]
   }
+  else if (args[i] === '--wrap-width' && args[i + 1]) {
+    wrapWidth = Number.parseInt(args[++i], 10) || undefined
+  }
   else if (args[i] === '-h' || args[i] === '--help') {
-    process.stdout.write('Usage: mdream [--origin <url>] [--preset minimal]\nPipe HTML via stdin, outputs Markdown to stdout.\n')
+    process.stdout.write('Usage: mdream [--origin <url>] [--preset minimal] [--wrap-width <n>]\nPipe HTML via stdin, outputs Markdown to stdout.\n')
     process.exit(0)
   }
 }
 
-const options = { origin, minimal: preset === 'minimal' }
+const options = { origin, minimal: preset === 'minimal', wrapWidth }
 const stream = Readable.toWeb(process.stdin)
 for await (const chunk of streamHtmlToMarkdown(stream, options)) {
   if (chunk?.length)

--- a/packages/mdream/src/index.ts
+++ b/packages/mdream/src/index.ts
@@ -72,6 +72,12 @@ export interface MdreamOptions {
   extraction?: Record<string, (element: ExtractedElement) => void>
   /** Tag overrides. String values act as aliases */
   tagOverrides?: Record<string, TagOverride | string>
+  /**
+   * Hard-wrap prose at this many characters, breaking on word boundaries.
+   * Applied inline during conversion (zero-cost when unset). Code blocks,
+   * tables, and headings are never wrapped. `0` disables wrapping.
+   */
+  wrapWidth?: number
 }
 
 const MINIMAL_FILTER_EXCLUDE = ['form', 'fieldset', 'object', 'embed', 'footer', 'aside', 'iframe', 'input', 'textarea', 'select', 'button', 'nav'] as const
@@ -145,7 +151,7 @@ function resolveOptions(options: Partial<MdreamOptions>): ResolvedOptions {
   const { cleanUrls, clean } = resolveCleanConfig(options, minimal)
 
   return {
-    napiOpts: { origin: options.origin, cleanUrls, clean, plugins },
+    napiOpts: { origin: options.origin, cleanUrls, clean, plugins, wrapWidth: options.wrapWidth },
     extractionHandlers,
     frontmatterCallback,
   }


### PR DESCRIPTION
### 🔗 Linked issue

Closes #106

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Adds a `wrapWidth` option that hard-wraps prose at a character width on word boundaries, for generating output aimed at plain-text editors (#106). It runs inline during conversion rather than as a second pass, so it costs nothing when unset (a single integer compare gates the whole path) and works under streaming. Code blocks (`<pre>`/`<code>`), tables, and headings are never wrapped; blockquote and list continuations keep their `> ` prefix / marker-width indent. Words are never split, so an oversized token (e.g. a URL) overflows rather than breaking.

Wired through every layer: the Rust core (`HTMLToMarkdownOptions.wrap_width`), the pure-JS engine, the NAPI bindings, the `mdream` wrapper, and both CLIs (`--wrap-width <n>`).

Behavior was fact-checked against Python `html2text` (`body_width`), the de-facto reference for width wrapping. We match it on word boundaries, no long-word splitting, skipping code/tables, and blockquote/list continuation indents. Intentional divergences: wrapping is opt-in (no default 78) to keep the hot path free; headings are not wrapped (html2text can split them); list items are wrapped with correct CommonMark continuation indent (html2text skips them by default).

Tested: Rust core suite (incl. 8 new wrap tests), `packages/js` suite (incl. 7 new wrap tests covering streaming), full `mdream` package suite, and an end-to-end check through the rebuilt native module. All green; typechecks clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable hard-wrapping of prose during conversion via a new wrapWidth option (exposed as CLI flag --wrap-width and in JS/Node/WASM options). Wrapping breaks on word boundaries, is disabled by default and when set to 0, skips code blocks/tables/headings, and preserves correct list/blockquote continuation prefixes. Streaming conversion honors the setting.

* **Tests**
  * Added comprehensive tests covering wrap behavior, edge cases, nested structures, and streaming parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->