### PR TITLE
feat(crawl): strip repeated cross-page boilerplate from markdown

### DIFF
--- a/packages/crawl/src/boilerplate.ts
+++ b/packages/crawl/src/boilerplate.ts
@@ -25,25 +25,39 @@
  * removed: a span has to recur across most of the site and be long to qualify.
  */
 
+// Single source of truth for the detection defaults. Re-exported and referenced
+// (e.g. in the crawl CLI help) so the documented values cannot drift from the
+// behaviour.
+/** Fraction of documents a shingle must appear in to count as chrome (0..1). */
+export const DEFAULT_BOILERPLATE_THRESHOLD = 0.5
+/** Minimum number of documents before detection runs at all. */
+export const DEFAULT_BOILERPLATE_MIN_DOCS = 3
+/** Number of consecutive tokens per shingle. */
+export const DEFAULT_BOILERPLATE_SHINGLE_SIZE = 6
+/** Minimum length (in tokens) of a covered run before it is removed. */
+export const DEFAULT_BOILERPLATE_MIN_RUN = 12
+
 export interface BoilerplateOptions {
   /**
    * Fraction of documents a shingle must appear in to count as chrome (0..1).
-   * Higher = stricter. Default 0.5.
+   * Higher = stricter. Defaults to `DEFAULT_BOILERPLATE_THRESHOLD` (0.5).
    */
   threshold?: number
   /**
-   * Minimum number of documents before detection runs at all. Default 3.
+   * Minimum number of documents before detection runs at all.
+   * Defaults to `DEFAULT_BOILERPLATE_MIN_DOCS` (3).
    */
   minDocs?: number
   /**
    * Number of consecutive tokens per shingle. Smaller catches shorter repeated
    * spans but risks matching common phrases; larger is more conservative.
-   * Default 6.
+   * Defaults to `DEFAULT_BOILERPLATE_SHINGLE_SIZE` (6).
    */
   shingleSize?: number
   /**
    * Minimum length (in tokens) of a covered run before it is removed. Stops short
-   * incidental matches inside unique prose from being nibbled away. Default 12.
+   * incidental matches inside unique prose from being nibbled away.
+   * Defaults to `DEFAULT_BOILERPLATE_MIN_RUN` (12).
    */
   minRun?: number
 }
