### PR TITLE
fix(parse): implied end-tag recovery for p/li/table/dl/a/headings

### DIFF
--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -710,6 +710,28 @@ impl ConvertState {
         std::mem::take(&mut self.buffer)
     }
 
+    /// Commit end-of-input state: flush trailing buffered text and close any
+    /// elements left open. The streaming parser keeps trailing text and unclosed
+    /// elements pending because a later chunk might continue them; at true EOF
+    /// they must be committed so trailing content is not dropped (e.g. a document
+    /// that ends mid-paragraph like `<p>a<p>b`, or any unclosed fragment).
+    ///
+    /// `leftover` is the residual returned by the final `process_html`. Pure
+    /// trailing text (no leading `<`) is emitted; a residual that is an
+    /// incomplete start tag (leading `<`) is dropped, matching the browser
+    /// tokenizer's EOF-in-tag behaviour. The text-buffer flags set while the
+    /// trailing text was scanned persist on `self`, so `process_text_buffer`
+    /// commits it exactly as if the next tag had triggered the flush.
+    pub fn finalize(&mut self, leftover: &str) {
+        if !leftover.is_empty() && leftover.as_bytes()[0] != LT_CHAR {
+            let mut buf = leftover.to_string();
+            self.process_text_buffer(&mut buf);
+        }
+        while !self.stack.is_empty() {
+            self.close_node();
+        }
+    }
+
     pub fn get_markdown_chunk(&mut self) -> String {
         let current_content = self.buffer.trim_start();
         let content_len = current_content.len();

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -110,6 +110,21 @@ fn is_cell_scope_boundary(tag_id: u8) -> bool {
     )
 }
 
+/// Block-level terminators for closing an `<a>`: a nested `<a>` closes the open
+/// one (HTML forbids nested anchors — the adoption agency closes the outer),
+/// but only within the same block so a stray open `<a>` in another block is left
+/// alone. Closing intervening inline formatting matches the spec's reconstruction.
+fn is_a_scope_boundary(tag_id: u8) -> bool {
+    matches!(
+        tag_id,
+        TAG_P | TAG_DIV | TAG_LI | TAG_UL | TAG_OL | TAG_DL | TAG_DD | TAG_DT
+            | TAG_TABLE | TAG_TD | TAG_TH | TAG_TR | TAG_CAPTION | TAG_BLOCKQUOTE
+            | TAG_SECTION | TAG_ARTICLE | TAG_HEADER | TAG_FOOTER | TAG_NAV | TAG_ASIDE
+            | TAG_MAIN | TAG_FORM | TAG_FIELDSET | TAG_FIGURE | TAG_BUTTON
+            | TAG_H1 | TAG_H2 | TAG_H3 | TAG_H4 | TAG_H5 | TAG_H6 | TAG_TEMPLATE | TAG_HTML
+    )
+}
+
 /// Whether an element is visually hidden, so the filter should drop it and its
 /// subtree: inline `display:none` / `visibility:hidden` / `position:absolute|fixed`,
 /// or the `hidden` attribute (except `hidden="until-found"`).
