### PR TITLE
chore: add nuxt package support metadata

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -10,6 +10,10 @@
     "url": "https://github.com/harlan-zw/mdream",
     "directory": "packages/nuxt"
   },
+  "homepage": "https://github.com/harlan-zw/mdream/tree/main/packages/nuxt#readme",
+  "bugs": {
+    "url": "https://github.com/harlan-zw/mdream/issues"
+  },
   "exports": {
     ".": {
       "types": "./dist/types.d.mts",


### PR DESCRIPTION
## Summary

- add `homepage` metadata for the published `@mdream/nuxt` package
- add `bugs.url` metadata pointing to the public issue tracker
- leave runtime code, dependencies, exports, and package versioning unchanged

## Why

`@mdream/nuxt@1.4.1` currently publishes repository and license metadata, but no `homepage` or `bugs` fields. Adding these standard npm fields makes the package README and issue tracker discoverable from registry tooling.

## Validation

```sh
npm view @mdream/nuxt@1.4.1 name version repository homepage bugs license --json
node -e "const p=require('./packages/nuxt/package.json'); if(p.homepage!=='https://github.com/harlan-zw/mdream/tree/main/packages/nuxt#readme') throw new Error('bad homepage'); if(p.bugs?.url!=='https://github.com/harlan-zw/mdream/issues') throw new Error('bad bugs'); console.log(JSON.stringify({name:p.name, version:p.version, homepage:p.homepage, bugs:p.bugs, repository:p.repository}, null, 2));"
npm pack --dry-run --ignore-scripts --json ./packages/nuxt
git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata with repository homepage and issue tracking information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->