@@ -205,10 +219,10 @@ function stripDoc(md: string, doc: TokenizedDoc, chrome: Set<number>, k: number,
  * detected chrome, or detection skipped) are returned byte-for-byte as given.
  */
 export function stripBoilerplateFromCorpus(contents: string[], options: BoilerplateOptions = {}): string[] {
-  const threshold = options.threshold ?? 0.5
-  const minDocs = options.minDocs ?? 3
-  const k = Math.max(2, options.shingleSize ?? 6)
-  const minRun = Math.max(k, options.minRun ?? 12)
+  const threshold = options.threshold ?? DEFAULT_BOILERPLATE_THRESHOLD
+  const minDocs = options.minDocs ?? DEFAULT_BOILERPLATE_MIN_DOCS
+  const k = Math.max(2, options.shingleSize ?? DEFAULT_BOILERPLATE_SHINGLE_SIZE)
+  const minRun = Math.max(k, options.minRun ?? DEFAULT_BOILERPLATE_MIN_RUN)
 
   if (contents.length < minDocs)
     return contents.slice()

--- a/packages/crawl/src/boilerplate.ts
+++ b/packages/crawl/src/boilerplate.ts
@@ -1,0 +1,222 @@
+/**
+ * Cross-page boilerplate stripping for crawled markdown.
+ *
+ * Site chrome (top nav, footer link cards, newsletter/testimonial walls) is
+ * serialized into every page's markdown. Because a crawl holds the whole corpus,
+ * we can detect that chrome by how often it repeats and strip it before the
+ * markdown is serialized.
+ *
+ * Block-level diffing (split on blank lines) is not enough: some sites convert to
+ * a single line with no paragraph breaks at all, so there are no blocks to compare.
+ * Instead we work at the *token* level with k-gram shingling, which is independent
+ * of line structure and catches duplicated spans wherever they appear (a leading
+ * nav, a trailing footer, or a repeated band in the middle of the page).
+ *
+ * Algorithm (linear in total tokens, no pairwise document comparison):
+ *   1. Tokenize each doc into whitespace-separated tokens, keeping char offsets.
+ *   2. Hash every k consecutive tokens into a shingle (rolling FNV/imul mix).
+ *   3. Count how many docs each shingle appears in (once per doc).
+ *   4. A shingle is "chrome" when it appears in >= threshold fraction of docs.
+ *   5. Mark every token covered by a chrome shingle; remove maximal covered runs
+ *      of at least `minRun` tokens; keep the surviving spans.
+ *
+ * The threshold (how widely a span must repeat) and minRun (how long a repeated
+ * span must be) are the safety knobs that stop unique article content being
+ * removed: a span has to recur across most of the site and be long to qualify.
+ */
+
+export interface BoilerplateOptions {
+  /**
+   * Fraction of documents a shingle must appear in to count as chrome (0..1).
+   * Higher = stricter. Default 0.5.
+   */
+  threshold?: number
+  /**
+   * Minimum number of documents before detection runs at all. Default 3.
+   */
+  minDocs?: number
+  /**
+   * Number of consecutive tokens per shingle. Smaller catches shorter repeated
+   * spans but risks matching common phrases; larger is more conservative.
+   * Default 6.
+   */
+  shingleSize?: number
+  /**
+   * Minimum length (in tokens) of a covered run before it is removed. Stops short
+   * incidental matches inside unique prose from being nibbled away. Default 12.
+   */
+  minRun?: number
+}
+
+const TOKEN_RE = /\S+/g
+
+/** FNV-1a 32-bit hash of a substring of `s` in [start, end). */
+function hashToken(s: string, start: number, end: number): number {
+  let h = 0x811C9DC5
+  for (let i = start; i < end; i++) {
+    h ^= s.charCodeAt(i)
+    h = Math.imul(h, 16777619) >>> 0
+  }
+  return h >>> 0
+}
+
+interface TokenizedDoc {
+  /** Char offset of the start of each token. */
+  starts: number[]
+  /** Char offset of the end (exclusive) of each token. */
+  ends: number[]
+  /** Per-token hash. */
+  tokenHashes: number[]
+  /** Per-shingle hash; length = max(0, tokens - k + 1), or 1 for a short doc. */
+  shingleHashes: number[]
+}
+
+function tokenize(md: string, k: number): TokenizedDoc {
+  const starts: number[] = []
+  const ends: number[] = []
+  const tokenHashes: number[] = []
+  TOKEN_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  // eslint-disable-next-line no-cond-assign
+  while ((m = TOKEN_RE.exec(md)) !== null) {
+    const start = m.index
+    const end = TOKEN_RE.lastIndex
+    starts.push(start)
+    ends.push(end)
+    tokenHashes.push(hashToken(md, start, end))
+  }
+
+  const n = tokenHashes.length
+  const shingleHashes: number[] = []
+  if (n === 0) {
+    return { starts, ends, tokenHashes, shingleHashes }
+  }
+  if (n < k) {
+    // Short doc: a single shingle over all its tokens.
+    shingleHashes.push(mixHashes(tokenHashes, 0, n))
+  }
+  else {
+    for (let i = 0; i + k <= n; i++)
+      shingleHashes.push(mixHashes(tokenHashes, i, i + k))
+  }
+  return { starts, ends, tokenHashes, shingleHashes }
+}
+
+/** Combine token hashes [from, to) into a single shingle hash. */
+function mixHashes(tokenHashes: number[], from: number, to: number): number {
+  let h = 0x811C9DC5
+  for (let i = from; i < to; i++) {
+    h ^= tokenHashes[i]
+    h = Math.imul(h, 16777619) >>> 0
+  }
+  return h >>> 0
+}
+
+function detectChromeShingles(docs: TokenizedDoc[], threshold: number): Set<number> {
+  const counts = new Map<number, number>()
+  for (let d = 0; d < docs.length; d++) {
+    const shingles = docs[d].shingleHashes
+    const seen = new Set<number>()
+    for (let i = 0; i < shingles.length; i++) {
+      const h = shingles[i]
+      if (seen.has(h))
+        continue
+      seen.add(h)
+      counts.set(h, (counts.get(h) ?? 0) + 1)
+    }
+  }
+  const minCount = Math.max(2, Math.ceil(threshold * docs.length))
+  const chrome = new Set<number>()
+  for (const [h, c] of counts) {
+    if (c >= minCount)
+      chrome.add(h)
+  }
+  return chrome
+}
+
+function stripDoc(md: string, doc: TokenizedDoc, chrome: Set<number>, k: number, minRun: number): string {
+  const n = doc.tokenHashes.length
+  if (n === 0)
+    return md
+
+  // Mark every token covered by a chrome shingle.
+  const covered = new Uint8Array(n)
+  const shingles = doc.shingleHashes
+  if (n < k) {
+    if (shingles.length === 1 && chrome.has(shingles[0]))
+      covered.fill(1)
+  }
+  else {
+    for (let i = 0; i < shingles.length; i++) {
+      if (chrome.has(shingles[i])) {
+        for (let j = i; j < i + k; j++)
+          covered[j] = 1
+      }
+    }
+  }
+
+  // Build the set of surviving token spans by dropping covered runs >= minRun.
+  const keptRanges: [number, number][] = [] // [startTokenIdx, endTokenIdx) inclusive-exclusive
+  let runStart = 0
+  let i = 0
+  while (i < n) {
+    if (!covered[i]) {
+      i++
+      continue
+    }
+    // Start of a covered run.
+    let j = i
+    while (j < n && covered[j])
+      j++
+    const runLen = j - i
+    if (runLen >= minRun) {
+      // Flush the surviving span before this run.
+      if (i > runStart)
+        keptRanges.push([runStart, i])
+      runStart = j
+    }
+    // Short covered run: treat as content, leave it in place.
+    i = j
+  }
+  if (runStart < n)
+    keptRanges.push([runStart, n])
+
+  // Nothing removed: preserve the original bytes exactly.
+  if (keptRanges.length === 1 && keptRanges[0][0] === 0 && keptRanges[0][1] === n)
+    return md
+
+  // Everything removed: keep the original rather than emit an empty file.
+  if (keptRanges.length === 0)
+    return md
+
+  // Reconstruct from surviving spans, preserving each span's internal formatting
+  // (whitespace/newlines), joining separated spans with a blank line.
+  const pieces: string[] = []
+  for (const [s, e] of keptRanges)
+    pieces.push(md.slice(doc.starts[s], doc.ends[e - 1]).trim())
+
+  return pieces.filter(Boolean).join('\n\n')
+}
+
+/**
+ * Strip repeated cross-page boilerplate from a corpus of markdown documents.
+ *
+ * Returns a new array aligned with `contents`. Documents that are unchanged (no
+ * detected chrome, or detection skipped) are returned byte-for-byte as given.
+ */
+export function stripBoilerplateFromCorpus(contents: string[], options: BoilerplateOptions = {}): string[] {
+  const threshold = options.threshold ?? 0.5
+  const minDocs = options.minDocs ?? 3
+  const k = Math.max(2, options.shingleSize ?? 6)
+  const minRun = Math.max(k, options.minRun ?? 12)
+
+  if (contents.length < minDocs)
+    return contents.slice()
+
+  const docs = contents.map(md => tokenize(md, k))
+  const chrome = detectChromeShingles(docs, threshold)
+  if (chrome.size === 0)
+    return contents.slice()
+
+  return contents.map((md, idx) => stripDoc(md, docs[idx], chrome, k, minRun))
+}

--- a/packages/crawl/src/cli.ts
+++ b/packages/crawl/src/cli.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url'
 import * as p from '@clack/prompts'
 import { dirname, join, relative, resolve } from 'pathe'
 import { withHttps } from 'ufo'
+import { DEFAULT_BOILERPLATE_THRESHOLD } from './boilerplate.js'
 import { loadMdreamConfig } from './config.js'
 import { crawlAndGenerate } from './crawl.js'
 import { parseUrlPattern, validateGlobPattern } from './glob-utils.js'
@@ -290,7 +291,7 @@ Options:
   --skip-sitemap              Skip sitemap.xml and robots.txt discovery
   --allow-subdomains          Crawl across subdomains of the same root domain
   --keep-boilerplate          Keep repeated site chrome (nav/footer) in per-page output (default: stripped)
-  --boilerplate-threshold <n> Fraction of pages a block must repeat in to count as chrome (0-1, default: 0.6)
+  --boilerplate-threshold <n> Fraction of pages a block must repeat in to count as chrome (0-1, default: ${DEFAULT_BOILERPLATE_THRESHOLD})
   -v, --verbose               Enable verbose logging
   -q, --quiet, --silent       Suppress all logs (clean stdout for JSON-RPC/MCP)
   -h, --help                  Show this help message

--- a/packages/crawl/src/cli.ts
+++ b/packages/crawl/src/cli.ts
@@ -289,6 +289,8 @@ Options:
   --exclude <pattern>         Exclude URLs matching glob patterns (can be used multiple times)
   --skip-sitemap              Skip sitemap.xml and robots.txt discovery
   --allow-subdomains          Crawl across subdomains of the same root domain
+  --keep-boilerplate          Keep repeated site chrome (nav/footer) in per-page output (default: stripped)
+  --boilerplate-threshold <n> Fraction of pages a block must repeat in to count as chrome (0-1, default: 0.6)
   -v, --verbose               Enable verbose logging
   -q, --quiet, --silent       Suppress all logs (clean stdout for JSON-RPC/MCP)
   -h, --help                  Show this help message
@@ -462,6 +464,21 @@ Examples:
   // Check for allow-subdomains flag
   const allowSubdomains = args.includes('--allow-subdomains')
 
+  // Boilerplate stripping is on by default; --keep-boilerplate opts out. Left
+  // undefined unless explicitly opted out, so a config-file value can still apply.
+  const stripBoilerplate = args.includes('--keep-boilerplate') ? false : undefined
+
+  // Validate boilerplate threshold
+  const boilerplateThresholdStr = getArgValue('--boilerplate-threshold')
+  let boilerplateThreshold: number | undefined
+  if (boilerplateThresholdStr !== undefined) {
+    boilerplateThreshold = Number(boilerplateThresholdStr)
+    if (Number.isNaN(boilerplateThreshold) || boilerplateThreshold <= 0 || boilerplateThreshold > 1) {
+      logger.error('Error: Boilerplate threshold must be a number between 0 (exclusive) and 1')
+      process.exit(1)
+    }
+  }
+
   // Warn if using skip-sitemap with wildcard URLs
   if (skipSitemap && parsed.isGlob) {
     logger.warn('Warning: Using --skip-sitemap with glob URLs may not discover all matching pages.')
@@ -486,6 +503,8 @@ Examples:
     verbose,
     skipSitemap,
     allowSubdomains,
+    stripBoilerplate,
+    boilerplateThreshold,
     silent,
   }
 }