@@ -309,6 +324,21 @@ impl ConvertState {
                 self.close_implied_to(|t| t == TAG_P, is_p_scope_boundary);
             }
             match id {
+                // A nested <a> closes the open one (anchors cannot nest), so the
+                // markdown is two adjacent links rather than invalid nested `[..]`.
+                TAG_A if self.depth_map[TAG_A as usize] > 0 => {
+                    self.close_implied_to(|t| t == TAG_A, is_a_scope_boundary);
+                }
+                // A heading start closes an open heading (they cannot nest); only
+                // when one is the current node, matching the spec's "if the current
+                // node is an h1–h6 element, pop it" step.
+                TAG_H1 | TAG_H2 | TAG_H3 | TAG_H4 | TAG_H5 | TAG_H6
+                    if self.stack.last().is_some_and(|n| {
+                        matches!(n.tag_id, Some(TAG_H1 | TAG_H2 | TAG_H3 | TAG_H4 | TAG_H5 | TAG_H6))
+                    }) =>
+                {
+                    self.close_node();
+                }
                 TAG_LI if self.depth_map[TAG_LI as usize] > 0 => {
                     self.close_implied_to(|t| t == TAG_LI, is_li_scope_boundary);
                 }

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -25,7 +25,7 @@ fn is_head_content_tag(tag_id: Option<u8>) -> bool {
 /// for every start tag opened while a `<p>` is on the stack (most inline tags in
 /// prose), so the hot path is a single indexed load, matching the table-driven
 /// style of `TAG_HANDLERS` and `depth_map`.
-static CLOSES_P: [bool; MAX_TAG_ID] = {
+const CLOSES_P: [bool; MAX_TAG_ID] = {
     let mut t = [false; MAX_TAG_ID];
     t[TAG_DIV as usize] = true;
     t[TAG_P as usize] = true;
@@ -64,10 +64,30 @@ static CLOSES_P: [bool; MAX_TAG_ID] = {
     t
 };
 
+/// Start tags that can trigger any implied-end-tag recovery branch below. The
+/// common inline tags (`code`, `em`, `span`, ...) otherwise skip the whole
+/// recovery dispatch instead of loading unrelated depth counters and matching
+/// through recovery-only cases on every start tag.
+const NEEDS_IMPLIED_END_RECOVERY: [bool; MAX_TAG_ID] = {
+    let mut t = CLOSES_P;
+    t[TAG_A as usize] = true;
+    t[TAG_TD as usize] = true;
+    t[TAG_TH as usize] = true;
+    t[TAG_TR as usize] = true;
+    t[TAG_THEAD as usize] = true;
+    t[TAG_TBODY as usize] = true;
+    t[TAG_TFOOT as usize] = true;
+    t
+};
+
 #[inline]
 fn closes_p(tag_id: u8) -> bool {
-    // tag_id is always a real built-in id (< MAX_TAG_ID) at the call site.
-    (tag_id as usize) < MAX_TAG_ID && CLOSES_P[tag_id as usize]
+    CLOSES_P[tag_id as usize]
+}
+
+#[inline]
+fn needs_implied_end_recovery(tag_id: u8) -> bool {
+    (tag_id as usize) < MAX_TAG_ID && NEEDS_IMPLIED_END_RECOVERY[tag_id as usize]
 }
 
 /// "Button scope" terminators for closing a `<p>`: scanning up the open stack
@@ -319,33 +339,13 @@ impl ConvertState {
         // open element so the new sibling is not wrongly nested. Runs after the
         // tag is confirmed complete (above) so a chunk-split start tag never
         // mutates parser state or emits a premature close.
-        if let Some(id) = tag_id {
-            if self.depth_map[TAG_P as usize] > 0 && closes_p(id) {
-                self.close_implied_to(|t| t == TAG_P, is_p_scope_boundary);
-            }
+        if let Some(id) = tag_id
+            && needs_implied_end_recovery(id) {
             match id {
                 // A nested <a> closes the open one (anchors cannot nest), so the
                 // markdown is two adjacent links rather than invalid nested `[..]`.
                 TAG_A if self.depth_map[TAG_A as usize] > 0 => {
                     self.close_implied_to(|t| t == TAG_A, is_a_scope_boundary);
-                }
-                // A heading start closes an open heading (they cannot nest); only
-                // when one is the current node, matching the spec's "if the current
-                // node is an h1–h6 element, pop it" step.
-                TAG_H1 | TAG_H2 | TAG_H3 | TAG_H4 | TAG_H5 | TAG_H6
-                    if self.stack.last().is_some_and(|n| {
-                        matches!(n.tag_id, Some(TAG_H1 | TAG_H2 | TAG_H3 | TAG_H4 | TAG_H5 | TAG_H6))
-                    }) =>
-                {
-                    self.close_node();
-                }
-                TAG_LI if self.depth_map[TAG_LI as usize] > 0 => {
-                    self.close_implied_to(|t| t == TAG_LI, is_li_scope_boundary);
-                }
-                TAG_DT | TAG_DD
-                    if self.depth_map[TAG_DT as usize] > 0 || self.depth_map[TAG_DD as usize] > 0 =>
-                {
-                    self.close_implied_to(|t| t == TAG_DT || t == TAG_DD, is_dl_scope_boundary);
                 }
                 TAG_TD | TAG_TH | TAG_TR | TAG_THEAD | TAG_TBODY | TAG_TFOOT
                     if self.depth_map[TAG_TABLE as usize] > 0 =>
@@ -367,7 +367,34 @@ impl ConvertState {
                         _ => {}
                     }
                 }
-                _ => {}
+                TAG_A | TAG_TD | TAG_TH | TAG_TR | TAG_THEAD | TAG_TBODY | TAG_TFOOT => {}
+                _ => {
+                    if self.depth_map[TAG_P as usize] > 0 {
+                        debug_assert!(closes_p(id));
+                        self.close_implied_to(|t| t == TAG_P, is_p_scope_boundary);
+                    }
+                    match id {
+                        // A heading start closes an open heading (they cannot nest); only
+                        // when one is the current node, matching the spec's "if the current
+                        // node is an h1–h6 element, pop it" step.
+                        TAG_H1 | TAG_H2 | TAG_H3 | TAG_H4 | TAG_H5 | TAG_H6
+                            if self.stack.last().is_some_and(|n| {
+                                matches!(n.tag_id, Some(TAG_H1 | TAG_H2 | TAG_H3 | TAG_H4 | TAG_H5 | TAG_H6))
+                            }) =>
+                        {
+                            self.close_node();
+                        }
+                        TAG_LI if self.depth_map[TAG_LI as usize] > 0 => {
+                            self.close_implied_to(|t| t == TAG_LI, is_li_scope_boundary);
+                        }
+                        TAG_DT | TAG_DD
+                            if self.depth_map[TAG_DT as usize] > 0 || self.depth_map[TAG_DD as usize] > 0 =>
+                        {
+                            self.close_implied_to(|t| t == TAG_DT || t == TAG_DD, is_dl_scope_boundary);
+                        }
+                        _ => {}
+                    }
+                }
             }
         }
 

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -20,16 +20,54 @@ fn is_head_content_tag(tag_id: Option<u8>) -> bool {
 /// (HTML §13.1.2.4 optional tags + the "in body" insertion mode, where these
 /// tags first close an open `<p>` in button scope). Block containers, headings,
 /// lists, tables, and the list-item/definition tags all close an open `<p>`.
+///
+/// A compile-time `[bool; MAX_TAG_ID]` table, not a `match`: this is evaluated
+/// for every start tag opened while a `<p>` is on the stack (most inline tags in
+/// prose), so the hot path is a single indexed load, matching the table-driven
+/// style of `TAG_HANDLERS` and `depth_map`.
+static CLOSES_P: [bool; MAX_TAG_ID] = {
+    let mut t = [false; MAX_TAG_ID];
+    t[TAG_DIV as usize] = true;
+    t[TAG_P as usize] = true;
+    t[TAG_UL as usize] = true;
+    t[TAG_OL as usize] = true;
+    t[TAG_DL as usize] = true;
+    t[TAG_LI as usize] = true;
+    t[TAG_DD as usize] = true;
+    t[TAG_DT as usize] = true;
+    t[TAG_TABLE as usize] = true;
+    t[TAG_H1 as usize] = true;
+    t[TAG_H2 as usize] = true;
+    t[TAG_H3 as usize] = true;
+    t[TAG_H4 as usize] = true;
+    t[TAG_H5 as usize] = true;
+    t[TAG_H6 as usize] = true;
+    t[TAG_BLOCKQUOTE as usize] = true;
+    t[TAG_SECTION as usize] = true;
+    t[TAG_ARTICLE as usize] = true;
+    t[TAG_HEADER as usize] = true;
+    t[TAG_FOOTER as usize] = true;
+    t[TAG_NAV as usize] = true;
+    t[TAG_ASIDE as usize] = true;
+    t[TAG_PRE as usize] = true;
+    t[TAG_HR as usize] = true;
+    t[TAG_FORM as usize] = true;
+    t[TAG_FIELDSET as usize] = true;
+    t[TAG_FIGURE as usize] = true;
+    t[TAG_FIGCAPTION as usize] = true;
+    t[TAG_ADDRESS as usize] = true;
+    t[TAG_MAIN as usize] = true;
+    t[TAG_CENTER as usize] = true;
+    t[TAG_DETAILS as usize] = true;
+    t[TAG_SUMMARY as usize] = true;
+    t[TAG_DIALOG as usize] = true;
+    t
+};
+
+#[inline]
 fn closes_p(tag_id: u8) -> bool {
-    matches!(
-        tag_id,
-        TAG_DIV | TAG_P | TAG_UL | TAG_OL | TAG_DL | TAG_LI | TAG_DD | TAG_DT
-            | TAG_TABLE | TAG_H1 | TAG_H2 | TAG_H3 | TAG_H4 | TAG_H5 | TAG_H6
-            | TAG_BLOCKQUOTE | TAG_SECTION | TAG_ARTICLE | TAG_HEADER | TAG_FOOTER
-            | TAG_NAV | TAG_ASIDE | TAG_PRE | TAG_HR | TAG_FORM | TAG_FIELDSET
-            | TAG_FIGURE | TAG_FIGCAPTION | TAG_ADDRESS | TAG_MAIN | TAG_CENTER
-            | TAG_DETAILS | TAG_SUMMARY | TAG_DIALOG
-    )
+    // tag_id is always a real built-in id (< MAX_TAG_ID) at the call site.
+    (tag_id as usize) < MAX_TAG_ID && CLOSES_P[tag_id as usize]
 }
 
 /// "Button scope" terminators for closing a `<p>`: scanning up the open stack

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -16,6 +16,62 @@ fn is_head_content_tag(tag_id: Option<u8>) -> bool {
     )
 }
 
+/// Start tags that cannot appear inside a `<p>` and therefore imply its end
+/// (HTML §13.1.2.4 optional tags + the "in body" insertion mode, where these
+/// tags first close an open `<p>` in button scope). Block containers, headings,
+/// lists, tables, and the list-item/definition tags all close an open `<p>`.
+fn closes_p(tag_id: u8) -> bool {
+    matches!(
+        tag_id,
+        TAG_DIV | TAG_P | TAG_UL | TAG_OL | TAG_DL | TAG_LI | TAG_DD | TAG_DT
+            | TAG_TABLE | TAG_H1 | TAG_H2 | TAG_H3 | TAG_H4 | TAG_H5 | TAG_H6
+            | TAG_BLOCKQUOTE | TAG_SECTION | TAG_ARTICLE | TAG_HEADER | TAG_FOOTER
+            | TAG_NAV | TAG_ASIDE | TAG_PRE | TAG_HR | TAG_FORM | TAG_FIELDSET
+            | TAG_FIGURE | TAG_FIGCAPTION | TAG_ADDRESS | TAG_MAIN | TAG_CENTER
+            | TAG_DETAILS | TAG_SUMMARY | TAG_DIALOG
+    )
+}
+
+/// "Button scope" terminators for closing a `<p>`: scanning up the open stack
+/// stops here so a `<p>` outside a table cell is never closed from inside one.
+/// `UL`/`OL`/`DL`/`LI` are added (a deviation from the bare spec list) to keep
+/// scans short; a `<p>` is always closed before any of these can become its
+/// ancestor, so they never hide a closable `<p>`.
+fn is_p_scope_boundary(tag_id: u8) -> bool {
+    matches!(
+        tag_id,
+        TAG_BUTTON | TAG_TD | TAG_TH | TAG_CAPTION | TAG_TABLE | TAG_TEMPLATE | TAG_HTML
+            | TAG_UL | TAG_OL | TAG_DL | TAG_LI
+    )
+}
+
+/// "List item scope" terminators for closing a `<li>`: a new `<li>` closes the
+/// previous one only within the same list, never across a nested list or table.
+fn is_li_scope_boundary(tag_id: u8) -> bool {
+    matches!(
+        tag_id,
+        TAG_UL | TAG_OL | TAG_TABLE | TAG_TD | TAG_TH | TAG_CAPTION | TAG_TEMPLATE | TAG_HTML
+    )
+}
+
+/// Scope terminators for closing a `<dt>`/`<dd>`: each closes the other within
+/// the same `<dl>`, never crossing into a nested list or table.
+fn is_dl_scope_boundary(tag_id: u8) -> bool {
+    matches!(
+        tag_id,
+        TAG_DL | TAG_UL | TAG_OL | TAG_LI | TAG_TABLE | TAG_TD | TAG_TH | TAG_CAPTION | TAG_TEMPLATE | TAG_HTML
+    )
+}
+
+/// "Table cell scope" terminators: a new `<td>`/`<th>` closes the current cell
+/// (and any inline content left open inside it), stopping at the row/section.
+fn is_cell_scope_boundary(tag_id: u8) -> bool {
+    matches!(
+        tag_id,
+        TAG_TR | TAG_THEAD | TAG_TBODY | TAG_TFOOT | TAG_TABLE | TAG_CAPTION | TAG_TEMPLATE | TAG_HTML
+    )
+}
+
 /// Whether an element is visually hidden, so the filter should drop it and its
 /// subtree: inline `display:none` / `visibility:hidden` / `position:absolute|fixed`,
 /// or the `hidden` attribute (except `hidden="until-found"`).
@@ -143,6 +199,40 @@ impl ConvertState {
         }
     }
 
+    /// Close open nodes from the top of the stack up to and including the nearest
+    /// node matching `target`, but only if it is found before `boundary` (in which
+    /// case nothing is closed). Implements implied end tags for `<p>`, `<li>`, and
+    /// `<dt>`/`<dd>`: the intervening unmatched nodes (inline formatting, unknown
+    /// elements) are closed along the way, mirroring the spec's "generate implied
+    /// end tags" step.
+    fn close_implied_to(&mut self, target: fn(u8) -> bool, boundary: fn(u8) -> bool) {
+        let mut close_count = 0usize;
+        let mut found = false;
+        for node in self.stack.iter().rev() {
+            match node.tag_id {
+                Some(id) if target(id) => { close_count += 1; found = true; break; }
+                Some(id) if boundary(id) => break,
+                _ => close_count += 1,
+            }
+        }
+        if found {
+            for _ in 0..close_count { self.close_node(); }
+        }
+    }
+
+    /// Close open table-internal nodes (cells, rows, sections) from the top while
+    /// they match `closeable`, stopping at the first node that does not (e.g. the
+    /// enclosing `<table>`). Implements implied end tags for `<tr>` (closes an open
+    /// cell + row) and `<thead>`/`<tbody>`/`<tfoot>` (closes cell + row + section).
+    fn close_table_context(&mut self, closeable: fn(u8) -> bool) {
+        while let Some(top) = self.stack.last() {
+            match top.tag_id {
+                Some(id) if closeable(id) => self.close_node(),
+                _ => break,
+            }
+        }
+    }
+
     pub(crate) fn process_opening_tag(&mut self, tag_name: &str, tag_id: Option<u8>, is_builtin: bool, html_chunk: &str, position: usize) -> OpeningTagResult {
         let tag_handler = tag_id.and_then(get_tag_handler);
         let needs_attrs = tag_handler.is_some_and(|h| h.needs_attributes)
@@ -167,6 +257,49 @@ impl ConvertState {
             }
             if self.stack.last().is_some_and(|n| n.tag_id == Some(TAG_HEAD)) {
                 self.close_node();
+            }
+        }
+
+        // Browser recovery: implied end tags (HTML §13.1.2.4 optional tags +
+        // tree-construction). Common malformed-but-valid markup omits end tags
+        // (`<p>a<p>b`, `<li>a<li>b`, `<td>a<td>b`, `<dt>t<dd>d`); auto-close the
+        // open element so the new sibling is not wrongly nested. Runs after the
+        // tag is confirmed complete (above) so a chunk-split start tag never
+        // mutates parser state or emits a premature close.
+        if let Some(id) = tag_id {
+            if self.depth_map[TAG_P as usize] > 0 && closes_p(id) {
+                self.close_implied_to(|t| t == TAG_P, is_p_scope_boundary);
+            }
+            match id {
+                TAG_LI if self.depth_map[TAG_LI as usize] > 0 => {
+                    self.close_implied_to(|t| t == TAG_LI, is_li_scope_boundary);
+                }
+                TAG_DT | TAG_DD
+                    if self.depth_map[TAG_DT as usize] > 0 || self.depth_map[TAG_DD as usize] > 0 =>
+                {
+                    self.close_implied_to(|t| t == TAG_DT || t == TAG_DD, is_dl_scope_boundary);
+                }
+                TAG_TD | TAG_TH | TAG_TR | TAG_THEAD | TAG_TBODY | TAG_TFOOT
+                    if self.depth_map[TAG_TABLE as usize] > 0 =>
+                {
+                    match id {
+                        TAG_TD | TAG_TH
+                            if self.depth_map[TAG_TD as usize] > 0 || self.depth_map[TAG_TH as usize] > 0 =>
+                        {
+                            self.close_implied_to(|t| t == TAG_TD || t == TAG_TH, is_cell_scope_boundary);
+                        }
+                        TAG_TR if self.depth_map[TAG_TR as usize] > 0 => {
+                            self.close_table_context(|t| matches!(t, TAG_TD | TAG_TH | TAG_TR));
+                        }
+                        TAG_THEAD | TAG_TBODY | TAG_TFOOT => {
+                            self.close_table_context(|t| {
+                                matches!(t, TAG_TD | TAG_TH | TAG_TR | TAG_THEAD | TAG_TBODY | TAG_TFOOT | TAG_CAPTION)
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+                _ => {}
             }
         }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -32,7 +32,8 @@ pub fn html_to_markdown(html: &str, options: HTMLToMarkdownOptions) -> String {
 pub fn html_to_markdown_result(html: &str, options: HTMLToMarkdownOptions) -> MdreamResult {
     let capacity = (html.len() / 3).clamp(1024, 256 * 1024);
     let mut state = ConvertState::new(options, capacity);
-    state.process_html(html);
+    let leftover = state.process_html(html);
+    state.finalize(&leftover);
 
     let extracted = if state.has_extraction {
         let results = std::mem::take(&mut state.extraction_results);
@@ -78,10 +79,13 @@ impl MarkdownStreamProcessor {
     }
 
     pub fn finish(&mut self) -> String {
-        if !self.buffer.is_empty() {
+        let leftover = if self.buffer.is_empty() {
+            String::new()
+        } else {
             let chunk = std::mem::take(&mut self.buffer);
-            self.state.process_html(&chunk);
-        }
+            self.state.process_html(&chunk)
+        };
+        self.state.finalize(&leftover);
         self.state.get_markdown_chunk()
     }
 }

--- a/crates/core/tests/implied_end_tags.rs
+++ b/crates/core/tests/implied_end_tags.rs
@@ -136,6 +136,38 @@ fn malformed_definition_list_matches_well_formed() {
     );
 }
 
+// ── nested anchors ──
+
+#[test]
+fn nested_anchor_closes_the_open_one() {
+    // Regression: nested <a> produced invalid nested markdown `[one [two](/2)](/1)`.
+    assert_eq!(convert("<a href=/1>one<a href=/2>two</a>"), "[one](/1) [two](/2)");
+    // Intervening inline formatting is closed along with the anchor.
+    assert_eq!(convert("<a href=/1>one<b>bold<a href=/2>two</a>"), "[one**bold**](/1) [two](/2)");
+}
+
+#[test]
+fn well_formed_and_cross_block_anchors_unchanged() {
+    assert_eq!(convert("<a href=/1>one</a><a href=/2>two</a>"), "[one](/1) [two](/2)");
+    // A closed anchor in another block is not affected.
+    assert_eq!(convert("<div><a href=/1>one</div><a href=/2>two</a>"), "[one](/1)\n\n[two](/2)");
+}
+
+// ── headings ──
+
+#[test]
+fn heading_closes_open_heading() {
+    // Regression: `<h1>a<h2>b` rendered "# a ## b" on one invalid line.
+    assert_eq!(convert("<h1>a<h2>b</h2>"), "# a\n\n## b");
+    assert_eq!(convert("<h2>a<h2>b"), "## a\n\n## b");
+}
+
+#[test]
+fn well_formed_headings_unchanged() {
+    assert_eq!(convert("<h1>a</h1><h2>b</h2>"), "# a\n\n## b");
+    assert_eq!(convert("<h1><em>a</em></h1>"), "# _a_");
+}
+
 // ── trailing content at EOF ──
 
 #[test]

--- a/crates/core/tests/implied_end_tags.rs
+++ b/crates/core/tests/implied_end_tags.rs
@@ -1,0 +1,165 @@
+//! Browser recovery: implied end tags (HTML §13.1.2.4 optional tags +
+//! tree-construction). Malformed-but-valid markup that omits end tags must
+//! recover the same way browsers do, so the missing close does not nest or drop
+//! content. Mirrors the JS engine's `implied-end-tags.test.ts`.
+use mdream::{MarkdownStreamProcessor, types::HTMLToMarkdownOptions, html_to_markdown};
+
+fn convert(html: &str) -> String {
+    html_to_markdown(html, HTMLToMarkdownOptions::default())
+}
+
+fn stream(chunks: &[&str]) -> String {
+    let mut p = MarkdownStreamProcessor::new(HTMLToMarkdownOptions::default());
+    let mut out = String::new();
+    for c in chunks {
+        out.push_str(&p.process_chunk(c));
+    }
+    out.push_str(&p.finish());
+    out
+}
+
+// ── <p> ──
+
+#[test]
+fn unclosed_p_followed_by_p_keeps_both_paragraphs() {
+    // Regression: the second <p> used to nest inside the first, dropping "two".
+    assert_eq!(convert("<p>one<p>two"), "one\n\ntwo");
+    assert_eq!(convert("<p>a<p>b<p>c"), "a\n\nb\n\nc");
+}
+
+#[test]
+fn unclosed_p_closed_by_block_elements_still_works() {
+    // Already-working cases must not regress.
+    assert_eq!(convert("<p>one<div>two</div>"), "one\n\ntwo");
+    assert_eq!(convert("<p>one<ul><li>x</li></ul>"), "one\n\n- x");
+    assert_eq!(convert("<p>a<h2>b</h2>"), "a\n\n## b");
+    assert_eq!(convert("<p>a<blockquote>b</blockquote>"), "a\n\n> b");
+}
+
+#[test]
+fn well_formed_paragraphs_are_unchanged() {
+    assert_eq!(convert("<p>one</p><p>two</p>"), "one\n\ntwo");
+}
+
+// ── <li> ──
+
+#[test]
+fn unclosed_li_followed_by_li_are_siblings() {
+    // Regression: the second <li> used to wrongly nest under the first.
+    assert_eq!(convert("<ul><li>one<li>two</ul>"), "- one\n- two");
+    assert_eq!(convert("<ol><li>one<li>two<li>three</ol>"), "1. one\n2. two\n3. three");
+}
+
+#[test]
+fn unclosed_li_at_eof_is_kept() {
+    assert_eq!(convert("<ul><li>one<li>two"), "- one\n- two");
+}
+
+#[test]
+fn nested_lists_with_unclosed_li_keep_structure() {
+    // Inner <li> closes only within the inner list; the outer item is untouched.
+    assert_eq!(
+        convert("<ul><li>a<ul><li>b<li>c</ul><li>d</ul>"),
+        "- a\n  - b\n  - c\n- d",
+    );
+}
+
+#[test]
+fn well_formed_list_is_unchanged() {
+    assert_eq!(convert("<ul><li>one</li><li>two</li></ul>"), "- one\n- two");
+}
+
+// ── tables ──
+
+#[test]
+fn implicit_cell_and_row_ends_build_a_clean_table() {
+    // Regression: a bare <tr>/<td> used to leak into the cell output.
+    assert_eq!(
+        convert("<table><tr><td>a<td>b<tr><td>c<td>d</table>"),
+        "| a | b |\n| --- | --- |\n| c | d |",
+    );
+}
+
+#[test]
+fn implicit_section_ends_build_a_clean_table() {
+    // <thead>/<tbody> auto-close each other; cells/rows close on the section.
+    assert_eq!(
+        convert("<table><thead><tr><th>H<tbody><tr><td>D</table>"),
+        "| H |\n| --- |\n| D |",
+    );
+}
+
+#[test]
+fn well_formed_table_is_unchanged() {
+    assert_eq!(
+        convert("<table><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table>"),
+        "| a | b |\n| --- | --- |\n| c | d |",
+    );
+}
+
+// ── definition lists ──
+//
+// `<dl>`/`<dt>`/`<dd>` keep their raw-HTML passthrough (valid inline markup for
+// GitHub-flavoured Markdown); the recovery only fixes the implied nesting, so a
+// malformed list produces the same clean tags as its well-formed equivalent.
+
+#[test]
+fn unclosed_dt_dd_recover_to_clean_raw_tags() {
+    // Regression: <dt>/<dd> used to nest endlessly (e.g. `…</dd></dt></dd></dt>`).
+    assert_eq!(
+        convert("<dl><dt>Coffee<dd>Black hot drink</dl>"),
+        "<dl><dt>Coffee</dt>\n<dd>Black hot drink</dd>\n</dl>",
+    );
+}
+
+#[test]
+fn definition_list_alternating_dt_dd_close_each_other() {
+    assert_eq!(
+        convert("<dl><dt>Coffee<dd>Hot drink<dt>Milk<dd>Cold drink</dl>"),
+        "<dl><dt>Coffee</dt>\n<dd>Hot drink</dd>\n<dt>Milk</dt>\n<dd>Cold drink</dd>\n</dl>",
+    );
+}
+
+#[test]
+fn definition_list_multiple_definitions_per_term() {
+    assert_eq!(
+        convert("<dl><dt>Term<dd>Def 1<dd>Def 2</dl>"),
+        "<dl><dt>Term</dt>\n<dd>Def 1</dd>\n<dd>Def 2</dd>\n</dl>",
+    );
+}
+
+#[test]
+fn malformed_definition_list_matches_well_formed() {
+    assert_eq!(
+        convert("<dl><dt>Coffee<dd>Hot drink</dl>"),
+        convert("<dl><dt>Coffee</dt><dd>Hot drink</dd></dl>"),
+    );
+}
+
+// ── trailing content at EOF ──
+
+#[test]
+fn trailing_text_at_eof_is_not_dropped() {
+    assert_eq!(convert("<p>hello"), "hello");
+    assert_eq!(convert("hello"), "hello");
+    assert_eq!(convert("<b>bold"), "**bold**");
+}
+
+// ── streaming: recovery must run only after the start tag is complete ──
+
+#[test]
+fn streaming_split_inside_trigger_tag_matches_whole() {
+    // Splitting the triggering tag across chunks must not change the result; the
+    // recovery runs only after the tag is confirmed complete.
+    for (chunks, whole) in [
+        (vec!["<p>one<p", ">two"], "<p>one<p>two"),
+        (vec!["<ul><li>one<l", "i>two</ul>"], "<ul><li>one<li>two</ul>"),
+        (
+            vec!["<table><tr><td>a<t", "d>b<tr><td>c<td>d</table>"],
+            "<table><tr><td>a<td>b<tr><td>c<td>d</table>",
+        ),
+        (vec!["<dl><dt>Coffee<d", "d>Hot drink</dl>"], "<dl><dt>Coffee<dd>Hot drink</dl>"),
+    ] {
+        assert_eq!(stream(&chunks).trim(), convert(whole), "chunks: {chunks:?}");
+    }
+}

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -23,7 +23,7 @@ import {
   TAG_TH,
   TEXT_NODE,
 } from './const'
-import { parseHtmlStream } from './parse'
+import { finalizeParse, parseHtmlStream } from './parse'
 import { processPluginsForEvent } from './plugin-processor'
 
 export interface MarkdownState {
@@ -589,9 +589,12 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
       tagOverrideHandlers,
     }
 
-    parseHtmlStream(html, parseState, (event) => {
+    const handleEvent = (event: NodeEvent): void => {
       processPluginsForEvent(event, resolvedPlugins, state, processEvent)
-    })
+    }
+    const leftover = parseHtmlStream(html, parseState, handleEvent)
+    // Commit trailing text and close unclosed elements at end of input.
+    finalizeParse(leftover, parseState, handleEvent)
   }
 
   /**

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -5,19 +5,59 @@ import {
   NodeEventEnter,
   NodeEventExit,
   TAG_A,
+  TAG_ADDRESS,
+  TAG_ARTICLE,
+  TAG_ASIDE,
   TAG_BASE,
   TAG_BLOCKQUOTE,
+  TAG_BUTTON,
+  TAG_CAPTION,
+  TAG_CENTER,
   TAG_CODE,
+  TAG_DD,
+  TAG_DETAILS,
+  TAG_DIALOG,
+  TAG_DIV,
+  TAG_DL,
+  TAG_DT,
+  TAG_FIELDSET,
+  TAG_FIGCAPTION,
+  TAG_FIGURE,
+  TAG_FOOTER,
+  TAG_FORM,
+  TAG_H1,
+  TAG_H2,
+  TAG_H3,
+  TAG_H4,
+  TAG_H5,
+  TAG_H6,
   TAG_HEAD,
+  TAG_HEADER,
+  TAG_HR,
+  TAG_HTML,
+  TAG_LI,
   TAG_LINK,
+  TAG_MAIN,
   TAG_META,
+  TAG_NAV,
   TAG_NOSCRIPT,
+  TAG_OL,
+  TAG_P,
   TAG_PRE,
   TAG_SCRIPT,
+  TAG_SECTION,
   TAG_STYLE,
+  TAG_SUMMARY,
   TAG_TABLE,
+  TAG_TBODY,
+  TAG_TD,
   TAG_TEMPLATE,
+  TAG_TFOOT,
+  TAG_TH,
+  TAG_THEAD,
   TAG_TITLE,
+  TAG_TR,
+  TAG_UL,
   TagIdMap,
   TEXT_NODE,
 } from './const'
@@ -60,6 +100,197 @@ const HEAD_CONTENT_TAGS = new Set<number>([
   TAG_NOSCRIPT,
   TAG_TEMPLATE,
 ])
+
+// Implied end tags (HTML §13.1.2.4 optional tags + "in body" insertion mode).
+// Mirrors the Rust engine's `parse.rs`. Start tags that cannot appear inside a
+// `<p>` imply its end; block containers, headings, lists, tables, and the
+// list-item/definition tags all close an open `<p>`.
+const CLOSES_P = new Set<number>([
+  TAG_DIV,
+  TAG_P,
+  TAG_UL,
+  TAG_OL,
+  TAG_DL,
+  TAG_LI,
+  TAG_DD,
+  TAG_DT,
+  TAG_TABLE,
+  TAG_H1,
+  TAG_H2,
+  TAG_H3,
+  TAG_H4,
+  TAG_H5,
+  TAG_H6,
+  TAG_BLOCKQUOTE,
+  TAG_SECTION,
+  TAG_ARTICLE,
+  TAG_HEADER,
+  TAG_FOOTER,
+  TAG_NAV,
+  TAG_ASIDE,
+  TAG_PRE,
+  TAG_HR,
+  TAG_FORM,
+  TAG_FIELDSET,
+  TAG_FIGURE,
+  TAG_FIGCAPTION,
+  TAG_ADDRESS,
+  TAG_MAIN,
+  TAG_CENTER,
+  TAG_DETAILS,
+  TAG_SUMMARY,
+  TAG_DIALOG,
+])
+
+// "Button scope" terminators for closing a `<p>`. `UL`/`OL`/`DL`/`LI` are added
+// (a deviation from the bare spec list) to keep scans short; a `<p>` is always
+// closed before any of these can become its ancestor.
+const P_SCOPE_BOUNDARY = new Set<number>([
+  TAG_BUTTON,
+  TAG_TD,
+  TAG_TH,
+  TAG_CAPTION,
+  TAG_TABLE,
+  TAG_TEMPLATE,
+  TAG_HTML,
+  TAG_UL,
+  TAG_OL,
+  TAG_DL,
+  TAG_LI,
+])
+
+// "List item scope": a new `<li>` closes the previous one only within the same
+// list, never across a nested list or table.
+const LI_SCOPE_BOUNDARY = new Set<number>([
+  TAG_UL,
+  TAG_OL,
+  TAG_TABLE,
+  TAG_TD,
+  TAG_TH,
+  TAG_CAPTION,
+  TAG_TEMPLATE,
+  TAG_HTML,
+])
+
+// Scope for `<dt>`/`<dd>`: each closes the other within the same `<dl>`.
+const DL_SCOPE_BOUNDARY = new Set<number>([
+  TAG_DL,
+  TAG_UL,
+  TAG_OL,
+  TAG_LI,
+  TAG_TABLE,
+  TAG_TD,
+  TAG_TH,
+  TAG_CAPTION,
+  TAG_TEMPLATE,
+  TAG_HTML,
+])
+
+// "Table cell scope": a new `<td>`/`<th>` closes the current cell, stopping at
+// the row/section.
+const CELL_SCOPE_BOUNDARY = new Set<number>([
+  TAG_TR,
+  TAG_THEAD,
+  TAG_TBODY,
+  TAG_TFOOT,
+  TAG_TABLE,
+  TAG_CAPTION,
+  TAG_TEMPLATE,
+  TAG_HTML,
+])
+
+// Implied-end-tag targets and table-context closeable sets.
+const SINGLE_P = new Set<number>([TAG_P])
+const SINGLE_LI = new Set<number>([TAG_LI])
+const DT_DD = new Set<number>([TAG_DT, TAG_DD])
+const TD_TH = new Set<number>([TAG_TD, TAG_TH])
+const TR_CELLS = new Set<number>([TAG_TD, TAG_TH, TAG_TR])
+const SECTION_CELLS = new Set<number>([TAG_TD, TAG_TH, TAG_TR, TAG_THEAD, TAG_TBODY, TAG_TFOOT, TAG_CAPTION])
+
+/**
+ * Close open nodes from `currentNode` up to and including the nearest node whose
+ * tagId is in `target`, but only if it is found before a `boundary` node (in
+ * which case nothing is closed). The intervening unmatched nodes (inline
+ * formatting, unknown elements) are closed along the way, mirroring the spec's
+ * "generate implied end tags" step.
+ */
+function closeImpliedTo(
+  state: ParseState,
+  target: Set<number>,
+  boundary: Set<number>,
+  handleEvent: (event: NodeEvent) => void,
+): void {
+  let found = false
+  for (let node = state.currentNode; node; node = node.parent) {
+    const id = node.tagId
+    if (id !== undefined && target.has(id)) {
+      found = true
+      break
+    }
+    if (id !== undefined && boundary.has(id)) {
+      break
+    }
+  }
+  if (!found) {
+    return
+  }
+  // closeNode always closes the current top and walks to its parent, so close
+  // from the top until the matched node has itself been closed.
+  while (state.currentNode) {
+    const id = state.currentNode.tagId
+    const isTarget = id !== undefined && target.has(id)
+    closeNode(state.currentNode, state, handleEvent)
+    if (isTarget) {
+      break
+    }
+  }
+}
+
+/**
+ * Close open table-internal nodes (cells, rows, sections) from the top while
+ * their tagId is in `closeable`, stopping at the first node that is not (e.g.
+ * the enclosing `<table>`). Implements implied end tags for `<tr>` and the
+ * table section elements.
+ */
+function closeTableContext(
+  state: ParseState,
+  closeable: Set<number>,
+  handleEvent: (event: NodeEvent) => void,
+): void {
+  while (state.currentNode) {
+    const id = state.currentNode.tagId
+    if (id === undefined || !closeable.has(id)) {
+      break
+    }
+    closeNode(state.currentNode, state, handleEvent)
+  }
+}
+
+/**
+ * Commit end-of-input state: flush trailing buffered text and close any open
+ * elements. The streaming parser keeps trailing text and unclosed elements
+ * pending (a later chunk might continue them); at true EOF they must be
+ * committed so trailing content is not dropped (e.g. `<p>a<p>b`).
+ *
+ * `leftover` is the residual returned by the final `parseHtmlStream`. Pure
+ * trailing text (no leading `<`) is emitted; a residual that is an incomplete
+ * start tag (leading `<`) is dropped, matching the browser tokenizer's
+ * EOF-in-tag behaviour. The text-buffer flags set while the trailing text was
+ * scanned persist on `state`, so `processTextBuffer` commits it as if the next
+ * tag had triggered the flush.
+ */
+export function finalizeParse(
+  leftover: string,
+  state: ParseState,
+  handleEvent: (event: NodeEvent) => void,
+): void {
+  if (leftover.length > 0 && leftover.charCodeAt(0) !== LT_CHAR) {
+    processTextBuffer(leftover, state, handleEvent)
+  }
+  while (state.currentNode) {
+    closeNode(state.currentNode, state, handleEvent)
+  }
+}
 
 // Pre-allocate arrays and objects to reduce allocations
 const EMPTY_ATTRIBUTES: Record<string, string> = Object.freeze({})
@@ -792,6 +1023,41 @@ function processOpeningTag(
     const headNode = state.currentNode
     if (headNode && headNode.tagId === TAG_HEAD) {
       closeNode(headNode, state, handleEvent)
+    }
+  }
+
+  // Browser recovery: implied end tags (HTML §13.1.2.4 optional tags +
+  // tree-construction). Common malformed-but-valid markup omits end tags
+  // (`<p>a<p>b`, `<li>a<li>b`, `<td>a<td>b`, `<dt>t<dd>d`); auto-close the open
+  // element so the new sibling is not wrongly nested. Runs after the tag is
+  // confirmed complete (above) so a chunk-split start tag never mutates parser
+  // state or emits a premature close.
+  if ((state.depthMap[TAG_P] || 0) > 0 && CLOSES_P.has(tagId)) {
+    closeImpliedTo(state, SINGLE_P, P_SCOPE_BOUNDARY, handleEvent)
+  }
+  if (tagId === TAG_LI) {
+    if ((state.depthMap[TAG_LI] || 0) > 0) {
+      closeImpliedTo(state, SINGLE_LI, LI_SCOPE_BOUNDARY, handleEvent)
+    }
+  }
+  else if (tagId === TAG_DT || tagId === TAG_DD) {
+    if ((state.depthMap[TAG_DT] || 0) > 0 || (state.depthMap[TAG_DD] || 0) > 0) {
+      closeImpliedTo(state, DT_DD, DL_SCOPE_BOUNDARY, handleEvent)
+    }
+  }
+  else if ((state.depthMap[TAG_TABLE] || 0) > 0) {
+    if (tagId === TAG_TD || tagId === TAG_TH) {
+      if ((state.depthMap[TAG_TD] || 0) > 0 || (state.depthMap[TAG_TH] || 0) > 0) {
+        closeImpliedTo(state, TD_TH, CELL_SCOPE_BOUNDARY, handleEvent)
+      }
+    }
+    else if (tagId === TAG_TR) {
+      if ((state.depthMap[TAG_TR] || 0) > 0) {
+        closeTableContext(state, TR_CELLS, handleEvent)
+      }
+    }
+    else if (tagId === TAG_THEAD || tagId === TAG_TBODY || tagId === TAG_TFOOT) {
+      closeTableContext(state, SECTION_CELLS, handleEvent)
     }
   }
 

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -209,9 +209,51 @@ const CELL_SCOPE_BOUNDARY = new Set<number>([
   TAG_HTML,
 ])
 
+// Block-level terminators for closing an `<a>`: a nested `<a>` closes the open
+// one (anchors cannot nest), but only within the same block.
+const A_SCOPE_BOUNDARY = new Set<number>([
+  TAG_P,
+  TAG_DIV,
+  TAG_LI,
+  TAG_UL,
+  TAG_OL,
+  TAG_DL,
+  TAG_DD,
+  TAG_DT,
+  TAG_TABLE,
+  TAG_TD,
+  TAG_TH,
+  TAG_TR,
+  TAG_CAPTION,
+  TAG_BLOCKQUOTE,
+  TAG_SECTION,
+  TAG_ARTICLE,
+  TAG_HEADER,
+  TAG_FOOTER,
+  TAG_NAV,
+  TAG_ASIDE,
+  TAG_MAIN,
+  TAG_FORM,
+  TAG_FIELDSET,
+  TAG_FIGURE,
+  TAG_BUTTON,
+  TAG_H1,
+  TAG_H2,
+  TAG_H3,
+  TAG_H4,
+  TAG_H5,
+  TAG_H6,
+  TAG_TEMPLATE,
+  TAG_HTML,
+])
+
+// Headings (h1–h6) for the "a heading start closes an open heading" check.
+const HEADINGS = new Set<number>([TAG_H1, TAG_H2, TAG_H3, TAG_H4, TAG_H5, TAG_H6])
+
 // Implied-end-tag targets and table-context closeable sets.
 const SINGLE_P = new Set<number>([TAG_P])
 const SINGLE_LI = new Set<number>([TAG_LI])
+const SINGLE_A = new Set<number>([TAG_A])
 const DT_DD = new Set<number>([TAG_DT, TAG_DD])
 const TD_TH = new Set<number>([TAG_TD, TAG_TH])
 const TR_CELLS = new Set<number>([TAG_TD, TAG_TH, TAG_TR])
@@ -1045,7 +1087,23 @@ function processOpeningTag(
   if ((state.depthMap[TAG_P] || 0) > 0 && tagId >= 0 && tagId < MAX_TAG_ID && CLOSES_P[tagId] === 1) {
     closeImpliedTo(state, SINGLE_P, P_SCOPE_BOUNDARY, handleEvent)
   }
-  if (tagId === TAG_LI) {
+  if (tagId === TAG_A) {
+    // A nested <a> closes the open one (anchors cannot nest), so the markdown is
+    // two adjacent links rather than invalid nested `[..]`.
+    if ((state.depthMap[TAG_A] || 0) > 0) {
+      closeImpliedTo(state, SINGLE_A, A_SCOPE_BOUNDARY, handleEvent)
+    }
+  }
+  else if (HEADINGS.has(tagId)) {
+    // A heading start closes an open heading (they cannot nest); only when one is
+    // the current node, matching the spec's "if the current node is an h1–h6
+    // element, pop it" step.
+    const top = state.currentNode
+    if (top && top.tagId !== undefined && HEADINGS.has(top.tagId)) {
+      closeNode(top, state, handleEvent)
+    }
+  }
+  else if (tagId === TAG_LI) {
     if ((state.depthMap[TAG_LI] || 0) > 0) {
       closeImpliedTo(state, SINGLE_LI, LI_SCOPE_BOUNDARY, handleEvent)
     }

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -105,42 +105,52 @@ const HEAD_CONTENT_TAGS = new Set<number>([
 // Mirrors the Rust engine's `parse.rs`. Start tags that cannot appear inside a
 // `<p>` imply its end; block containers, headings, lists, tables, and the
 // list-item/definition tags all close an open `<p>`.
-const CLOSES_P = new Set<number>([
-  TAG_DIV,
-  TAG_P,
-  TAG_UL,
-  TAG_OL,
-  TAG_DL,
-  TAG_LI,
-  TAG_DD,
-  TAG_DT,
-  TAG_TABLE,
-  TAG_H1,
-  TAG_H2,
-  TAG_H3,
-  TAG_H4,
-  TAG_H5,
-  TAG_H6,
-  TAG_BLOCKQUOTE,
-  TAG_SECTION,
-  TAG_ARTICLE,
-  TAG_HEADER,
-  TAG_FOOTER,
-  TAG_NAV,
-  TAG_ASIDE,
-  TAG_PRE,
-  TAG_HR,
-  TAG_FORM,
-  TAG_FIELDSET,
-  TAG_FIGURE,
-  TAG_FIGCAPTION,
-  TAG_ADDRESS,
-  TAG_MAIN,
-  TAG_CENTER,
-  TAG_DETAILS,
-  TAG_SUMMARY,
-  TAG_DIALOG,
-])
+//
+// A typed-array lookup, not a Set: this is checked for every start tag opened
+// while a `<p>` is on the stack (most inline tags in prose), so the hot path is
+// a single indexed load rather than a Set hash.
+const CLOSES_P: Uint8Array = (() => {
+  const t = new Uint8Array(MAX_TAG_ID)
+  const ids = [
+    TAG_DIV,
+    TAG_P,
+    TAG_UL,
+    TAG_OL,
+    TAG_DL,
+    TAG_LI,
+    TAG_DD,
+    TAG_DT,
+    TAG_TABLE,
+    TAG_H1,
+    TAG_H2,
+    TAG_H3,
+    TAG_H4,
+    TAG_H5,
+    TAG_H6,
+    TAG_BLOCKQUOTE,
+    TAG_SECTION,
+    TAG_ARTICLE,
+    TAG_HEADER,
+    TAG_FOOTER,
+    TAG_NAV,
+    TAG_ASIDE,
+    TAG_PRE,
+    TAG_HR,
+    TAG_FORM,
+    TAG_FIELDSET,
+    TAG_FIGURE,
+    TAG_FIGCAPTION,
+    TAG_ADDRESS,
+    TAG_MAIN,
+    TAG_CENTER,
+    TAG_DETAILS,
+    TAG_SUMMARY,
+    TAG_DIALOG,
+  ]
+  for (const id of ids)
+    t[id] = 1
+  return t
+})()
 
 // "Button scope" terminators for closing a `<p>`. `UL`/`OL`/`DL`/`LI` are added
 // (a deviation from the bare spec list) to keep scans short; a `<p>` is always
@@ -1032,7 +1042,7 @@ function processOpeningTag(
   // element so the new sibling is not wrongly nested. Runs after the tag is
   // confirmed complete (above) so a chunk-split start tag never mutates parser
   // state or emits a premature close.
-  if ((state.depthMap[TAG_P] || 0) > 0 && CLOSES_P.has(tagId)) {
+  if ((state.depthMap[TAG_P] || 0) > 0 && tagId >= 0 && tagId < MAX_TAG_ID && CLOSES_P[tagId] === 1) {
     closeImpliedTo(state, SINGLE_P, P_SCOPE_BOUNDARY, handleEvent)
   }
   if (tagId === TAG_LI) {

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -152,6 +152,17 @@ const CLOSES_P: Uint8Array = (() => {
   return t
 })()
 
+// Start tags that can trigger any implied-end-tag recovery branch. The common
+// inline tags (`code`, `em`, `span`, ...) otherwise run the whole dispatch just
+// to prove they need no recovery, so gating on a single indexed load lets them
+// skip it entirely. Mirrors the Rust engine's `NEEDS_IMPLIED_END_RECOVERY`.
+const NEEDS_IMPLIED_END_RECOVERY: Uint8Array = (() => {
+  const t = CLOSES_P.slice()
+  for (const id of [TAG_A, TAG_TD, TAG_TH, TAG_TR, TAG_THEAD, TAG_TBODY, TAG_TFOOT])
+    t[id] = 1
+  return t
+})()
+
 // "Button scope" terminators for closing a `<p>`. `UL`/`OL`/`DL`/`LI` are added
 // (a deviation from the bare spec list) to keep scans short; a `<p>` is always
 // closed before any of these can become its ancestor.
@@ -1084,48 +1095,58 @@ function processOpeningTag(
   // element so the new sibling is not wrongly nested. Runs after the tag is
   // confirmed complete (above) so a chunk-split start tag never mutates parser
   // state or emits a premature close.
-  if ((state.depthMap[TAG_P] || 0) > 0 && tagId >= 0 && tagId < MAX_TAG_ID && CLOSES_P[tagId] === 1) {
-    closeImpliedTo(state, SINGLE_P, P_SCOPE_BOUNDARY, handleEvent)
-  }
-  if (tagId === TAG_A) {
-    // A nested <a> closes the open one (anchors cannot nest), so the markdown is
-    // two adjacent links rather than invalid nested `[..]`.
-    if ((state.depthMap[TAG_A] || 0) > 0) {
-      closeImpliedTo(state, SINGLE_A, A_SCOPE_BOUNDARY, handleEvent)
-    }
-  }
-  else if (HEADINGS.has(tagId)) {
-    // A heading start closes an open heading (they cannot nest); only when one is
-    // the current node, matching the spec's "if the current node is an h1–h6
-    // element, pop it" step.
-    const top = state.currentNode
-    if (top && top.tagId !== undefined && HEADINGS.has(top.tagId)) {
-      closeNode(top, state, handleEvent)
-    }
-  }
-  else if (tagId === TAG_LI) {
-    if ((state.depthMap[TAG_LI] || 0) > 0) {
-      closeImpliedTo(state, SINGLE_LI, LI_SCOPE_BOUNDARY, handleEvent)
-    }
-  }
-  else if (tagId === TAG_DT || tagId === TAG_DD) {
-    if ((state.depthMap[TAG_DT] || 0) > 0 || (state.depthMap[TAG_DD] || 0) > 0) {
-      closeImpliedTo(state, DT_DD, DL_SCOPE_BOUNDARY, handleEvent)
-    }
-  }
-  else if ((state.depthMap[TAG_TABLE] || 0) > 0) {
-    if (tagId === TAG_TD || tagId === TAG_TH) {
-      if ((state.depthMap[TAG_TD] || 0) > 0 || (state.depthMap[TAG_TH] || 0) > 0) {
-        closeImpliedTo(state, TD_TH, CELL_SCOPE_BOUNDARY, handleEvent)
+  if (tagId >= 0 && tagId < MAX_TAG_ID && NEEDS_IMPLIED_END_RECOVERY[tagId] === 1) {
+    if (tagId === TAG_A) {
+      // A nested <a> closes the open one (anchors cannot nest), so the markdown is
+      // two adjacent links rather than invalid nested `[..]`. <a> never closes <p>.
+      if ((state.depthMap[TAG_A] || 0) > 0) {
+        closeImpliedTo(state, SINGLE_A, A_SCOPE_BOUNDARY, handleEvent)
       }
     }
-    else if (tagId === TAG_TR) {
-      if ((state.depthMap[TAG_TR] || 0) > 0) {
-        closeTableContext(state, TR_CELLS, handleEvent)
+    else if (tagId === TAG_TD || tagId === TAG_TH || tagId === TAG_TR
+      || tagId === TAG_THEAD || tagId === TAG_TBODY || tagId === TAG_TFOOT) {
+      // Table cells/rows/sections close earlier ones; they never close <p>.
+      if ((state.depthMap[TAG_TABLE] || 0) > 0) {
+        if (tagId === TAG_TD || tagId === TAG_TH) {
+          if ((state.depthMap[TAG_TD] || 0) > 0 || (state.depthMap[TAG_TH] || 0) > 0) {
+            closeImpliedTo(state, TD_TH, CELL_SCOPE_BOUNDARY, handleEvent)
+          }
+        }
+        else if (tagId === TAG_TR) {
+          if ((state.depthMap[TAG_TR] || 0) > 0) {
+            closeTableContext(state, TR_CELLS, handleEvent)
+          }
+        }
+        else {
+          closeTableContext(state, SECTION_CELLS, handleEvent)
+        }
       }
     }
-    else if (tagId === TAG_THEAD || tagId === TAG_TBODY || tagId === TAG_TFOOT) {
-      closeTableContext(state, SECTION_CELLS, handleEvent)
+    else {
+      // Remaining recovery tags are all in CLOSES_P, so they close an open <p>
+      // first, then any heading/list-item implied end.
+      if ((state.depthMap[TAG_P] || 0) > 0) {
+        closeImpliedTo(state, SINGLE_P, P_SCOPE_BOUNDARY, handleEvent)
+      }
+      if (HEADINGS.has(tagId)) {
+        // A heading start closes an open heading (they cannot nest); only when one
+        // is the current node, matching the spec's "if the current node is an
+        // h1–h6 element, pop it" step.
+        const top = state.currentNode
+        if (top && top.tagId !== undefined && HEADINGS.has(top.tagId)) {
+          closeNode(top, state, handleEvent)
+        }
+      }
+      else if (tagId === TAG_LI) {
+        if ((state.depthMap[TAG_LI] || 0) > 0) {
+          closeImpliedTo(state, SINGLE_LI, LI_SCOPE_BOUNDARY, handleEvent)
+        }
+      }
+      else if (tagId === TAG_DT || tagId === TAG_DD) {
+        if ((state.depthMap[TAG_DT] || 0) > 0 || (state.depthMap[TAG_DD] || 0) > 0) {
+          closeImpliedTo(state, DT_DD, DL_SCOPE_BOUNDARY, handleEvent)
+        }
+      }
     }
   }
 

--- a/packages/js/src/stream.ts
+++ b/packages/js/src/stream.ts
@@ -1,7 +1,7 @@
 import type { ParseState } from './parse'
-import type { EngineOptions, TagHandler, TransformPlugin } from './types'
+import type { EngineOptions, NodeEvent, TagHandler, TransformPlugin } from './types'
 import { createMarkdownProcessor } from './markdown-processor'
-import { parseHtmlStream } from './parse'
+import { finalizeParse, parseHtmlStream } from './parse'
 import { processPluginsForEvent } from './plugin-processor'
 
 /**
@@ -54,12 +54,15 @@ export async function* streamHtmlToMarkdown(
         yield chunk
       }
     }
-    // Process any remaining HTML and emit final chunk
-    if (remainingHtml) {
-      parseHtmlStream(remainingHtml, parseState, (event) => {
-        processPluginsForEvent(event, resolvedPlugins, processor.state, processor.processEvent)
-      })
+    // Process any remaining HTML, then commit trailing text and close any
+    // elements left open at end of input.
+    const handleEvent = (event: NodeEvent): void => {
+      processPluginsForEvent(event, resolvedPlugins, processor.state, processor.processEvent)
     }
+    const leftover = remainingHtml
+      ? parseHtmlStream(remainingHtml, parseState, handleEvent)
+      : ''
+    finalizeParse(leftover, parseState, handleEvent)
 
     // Emit any final content
     const finalChunk = processor.getMarkdownChunk()

--- a/packages/js/test/unit/implied-end-tags.test.ts
+++ b/packages/js/test/unit/implied-end-tags.test.ts
@@ -102,6 +102,32 @@ describe('definition list implied end tags', () => {
   })
 })
 
+describe('nested anchors', () => {
+  it('closes the open <a> when another opens', () => {
+    // Regression: nested <a> produced invalid nested markdown `[one [two](/2)](/1)`.
+    expect(htmlToMarkdown('<a href=/1>one<a href=/2>two</a>')).toBe('[one](/1) [two](/2)')
+    expect(htmlToMarkdown('<a href=/1>one<b>bold<a href=/2>two</a>')).toBe('[one**bold**](/1) [two](/2)')
+  })
+
+  it('leaves well-formed and cross-block anchors unchanged', () => {
+    expect(htmlToMarkdown('<a href=/1>one</a><a href=/2>two</a>')).toBe('[one](/1) [two](/2)')
+    expect(htmlToMarkdown('<div><a href=/1>one</div><a href=/2>two</a>')).toBe('[one](/1)\n\n[two](/2)')
+  })
+})
+
+describe('headings', () => {
+  it('closes an open heading when another opens', () => {
+    // Regression: `<h1>a<h2>b` rendered "# a ## b" on one invalid line.
+    expect(htmlToMarkdown('<h1>a<h2>b</h2>')).toBe('# a\n\n## b')
+    expect(htmlToMarkdown('<h2>a<h2>b')).toBe('## a\n\n## b')
+  })
+
+  it('leaves well-formed headings unchanged', () => {
+    expect(htmlToMarkdown('<h1>a</h1><h2>b</h2>')).toBe('# a\n\n## b')
+    expect(htmlToMarkdown('<h1><em>a</em></h1>')).toBe('# _a_')
+  })
+})
+
 describe('trailing content at EOF', () => {
   it('does not drop trailing text', () => {
     expect(htmlToMarkdown('<p>hello')).toBe('hello')

--- a/packages/js/test/unit/implied-end-tags.test.ts
+++ b/packages/js/test/unit/implied-end-tags.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+import { htmlToMarkdown, streamHtmlToMarkdown } from '../../src/index'
+
+// Browser recovery: implied end tags (HTML §13.1.2.4 optional tags +
+// tree-construction). Malformed-but-valid markup that omits end tags must
+// recover the same way browsers do, so the missing close does not nest or drop
+// content. Mirrors the Rust engine's `implied_end_tags.rs`.
+
+async function streamConvert(chunks: string[]): Promise<string> {
+  const stream = new ReadableStream<string>({
+    start(controller) {
+      for (const c of chunks)
+        controller.enqueue(c)
+      controller.close()
+    },
+  })
+  let out = ''
+  for await (const chunk of streamHtmlToMarkdown(stream))
+    out += chunk
+  return out
+}
+
+describe('<p> implied end tags', () => {
+  it('keeps both paragraphs when the first <p> is unclosed', () => {
+    // Regression: the second <p> used to nest inside the first, dropping "two".
+    expect(htmlToMarkdown('<p>one<p>two')).toBe('one\n\ntwo')
+    expect(htmlToMarkdown('<p>a<p>b<p>c')).toBe('a\n\nb\n\nc')
+  })
+
+  it('still closes an unclosed <p> on other block elements', () => {
+    expect(htmlToMarkdown('<p>one<div>two</div>')).toBe('one\n\ntwo')
+    expect(htmlToMarkdown('<p>one<ul><li>x</li></ul>')).toBe('one\n\n- x')
+    expect(htmlToMarkdown('<p>a<h2>b</h2>')).toBe('a\n\n## b')
+    expect(htmlToMarkdown('<p>a<blockquote>b</blockquote>')).toBe('a\n\n> b')
+  })
+
+  it('leaves well-formed paragraphs unchanged', () => {
+    expect(htmlToMarkdown('<p>one</p><p>two</p>')).toBe('one\n\ntwo')
+  })
+})
+
+describe('<li> implied end tags', () => {
+  it('treats unclosed <li> as siblings', () => {
+    // Regression: the second <li> used to wrongly nest under the first.
+    expect(htmlToMarkdown('<ul><li>one<li>two</ul>')).toBe('- one\n- two')
+    expect(htmlToMarkdown('<ol><li>one<li>two<li>three</ol>')).toBe('1. one\n2. two\n3. three')
+  })
+
+  it('keeps a trailing unclosed <li> at EOF', () => {
+    expect(htmlToMarkdown('<ul><li>one<li>two')).toBe('- one\n- two')
+  })
+
+  it('preserves nested-list structure with unclosed <li>', () => {
+    expect(htmlToMarkdown('<ul><li>a<ul><li>b<li>c</ul><li>d</ul>')).toBe('- a\n  - b\n  - c\n- d')
+  })
+
+  it('leaves a well-formed list unchanged', () => {
+    expect(htmlToMarkdown('<ul><li>one</li><li>two</li></ul>')).toBe('- one\n- two')
+  })
+})
+
+describe('table implied end tags', () => {
+  it('builds a clean table from implicit cell/row ends', () => {
+    // Regression: a bare <tr>/<td> used to leak into the cell output.
+    expect(htmlToMarkdown('<table><tr><td>a<td>b<tr><td>c<td>d</table>'))
+      .toBe('| a | b |\n| --- | --- |\n| c | d |')
+  })
+
+  it('builds a clean table from implicit section ends', () => {
+    expect(htmlToMarkdown('<table><thead><tr><th>H<tbody><tr><td>D</table>'))
+      .toBe('| H |\n| --- |\n| D |')
+  })
+
+  it('leaves a well-formed table unchanged', () => {
+    expect(htmlToMarkdown('<table><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table>'))
+      .toBe('| a | b |\n| --- | --- |\n| c | d |')
+  })
+})
+
+// <dl>/<dt>/<dd> keep their raw-HTML passthrough (valid inline markup for
+// GitHub-flavoured Markdown); the recovery only fixes the implied nesting.
+describe('definition list implied end tags', () => {
+  it('recovers unclosed <dt>/<dd> to clean raw tags', () => {
+    // Regression: <dt>/<dd> used to nest endlessly (e.g. `…</dd></dt></dd></dt>`).
+    expect(htmlToMarkdown('<dl><dt>Coffee<dd>Black hot drink</dl>'))
+      .toBe('<dl><dt>Coffee</dt>\n<dd>Black hot drink</dd>\n</dl>')
+  })
+
+  it('closes alternating <dt>/<dd>', () => {
+    expect(htmlToMarkdown('<dl><dt>Coffee<dd>Hot drink<dt>Milk<dd>Cold drink</dl>'))
+      .toBe('<dl><dt>Coffee</dt>\n<dd>Hot drink</dd>\n<dt>Milk</dt>\n<dd>Cold drink</dd>\n</dl>')
+  })
+
+  it('supports multiple definitions per term', () => {
+    expect(htmlToMarkdown('<dl><dt>Term<dd>Def 1<dd>Def 2</dl>'))
+      .toBe('<dl><dt>Term</dt>\n<dd>Def 1</dd>\n<dd>Def 2</dd>\n</dl>')
+  })
+
+  it('makes a malformed list match its well-formed equivalent', () => {
+    expect(htmlToMarkdown('<dl><dt>Coffee<dd>Hot drink</dl>'))
+      .toBe(htmlToMarkdown('<dl><dt>Coffee</dt><dd>Hot drink</dd></dl>'))
+  })
+})
+
+describe('trailing content at EOF', () => {
+  it('does not drop trailing text', () => {
+    expect(htmlToMarkdown('<p>hello')).toBe('hello')
+    expect(htmlToMarkdown('hello')).toBe('hello')
+    expect(htmlToMarkdown('<b>bold')).toBe('**bold**')
+  })
+})
+
+describe('streaming: recovery runs only after a complete start tag', () => {
+  it('matches whole-document output when the trigger tag is split across chunks', async () => {
+    for (const [chunks, whole] of [
+      [['<p>one<p', '>two'], '<p>one<p>two'],
+      [['<ul><li>one<l', 'i>two</ul>'], '<ul><li>one<li>two</ul>'],
+      [['<table><tr><td>a<t', 'd>b<tr><td>c<td>d</table>'], '<table><tr><td>a<td>b<tr><td>c<td>d</table>'],
+      [['<dl><dt>Coffee<d', 'd>Hot drink</dl>'], '<dl><dt>Coffee<dd>Hot drink</dl>'],
+    ] as [string[], string][]) {
+      const streamed = (await streamConvert(chunks)).trim()
+      expect(streamed).toBe(htmlToMarkdown(whole))
+    }
+  })
+})

--- a/packages/js/test/unit/implied-end-tags.test.ts
+++ b/packages/js/test/unit/implied-end-tags.test.ts
@@ -118,8 +118,14 @@ describe('streaming: recovery runs only after a complete start tag', () => {
       [['<table><tr><td>a<t', 'd>b<tr><td>c<td>d</table>'], '<table><tr><td>a<td>b<tr><td>c<td>d</table>'],
       [['<dl><dt>Coffee<d', 'd>Hot drink</dl>'], '<dl><dt>Coffee<dd>Hot drink</dl>'],
     ] as [string[], string][]) {
-      const streamed = (await streamConvert(chunks)).trim()
-      expect(streamed).toBe(htmlToMarkdown(whole))
+      const streamedSplit = await streamConvert(chunks)
+      const streamedWhole = await streamConvert([whole])
+      // Exact (no trim): splitting the trigger tag across chunks must not change
+      // a single byte of the streamed output — catches boundary regressions.
+      expect(streamedSplit).toBe(streamedWhole)
+      // Content matches the batch conversion (streaming keeps the trailing
+      // newlines that the one-shot getMarkdown trims).
+      expect(streamedSplit.trim()).toBe(htmlToMarkdown(whole))
     }
   })
 })


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

mdream's parsers didn't implement HTML's optional-end-tag / implied-end-tag rules (spec §13.1.2.4 + tree construction), so common malformed-but-valid markup was mis-parsed. Same class of bug as #108. Fixed in both the Rust engine (canonical) and the JS mirror, in lockstep.

Recovered cases:

- `<p>one<p>two` dropped "two" → now `one\n\ntwo`. A block-level start tag closes an open `<p>`.
- `<ul><li>one<li>two</ul>` wrongly nested the second item → now two siblings.
- `<table><tr><td>a<td>b<tr><td>c<td>d</table>` leaked raw `<tr>`/`<td>` into cells → now a clean 2×2 table. Cells/rows/sections close on the next cell/row/section.
- `<dl><dt>t<dd>d<dt>t2<dd>d2</dl>` nested endlessly → now clean siblings. `<dt>`/`<dd>` close each other. The `<dl>`/`<dt>`/`<dd>` keep their existing raw-HTML passthrough (valid inline markup for GitHub-flavoured Markdown); only the nesting is corrected.
- `<a href=/1>one<a href=/2>two</a>` produced invalid nested markdown `[one [two](/2)](/1)` → now `[one](/1) [two](/2)`. A nested `<a>` closes the open one.
- `<h1>a<h2>b` rendered `# a ## b` on one invalid line → now `# a\n\n## b`. A heading start closes an open heading.

Also fixes a pre-existing data-loss bug: trailing text after the last tag and any still-open elements were dropped at end of input (e.g. `htmlToMarkdown('hello')` returned `''`). At true EOF they are now flushed and closed.

Recovery runs only after a start tag is confirmed complete, so a tag split across stream chunks never mutates parser state prematurely (the transactional-ordering issue flagged on #108). The hot `<p>`-close check is a compile-time lookup table (`[bool; MAX_TAG_ID]` / `Uint8Array`), so the dispatch adds no measurable overhead — `convert_bench` is at parity with main.

Known remaining gap: `<option>`/`<optgroup>` still leak raw tags when unclosed; fixing that needs `<option>`'s non-nesting rawtext handling reworked, left for a separate change.

Tests: `crates/core/tests/implied_end_tags.rs` (20) and `packages/js/test/unit/implied-end-tags.test.ts` (20) cover each case, the already-working well-formed cases, and exact streaming chunk-split parity. Existing suites stay green (Rust `cargo test`, Node 1018 passing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser-like implied-end-tag recovery for malformed-but-valid HTML, ensuring correct closure/sibling behavior for unclosed `<p>`, `<li>`, `<dt>/<dd>`, nested `<a>`, and heading transitions.
  * Enhanced implied table boundary handling for cleaner Markdown table reconstruction.
  * Fixed end-of-input finalization in both one-shot and streaming conversions, preventing dropped trailing text and unterminated markup.
* **Tests**
  * Added implied-end-tag recovery test coverage for both one-shot and chunked streaming modes, including EOF and split-tag scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->