### PR TITLE
fix: auto-close unclosed `<head>` on body content

### DIFF
--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -2,6 +2,17 @@
 
 use super::*;
 
+/// Tags valid inside `<head>` per the HTML parser's "in head" insertion mode.
+/// Any other start tag implies the end of `<head>` and the start of the body, so
+/// an unclosed head is auto-closed when one appears. Unknown tags (`None`) are
+/// treated as body content, matching the spec's "anything else" rule.
+fn is_head_content_tag(tag_id: Option<u8>) -> bool {
+    matches!(
+        tag_id,
+        Some(TAG_HEAD | TAG_TITLE | TAG_META | TAG_LINK | TAG_BASE | TAG_STYLE | TAG_SCRIPT | TAG_NOSCRIPT | TAG_TEMPLATE)
+    )
+}
+
 /// Whether an element is visually hidden, so the filter should drop it and its
 /// subtree: inline `display:none` / `visibility:hidden` / `position:absolute|fixed`,
 /// or the `hidden` attribute (except `hidden="until-found"`).
@@ -141,6 +152,19 @@ impl ConvertState {
                 complete: false, new_position: position,
                 self_closing: false, skip: false,
             };
+        }
+
+        // Browser recovery: a non-head start tag while <head> is still open means the
+        // page never closed its head (no </head>/<body>). Auto-close head (and anything
+        // wrongly opened inside it) so body content parses as flow content with normal
+        // block spacing instead of inheriting head's whitespace collapsing.
+        if self.depth_map[TAG_HEAD as usize] > 0 && !is_head_content_tag(tag_id) {
+            while self.stack.last().is_some_and(|n| n.tag_id != Some(TAG_HEAD)) {
+                self.close_node();
+            }
+            if self.stack.last().is_some_and(|n| n.tag_id == Some(TAG_HEAD)) {
+                self.close_node();
+            }
         }
 
         if let Some(id) = tag_id {

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -5,11 +5,14 @@ use super::*;
 /// Tags valid inside `<head>` per the HTML parser's "in head" insertion mode.
 /// Any other start tag implies the end of `<head>` and the start of the body, so
 /// an unclosed head is auto-closed when one appears. Unknown tags (`None`) are
-/// treated as body content, matching the spec's "anything else" rule.
+/// treated as body content, matching the spec's "anything else" rule. `<head>` is
+/// deliberately excluded: a second/nested head must close the first rather than
+/// stack, so malformed `<head><head>...<p>` does not trap body flow under an
+/// outer head.
 fn is_head_content_tag(tag_id: Option<u8>) -> bool {
     matches!(
         tag_id,
-        Some(TAG_HEAD | TAG_TITLE | TAG_META | TAG_LINK | TAG_BASE | TAG_STYLE | TAG_SCRIPT | TAG_NOSCRIPT | TAG_TEMPLATE)
+        Some(TAG_TITLE | TAG_META | TAG_LINK | TAG_BASE | TAG_STYLE | TAG_SCRIPT | TAG_NOSCRIPT | TAG_TEMPLATE)
     )
 }
 

--- a/crates/core/tests/head_autoclose.rs
+++ b/crates/core/tests/head_autoclose.rs
@@ -1,0 +1,24 @@
+//! Browser recovery: an unclosed <head> (no </head>/<body>) must not swallow body
+//! content. Body-level start tags auto-close head so block spacing is preserved.
+//! Regression for marketingexamples.com pages collapsing to a single line.
+use mdream::{html_to_markdown, types::HTMLToMarkdownOptions};
+
+fn convert(html: &str) -> String {
+    html_to_markdown(html, HTMLToMarkdownOptions::default())
+}
+
+#[test]
+fn unclosed_head_produces_same_output_as_well_formed() {
+    // Identical body content; one page forgets </head> and <body>.
+    let broken = "<html><head><title>t</title><meta charset=\"utf-8\"><div><h1>Title</h1><p>para one</p><h2>Heading</h2><p>para two</p></div></html>";
+    let well_formed = "<html><head><title>t</title><meta charset=\"utf-8\"></head><body><div><h1>Title</h1><p>para one</p><h2>Heading</h2><p>para two</p></div></body></html>";
+    assert_eq!(convert(broken), convert(well_formed));
+    assert!(convert(broken).contains("# Title\n\npara one\n\n## Heading\n\npara two"));
+}
+
+#[test]
+fn head_metadata_stays_in_head_until_flow_content() {
+    // title/link/style/script are head content; the first flow tag closes head.
+    let html = "<head><title>t</title><link rel=\"x\"><style>a{}</style><p>body text</p>";
+    assert_eq!(convert(html), "t\n\nbody text");
+}

--- a/crates/core/tests/head_autoclose.rs
+++ b/crates/core/tests/head_autoclose.rs
@@ -22,3 +22,11 @@ fn head_metadata_stays_in_head_until_flow_content() {
     let html = "<head><title>t</title><link rel=\"x\"><style>a{}</style><p>body text</p>";
     assert_eq!(convert(html), "t\n\nbody text");
 }
+
+#[test]
+fn duplicated_head_does_not_keep_body_in_head_context() {
+    // A second <head> closes the first (head is not head-content), so the trailing
+    // <p> is body flow rather than collapsed head content.
+    let html = "<head><head><title>t</title><p>body text</p>";
+    assert_eq!(convert(html), "t\n\nbody text");
+}

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -771,12 +771,13 @@ function processOpeningTag(
   // page never closed its head (no </head>/<body>). Auto-close head (and anything
   // wrongly opened inside it) so body content is parsed as flow content with
   // normal block spacing, instead of inheriting head's whitespace collapsing.
-  if (state.depthMap[TAG_HEAD] > 0 && !HEAD_CONTENT_TAGS.has(tagId)) {
+  if ((state.depthMap[TAG_HEAD] || 0) > 0 && !HEAD_CONTENT_TAGS.has(tagId)) {
     while (state.currentNode && state.currentNode.tagId !== TAG_HEAD) {
       closeNode(state.currentNode, state, handleEvent)
     }
-    if (state.currentNode?.tagId === TAG_HEAD) {
-      closeNode(state.currentNode, state, handleEvent)
+    const headNode = state.currentNode
+    if (headNode && headNode.tagId === TAG_HEAD) {
+      closeNode(headNode, state, handleEvent)
     }
   }
 

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -47,9 +47,10 @@ const CLOSE_BRACKET_CHAR = 93 // ']'
 // Tags that are valid inside <head>. Per the HTML parser's "in head" insertion
 // mode, any start tag NOT in this set implies the end of <head> and the start of
 // the body, so we auto-close an unclosed <head> when one appears (browser
-// recovery for malformed pages that never emit </head> or <body>).
+// recovery for malformed pages that never emit </head> or <body>). TAG_HEAD is
+// deliberately excluded: a second/nested <head> must close the first rather than
+// stack, so malformed `<head><head>...<p>` does not trap body flow under head.
 const HEAD_CONTENT_TAGS = new Set<number>([
-  TAG_HEAD,
   TAG_TITLE,
   TAG_META,
   TAG_LINK,

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -5,12 +5,19 @@ import {
   NodeEventEnter,
   NodeEventExit,
   TAG_A,
+  TAG_BASE,
   TAG_BLOCKQUOTE,
   TAG_CODE,
+  TAG_HEAD,
+  TAG_LINK,
+  TAG_META,
+  TAG_NOSCRIPT,
   TAG_PRE,
   TAG_SCRIPT,
   TAG_STYLE,
   TAG_TABLE,
+  TAG_TEMPLATE,
+  TAG_TITLE,
   TagIdMap,
   TEXT_NODE,
 } from './const'
@@ -36,6 +43,22 @@ const BACKTICK_CHAR = 96 // '`'
 const PIPE_CHAR = 124 // '|'
 const OPEN_BRACKET_CHAR = 91 // '['
 const CLOSE_BRACKET_CHAR = 93 // ']'
+
+// Tags that are valid inside <head>. Per the HTML parser's "in head" insertion
+// mode, any start tag NOT in this set implies the end of <head> and the start of
+// the body, so we auto-close an unclosed <head> when one appears (browser
+// recovery for malformed pages that never emit </head> or <body>).
+const HEAD_CONTENT_TAGS = new Set<number>([
+  TAG_HEAD,
+  TAG_TITLE,
+  TAG_META,
+  TAG_LINK,
+  TAG_BASE,
+  TAG_STYLE,
+  TAG_SCRIPT,
+  TAG_NOSCRIPT,
+  TAG_TEMPLATE,
+])
 
 // Pre-allocate arrays and objects to reduce allocations
 const EMPTY_ATTRIBUTES: Record<string, string> = Object.freeze({})
@@ -741,6 +764,19 @@ function processOpeningTag(
   // Check if current element needs closing
   if (state.currentNode?.tagHandler?.isNonNesting) {
     closeNode(state.currentNode, state, handleEvent)
+  }
+
+  // Browser recovery: a non-head start tag while <head> is still open means the
+  // page never closed its head (no </head>/<body>). Auto-close head (and anything
+  // wrongly opened inside it) so body content is parsed as flow content with
+  // normal block spacing, instead of inheriting head's whitespace collapsing.
+  if (state.depthMap[TAG_HEAD] > 0 && !HEAD_CONTENT_TAGS.has(tagId)) {
+    while (state.currentNode && state.currentNode.tagId !== TAG_HEAD) {
+      closeNode(state.currentNode, state, handleEvent)
+    }
+    if (state.currentNode?.tagId === TAG_HEAD) {
+      closeNode(state.currentNode, state, handleEvent)
+    }
   }
 
   const tagHandler = state.tagOverrideHandlers?.get(tagName) ?? tagHandlers[tagId]

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -767,20 +767,6 @@ function processOpeningTag(
     closeNode(state.currentNode, state, handleEvent)
   }
 
-  // Browser recovery: a non-head start tag while <head> is still open means the
-  // page never closed its head (no </head>/<body>). Auto-close head (and anything
-  // wrongly opened inside it) so body content is parsed as flow content with
-  // normal block spacing, instead of inheriting head's whitespace collapsing.
-  if ((state.depthMap[TAG_HEAD] || 0) > 0 && !HEAD_CONTENT_TAGS.has(tagId)) {
-    while (state.currentNode && state.currentNode.tagId !== TAG_HEAD) {
-      closeNode(state.currentNode, state, handleEvent)
-    }
-    const headNode = state.currentNode
-    if (headNode && headNode.tagId === TAG_HEAD) {
-      closeNode(headNode, state, handleEvent)
-    }
-  }
-
   const tagHandler = state.tagOverrideHandlers?.get(tagName) ?? tagHandlers[tagId]
   const result = processTagAttributes(htmlChunk, i, tagHandler)
 
@@ -790,6 +776,22 @@ function processOpeningTag(
       newPosition: i,
       remainingText: `<${tagName}${result.attrBuffer}`,
       selfClosing: false,
+    }
+  }
+
+  // Browser recovery: a non-head start tag while <head> is still open means the
+  // page never closed its head (no </head>/<body>). Auto-close head (and anything
+  // wrongly opened inside it) so body content is parsed as flow content with
+  // normal block spacing, instead of inheriting head's whitespace collapsing.
+  // Runs only after the tag is confirmed complete so incomplete/chunk-split start
+  // tags do not mutate parser state or emit a premature head close.
+  if ((state.depthMap[TAG_HEAD] || 0) > 0 && !HEAD_CONTENT_TAGS.has(tagId)) {
+    while (state.currentNode && state.currentNode.tagId !== TAG_HEAD) {
+      closeNode(state.currentNode, state, handleEvent)
+    }
+    const headNode = state.currentNode
+    if (headNode && headNode.tagId === TAG_HEAD) {
+      closeNode(headNode, state, handleEvent)
     }
   }
 

--- a/packages/js/test/unit/head-autoclose.test.ts
+++ b/packages/js/test/unit/head-autoclose.test.ts
@@ -17,4 +17,10 @@ describe('unclosed <head> auto-close', () => {
     const html = '<head><title>t</title><link rel="x"><style>a{}</style><p>body text</p>'
     expect(htmlToMarkdown(html)).toBe('t\n\nbody text')
   })
+
+  it('does not keep body in head context for duplicated <head>', () => {
+    // A second <head> closes the first, so the trailing <p> is body flow.
+    const html = '<head><head><title>t</title><p>body text</p>'
+    expect(htmlToMarkdown(html)).toBe('t\n\nbody text')
+  })
 })

--- a/packages/js/test/unit/head-autoclose.test.ts
+++ b/packages/js/test/unit/head-autoclose.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { htmlToMarkdown } from '../../src/index'
+
+// Browser recovery: a page that never closes <head> (no </head>/<body>) parses
+// its body content inside <head>, which collapses all block spacing to a single
+// line. The parser auto-closes head on the first non-head start tag, matching the
+// HTML "in head" insertion mode. Regression for marketingexamples.com pages.
+describe('unclosed <head> auto-close', () => {
+  it('produces the same output as the well-formed equivalent', () => {
+    const broken = '<html><head><title>t</title><meta charset="utf-8"><div><h1>Title</h1><p>para one</p><h2>Heading</h2><p>para two</p></div></html>'
+    const wellFormed = '<html><head><title>t</title><meta charset="utf-8"></head><body><div><h1>Title</h1><p>para one</p><h2>Heading</h2><p>para two</p></div></body></html>'
+    expect(htmlToMarkdown(broken)).toBe(htmlToMarkdown(wellFormed))
+    expect(htmlToMarkdown(broken)).toContain('# Title\n\npara one\n\n## Heading\n\npara two')
+  })
+
+  it('keeps head metadata in head until flow content appears', () => {
+    const html = '<head><title>t</title><link rel="x"><style>a{}</style><p>body text</p>'
+    expect(htmlToMarkdown(html)).toBe('t\n\nbody text')
+  })
+})

--- a/packages/js/test/unit/head-autoclose.test.ts
+++ b/packages/js/test/unit/head-autoclose.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, it } from 'vitest'
-import { htmlToMarkdown } from '../../src/index'
+import { htmlToMarkdown, streamHtmlToMarkdown } from '../../src/index'
+
+async function streamConvert(chunks: string[]): Promise<string> {
+  const stream = new ReadableStream<string>({
+    start(controller) {
+      for (const c of chunks)
+        controller.enqueue(c)
+      controller.close()
+    },
+  })
+  let out = ''
+  for await (const chunk of streamHtmlToMarkdown(stream))
+    out += chunk
+  return out
+}
 
 // Browser recovery: a page that never closes <head> (no </head>/<body>) parses
 // its body content inside <head>, which collapses all block spacing to a single
@@ -22,5 +36,19 @@ describe('unclosed <head> auto-close', () => {
     // A second <head> closes the first, so the trailing <p> is body flow.
     const html = '<head><head><title>t</title><p>body text</p>'
     expect(htmlToMarkdown(html)).toBe('t\n\nbody text')
+  })
+
+  it('keeps <head> open across a chunk boundary that splits the triggering tag', async () => {
+    // The auto-close must run only after the start tag is confirmed complete.
+    // Splitting inside the <div ...> tag must not prematurely close head; the
+    // streamed result must match the whole-document conversion.
+    const whole = '<head><title>t</title><div class="x"><h1>Title</h1><p>body text</p></div>'
+    const streamedSplit = await streamConvert(['<head><title>t</title><div', ' class="x"><h1>Title</h1><p>body text</p></div>'])
+    const streamedWhole = await streamConvert([whole])
+    // Splitting the triggering <div> tag across chunks must not change the result.
+    expect(streamedSplit).toBe(streamedWhole)
+    // And the result is correct: head closed, block spacing preserved.
+    expect(streamedSplit.trim()).toBe(htmlToMarkdown(whole))
+    expect(streamedSplit).toContain('# Title\n\nbody text')
   })
 })


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

When a page never closes `<head>` (no `</head>` and no `<body>`, which is malformed but common in the wild), all of the body content gets parsed as children of the still-open `<head>`. Since `<head>` carries `collapses_inner_white_space`, every descendant inherits it, so the whole document is emitted as one line with zero block separators (headings, paragraphs and lists all run together).

The fix follows the HTML parser's "in head" insertion mode: a start tag that is not valid head content (`title`, `meta`, `link`, `base`, `style`, `script`, `noscript`, `template`) implies the end of head. So when such a tag opens while `<head>` is still on the stack, `process_opening_tag` (Rust) / `processOpenTag` (JS) auto-closes head and anything wrongly opened inside it before opening the new element. Unknown tags are treated as body content, matching the spec's "anything else" rule.

Applied to both parsers:
- `crates/core/src/convert/parse.rs` (`is_head_content_tag` + auto-close in `process_opening_tag`)
- `packages/js/src/parse.ts` (`HEAD_CONTENT_TAGS` + auto-close in `processOpenTag`)

Real-world repro, a `marketingexamples.com` article page (its HTML omits `</head>`/`<body>`):

| | newlines | shape |
|---|---|---|
| before | 0 | entire page on a single line |
| after | 188 | proper headings / paragraphs / lists |

### ✅ Tests

- `crates/core/tests/head_autoclose.rs`: an unclosed-head page now converts identically to its well-formed equivalent; head metadata stays in head until the first flow element.
- `packages/js/test/unit/head-autoclose.test.ts`: same coverage for the JS parser.
- Full suites green with no regressions: 296 Rust tests, 855 JS tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML-to-Markdown conversion to recover from missing or improperly nested `<head>` tags using browser-style “in head” handling
  * Prevented `<head>` metadata (e.g., `title`, `link`, `style`, `base`, `meta`) from leaking into body formatting or whitespace behavior
  * Ensured subsequent content is parsed as normal body flow after automatic head termination/recovery
* **Tests**
  * Added core and JS regression tests for unclosed/duplicated `<head>` cases, including streaming conversion consistency across chunk boundaries
<!-- end of auto-generated comment: release notes by coderabbit.ai -->