@@ -519,6 +538,8 @@ async function main() {
       crawlDelay: cliOptions.crawlDelay ?? fileConfig.crawlDelay,
       skipSitemap: cliOptions.skipSitemap || fileConfig.skipSitemap || false,
       allowSubdomains: cliOptions.allowSubdomains || fileConfig.allowSubdomains || false,
+      stripBoilerplate: cliOptions.stripBoilerplate ?? fileConfig.stripBoilerplate ?? true,
+      boilerplateThreshold: cliOptions.boilerplateThreshold ?? fileConfig.boilerplateThreshold,
       verbose: cliOptions.verbose || fileConfig.verbose || false,
       silent,
       exclude: configExclude.length > 0 || cliExclude.length > 0

--- a/packages/crawl/src/crawl.ts
+++ b/packages/crawl/src/crawl.ts
@@ -9,6 +9,7 @@ import { htmlToMarkdown } from 'mdream'
 import { ofetch } from 'ofetch'
 import { dirname, join, normalize, resolve } from 'pathe'
 import { withHttps } from 'ufo'
+import { stripBoilerplateFromCorpus } from './boilerplate.js'
 import { getRegistrableDomain, getStartingUrl, isUrlExcluded, isValidSitemapXml, matchesGlobPattern, parseUrlPattern } from './glob-utils.js'
 import { resolveLogger } from './logger.js'
 
@@ -292,6 +293,8 @@ export async function crawlAndGenerate(options: CrawlOptions, onProgress?: (prog
     verbose = false,
     skipSitemap = false,
     allowSubdomains = false,
+    stripBoilerplate = true,
+    boilerplateThreshold,
     hooks: hooksConfig,
     onPage,
   } = options
@@ -620,19 +623,9 @@ export async function crawlAndGenerate(options: CrawlOptions, onProgress?: (prog
       const safeFilename = normalize(`${filename}.md`)
 
       filePath = join(outputDir, safeFilename)
-
-      // Call crawl:content hook before writing
-      const contentCtx = { url, title, content: md, filePath }
-      await hooks.callHook('crawl:content', contentCtx)
-      md = contentCtx.content
-      filePath = contentCtx.filePath
-
-      const fileDir = dirname(filePath)
-      if (fileDir && !createdDirs.has(fileDir)) {
-        await mkdir(fileDir, { recursive: true })
-        createdDirs.add(fileDir)
-      }
-      await writeFile(filePath, md, 'utf-8')
+      // The crawl:content hook and the file write are deferred until after the
+      // crawl completes (see the generation block below), so cross-page
+      // boilerplate can be stripped from the whole corpus before serialization.
     }
 
     const isHomePage = parsedUrl.pathname === '/' && parsedUrl.origin === normalizedHomePageUrl
@@ -891,6 +884,41 @@ export async function crawlAndGenerate(options: CrawlOptions, onProgress?: (prog
     onProgress?.(progress)
 
     const successfulResults = results.filter(r => r.success)
+
+    // Strip repeated site chrome from the corpus before anything is serialized.
+    // This is a post-processing pass over the generated markdown: spans that repeat
+    // across pages are detected and removed. Needs a corpus, so single-page crawls
+    // are left as-is. result.content is mutated in place so both the per-page .md
+    // files and the llms-full.txt page sections use the cleaned content. The
+    // llms.txt link index is unaffected (it is built from metadata, not content).
+    if (stripBoilerplate && !singlePageMode) {
+      const cleaned = stripBoilerplateFromCorpus(
+        successfulResults.map(r => r.content),
+        boilerplateThreshold !== undefined ? { threshold: boilerplateThreshold } : {},
+      )
+      for (let i = 0; i < successfulResults.length; i++)
+        successfulResults[i].content = cleaned[i]
+    }
+
+    // Write per-page markdown now that content is finalized. The crawl:content
+    // hook fires here (deferred from processPage) so it sees the stripped content.
+    if (generateIndividualMd) {
+      for (const result of successfulResults) {
+        if (!result.filePath)
+          continue
+        const contentCtx = { url: result.url, title: result.title, content: result.content, filePath: result.filePath }
+        await hooks.callHook('crawl:content', contentCtx)
+        result.content = contentCtx.content
+        result.filePath = contentCtx.filePath
+
+        const fileDir = dirname(result.filePath)
+        if (fileDir && !createdDirs.has(fileDir)) {
+          await mkdir(fileDir, { recursive: true })
+          createdDirs.add(fileDir)
+        }
+        await writeFile(result.filePath, result.content, 'utf-8')
+      }
+    }
 
     const firstUrl = new URL(withHttps(urls[0]))
     const originUrl = firstUrl.origin

--- a/packages/crawl/src/index.ts
+++ b/packages/crawl/src/index.ts
@@ -1,3 +1,5 @@
+export type { BoilerplateOptions } from './boilerplate.js'
+export { stripBoilerplateFromCorpus } from './boilerplate.js'
 export { crawlAndGenerate } from './crawl.js'
 export { createClackLogger, resolveLogger, silentLogger } from './logger.js'
 export type { CrawlLogger, CrawlSpinner } from './logger.js'

--- a/packages/crawl/src/types.ts
+++ b/packages/crawl/src/types.ts
@@ -38,6 +38,21 @@ export interface CrawlOptions {
   skipSitemap?: boolean
   allowSubdomains?: boolean
   /**
+   * Strip repeated site chrome (top nav, footer, newsletter walls) from per-page
+   * markdown and llms-full.txt page sections. Implemented as a post-processing
+   * pass over the generated markdown: blocks that repeat across the corpus are
+   * detected by frequency and removed only from the wrapping (leading/trailing)
+   * run of each page, so a page's main content is preserved. Does not affect the
+   * llms.txt link index. Defaults to true. Needs a corpus (>= 3 pages) to run, so
+   * single-page crawls are left unchanged.
+   */
+  stripBoilerplate?: boolean
+  /**
+   * Fraction of crawled pages a block must appear in to count as chrome (0..1).
+   * Higher is stricter. Defaults to 0.6.
+   */
+  boilerplateThreshold?: number
+  /**
    * Suppress all diagnostic/progress logging. Use when stdout must stay clean,
    * e.g. an MCP server that only emits JSON-RPC (issue #100). Ignored when an
    * explicit `logger` is provided.
@@ -60,6 +75,10 @@ export interface MdreamCrawlConfig {
   crawlDelay?: number
   skipSitemap?: boolean
   allowSubdomains?: boolean
+  /** Strip repeated site chrome from per-page output. Defaults to true. */
+  stripBoilerplate?: boolean
+  /** Fraction of pages a block must repeat in to count as chrome (0..1). Defaults to 0.6. */
+  boilerplateThreshold?: number
   verbose?: boolean
   /** Suppress all diagnostic/progress logging (issue #100). */
   silent?: boolean

--- a/packages/crawl/src/types.ts
+++ b/packages/crawl/src/types.ts
@@ -49,7 +49,7 @@ export interface CrawlOptions {
   stripBoilerplate?: boolean
   /**
    * Fraction of crawled pages a block must appear in to count as chrome (0..1).
-   * Higher is stricter. Defaults to 0.6.
+   * Higher is stricter. Defaults to `DEFAULT_BOILERPLATE_THRESHOLD` (0.5).
    */
   boilerplateThreshold?: number
   /**
@@ -77,7 +77,7 @@ export interface MdreamCrawlConfig {
   allowSubdomains?: boolean
   /** Strip repeated site chrome from per-page output. Defaults to true. */
   stripBoilerplate?: boolean
-  /** Fraction of pages a block must repeat in to count as chrome (0..1). Defaults to 0.6. */
+  /** Fraction of pages a block must repeat in to count as chrome (0..1). Defaults to 0.5. */
   boilerplateThreshold?: number
   verbose?: boolean
   /** Suppress all diagnostic/progress logging (issue #100). */

--- a/packages/crawl/test/unit/boilerplate-crawl.test.ts
+++ b/packages/crawl/test/unit/boilerplate-crawl.test.ts
@@ -1,0 +1,134 @@
+import { readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// A small multi-page fixture site that wraps every page in identical chrome:
+// a top nav and a footer "testimonial wall". Each page has a unique <main> body.
+const SHARED_HEADER = '<header><nav>Home About Blog Products Pricing Customers Docs Support Careers Press Community Login Signup Contact <a href="https://site.test/cta">CTA</a> <a href="https://site.test/tips">Tips</a> <a href="https://site.test/guide">Guide</a></nav></header>'
+const SHARED_FOOTER = '<footer><p>Subscribe to our newsletter and join ten thousand happy marketers for weekly growth tips.</p><p>"Best resource ever" said Alice from Acme.</p><p>"Changed my career" said Bob from Globex.</p><p>Copyright 2024 Marketing Examples all rights reserved worldwide.</p></footer>'
+
+function htmlPage(title: string, main: string): string {
+  return `<!doctype html><html><head><title>${title}</title></head><body>${SHARED_HEADER}<main>${main}</main>${SHARED_FOOTER}</body></html>`
+}
+
+// Bodies are unique per page, including their trailing words, so the tiny-corpus
+// k-gram boundary effect does not nibble the last real word before the footer.
+const BODIES: Record<string, { title: string, main: string }> = {
+  '': { title: 'Home', main: '<h1>Welcome</h1><p>Welcome to the homepage overview today.</p>' },
+  '/cta': { title: 'CTA', main: '<h1>Call To Action</h1><p>Short unique cta content lives here.</p>' },
+  '/tips': { title: 'Tips', main: '<h1>Tips</h1><p>A paragraph of tips written down.</p><p>Another distinct tip writeup section.</p>' },
+  '/guide': { title: 'Guide', main: '<h1>Guide</h1><p>Guide paragraph one is long and detailed enough.</p><p>Guide paragraph two continues the explanation further.</p><p>Guide paragraph three wraps it up nicely overall.</p>' },
+}
+
+const fetchedUrls: string[] = []
+
+vi.mock('ofetch', () => {
+  const mockOfetch = Object.assign(
+    async () => '',
+    {
+      raw: async (url: string) => {
+        fetchedUrls.push(url)
+        const path = url.replace('https://site.test', '')
+        const entry = BODIES[path] ?? BODIES['']
+        return {
+          _data: htmlPage(entry.title, entry.main),
+          headers: new Headers({ 'content-type': 'text/html' }),
+        }
+      },
+    },
+  )
+  return { ofetch: mockOfetch }
+})
+
+vi.mock('@clack/prompts', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), success: vi.fn() },
+  note: vi.fn(),
+  intro: vi.fn(),
+  outro: vi.fn(),
+  spinner: () => ({ start: vi.fn(), stop: vi.fn(), message: vi.fn() }),
+}))
+
+// Real htmlToMarkdown + real llms-txt generation (packages are built).
+const { crawlAndGenerate } = await import('../../src/crawl.ts')
+
+function tmpOut(): string {
+  return join(tmpdir(), `mdream-boilerplate-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+}
+
+afterEach(() => {
+  fetchedUrls.length = 0
+})
+
+describe('boilerplate stripping across a crawled corpus', () => {
+  it('removes shared nav/footer chrome from per-page markdown while keeping bodies and the link index', async () => {
+    const outputDir = tmpOut()
+
+    await crawlAndGenerate({
+      urls: ['https://site.test'],
+      outputDir,
+      maxDepth: 1,
+      followLinks: true,
+      skipSitemap: true,
+      generateLlmsTxt: true,
+      generateLlmsFullTxt: true,
+      generateIndividualMd: true,
+      silent: true,
+    })
+
+    const cta = await readFile(join(outputDir, 'cta.md'), 'utf-8')
+    const tips = await readFile(join(outputDir, 'tips.md'), 'utf-8')
+    const guide = await readFile(join(outputDir, 'guide.md'), 'utf-8')
+    const index = await readFile(join(outputDir, 'index.md'), 'utf-8')
+
+    // Chrome is gone from every per-page file.
+    for (const md of [cta, tips, guide, index]) {
+      expect(md).not.toContain('Subscribe to our newsletter')
+      expect(md).not.toContain('Best resource ever')
+      expect(md).not.toContain('Changed my career')
+      expect(md).not.toContain('Copyright 2024 Marketing Examples')
+      // The nav link list is repeated chrome too.
+      expect(md).not.toContain('Products Pricing Customers')
+    }
+
+    // Bodies survive.
+    expect(cta).toContain('Short unique cta content lives here.')
+    expect(tips).toContain('A paragraph of tips written down.')
+    expect(tips).toContain('Another distinct tip writeup section.')
+    expect(guide).toContain('Guide paragraph one is long and detailed enough.')
+    expect(guide).toContain('Guide paragraph two continues the explanation further.')
+    expect(guide).toContain('Guide paragraph three wraps it up nicely overall.')
+    expect(index).toContain('Welcome to the homepage overview today.')
+
+    // llms.txt still lists every discovered page (link index is unaffected).
+    const llmsTxt = await readFile(join(outputDir, 'llms.txt'), 'utf-8')
+    expect(llmsTxt).toContain('index.md')
+    expect(llmsTxt).toContain('cta.md')
+    expect(llmsTxt).toContain('tips.md')
+    expect(llmsTxt).toContain('guide.md')
+
+    // llms-full.txt page sections are also stripped.
+    const llmsFull = await readFile(join(outputDir, 'llms-full.txt'), 'utf-8')
+    expect(llmsFull).not.toContain('Subscribe to our newsletter')
+    expect(llmsFull).toContain('Short unique cta content lives here.')
+  })
+
+  it('keeps chrome when stripBoilerplate is disabled', async () => {
+    const outputDir = tmpOut()
+
+    await crawlAndGenerate({
+      urls: ['https://site.test'],
+      outputDir,
+      maxDepth: 1,
+      followLinks: true,
+      skipSitemap: true,
+      generateIndividualMd: true,
+      stripBoilerplate: false,
+      silent: true,
+    })
+
+    const cta = await readFile(join(outputDir, 'cta.md'), 'utf-8')
+    expect(cta).toContain('Subscribe to our newsletter')
+    expect(cta).toContain('Short unique cta content lives here.')
+  })
+})

--- a/packages/crawl/test/unit/boilerplate.test.ts
+++ b/packages/crawl/test/unit/boilerplate.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import { stripBoilerplateFromCorpus } from '../../src/boilerplate.ts'
+
+// Long shared chrome that wraps every page (>= the default minRun of 12 tokens).
+const NAV = 'Home About Blog Products Pricing Contact Login Sign-up Docs Support Careers Press Community'
+const FOOTER = 'Subscribe to our newsletter and join ten thousand happy marketers for weekly growth tips and tricks'
+
+function page(body: string): string {
+  return `${NAV} ${body} ${FOOTER}`
+}
+
+describe('stripBoilerplateFromCorpus (token shingles)', () => {
+  it('strips repeated nav/footer chrome shared across pages, keeps the unique body', () => {
+    const pages = [
+      page('Call to action article with its own distinct sentence number one right here.'),
+      page('Tips article featuring a completely different and unique sentence over here now.'),
+      page('Guide article with yet another wholly distinct body sentence written right here.'),
+      page('Welcome to the home page intro paragraph that is unique only to home.'),
+    ]
+
+    const out = stripBoilerplateFromCorpus(pages)
+
+    for (const o of out) {
+      expect(o).not.toContain('Subscribe to our newsletter')
+      expect(o).not.toContain('Products Pricing Contact')
+    }
+    expect(out[0]).toContain('Call to action article')
+    expect(out[1]).toContain('Tips article')
+    expect(out[2]).toContain('Guide article')
+    expect(out[3]).toContain('Welcome to the home page')
+  })
+
+  it('catches an inner duplicated band repeated across the corpus, not just wrapping', () => {
+    const BAND = 'this entire promotional banner sentence repeats word for word identically across every single page'
+    const pages = [
+      `Unique alpha opening line written for page one here. ${BAND} Unique alpha closing line for page one.`,
+      `Different beta opening line written for page two here. ${BAND} Different beta closing line for page two.`,
+      `Distinct gamma opening line written for page three here. ${BAND} Distinct gamma closing line for page three.`,
+    ]
+
+    const out = stripBoilerplateFromCorpus(pages, { threshold: 0.6 })
+
+    for (const o of out)
+      expect(o).not.toContain('promotional banner sentence repeats')
+    expect(out[0]).toContain('Unique alpha opening')
+    expect(out[0]).toContain('Unique alpha closing')
+  })
+
+  it('keeps short repeated phrases below minRun (does not nibble prose)', () => {
+    // Only ~7 consecutive shared tokens, under the default minRun of 12.
+    const pages = [
+      'Intro one as we know and then unique tail one continues onward here today nicely.',
+      'Intro two as we know and then unique tail two continues onward there right now today.',
+      'Intro three as we know and then unique tail three continues onward somewhere else entirely.',
+    ]
+
+    const out = stripBoilerplateFromCorpus(pages)
+
+    for (const o of out)
+      expect(o).toContain('as we know')
+  })
+
+  it('does nothing when there are fewer than minDocs pages', () => {
+    const pages = [page('body one is here'), page('body two is here')]
+    const out = stripBoilerplateFromCorpus(pages)
+    expect(out).toEqual(pages)
+  })
+
+  it('leaves a fully unique page untouched byte-for-byte', () => {
+    const unique = 'This page shares no sequence of words with anything else in the whole corpus at all.'
+    const pages = [unique, page('body two here now'), page('body three here now'), page('body four here now')]
+    const out = stripBoilerplateFromCorpus(pages)
+    expect(out[0]).toBe(unique)
+  })
+
+  it('a stricter threshold keeps chrome that is not on enough pages', () => {
+    // FOOTER on 3/4 pages. threshold 0.9 -> needs ceil(0.9*4)=4 -> kept. NAV on 4/4 -> stripped.
+    const pages = [
+      `${NAV} alpha unique body sentence number one here ${FOOTER}`,
+      `${NAV} beta unique body sentence number two here ${FOOTER}`,
+      `${NAV} gamma unique body sentence number three here ${FOOTER}`,
+      `${NAV} delta unique body sentence number four right here today`,
+    ]
+    const out = stripBoilerplateFromCorpus(pages, { threshold: 0.9 })
+    expect(out[0]).not.toContain('Products Pricing Contact')
+    expect(out[0]).toContain('Subscribe to our newsletter')
+  })
+})


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`@mdream/crawl` was serializing shared site chrome (top nav + footer/newsletter walls) into every page's markdown and `llms-full.txt` section, so leaf pages were mostly boilerplate. On marketingexamples.com, `landing-page/cta.md` was 26,504 chars of which ~400 was real content.

This adds a post-processing pass over the crawled corpus (`stripBoilerplateFromCorpus` in `packages/crawl/src/boilerplate.ts`): it tokenizes each page, hashes k-gram shingles, counts how many pages each shingle appears in, and removes spans whose document-frequency clears a threshold. Working at the token level (not blank-line blocks) is deliberate, since some sites convert to a single line with no block boundaries. Per-page writes are deferred until after the crawl so the whole corpus is available; the `llms.txt` link index is untouched (it is built from `metadata.links`, not page content).

On by default. `--keep-boilerplate` opts out; `--boilerplate-threshold <0..1>` tunes the document-frequency cutoff.

### Before / after

| site | result |
|------|--------|
| marketingexamples.com (159 pages) | corpus 4.40M → 0.31M chars (~93% removed); `cta.md` 26,504 → ~400, article bodies intact |
| nuxt.com (clean content pages) | 0% removed (nothing repeats → nothing stripped) |

### ✅ Tests

- `boilerplate.test.ts`: token-shingle algorithm — strips repeated nav/footer, catches inner duplicated bands, keeps short repeated phrases under `minRun`, leaves unique pages byte-for-byte, respects the threshold.
- `boilerplate-crawl.test.ts`: end-to-end crawl against a mocked multi-page fixture — chrome removed from every per-page file and `llms-full.txt`, bodies kept, `llms.txt` still lists all pages, `--keep-boilerplate` disables it.
- 73 crawl tests green; lint + typecheck clean.

### Notes

Needs a corpus (≥ 3 pages) to detect repetition, so single-page crawls are left unchanged. A suffix-automaton / maximal-repeat upgrade (no fixed `k`, exact boundaries) is a possible follow-up if accuracy needs tightening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional corpus-level boilerplate detection and removal for crawled output, stripping repeated headers/footers and navigation while preserving page-specific content.
  * Added CLI controls `--keep-boilerplate` and `--boilerplate-threshold <n>` to tune stripping sensitivity.
  * Extended crawl configuration with `stripBoilerplate` and `boilerplateThreshold` (applies to generated page content and `llms-full.txt`; link indexing in `llms.txt` remains unchanged).

* **Tests**
  * Added unit tests covering detection accuracy, edge cases, and end-to-end crawl generation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->