### PR TITLE
fix: omit CDATA markup by default

### DIFF
--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -396,64 +396,13 @@ impl ConvertState {
                     continue;
                 }
 
-                if cc == AMPERSAND_CHAR {
-                    self.has_encoded_html_entity = true;
-                }
-
-                if is_whitespace(cc) {
-                    if self.just_closed_tag {
-                        self.just_closed_tag = false;
-                        self.last_char_was_whitespace = false;
-                    }
-                    if !self.in_pre && self.last_char_was_whitespace {
-                        i += 1;
-                        continue;
-                    }
-                    if self.in_pre {
-                        text_buffer.push(cc as char);
-                    } else if cc == SPACE_CHAR || !self.last_char_was_whitespace {
-                        text_buffer.push(' ');
-                    }
-                    self.last_char_was_whitespace = true;
-                    self.text_buffer_contains_whitespace = true;
-
+                let end = if cc < 0x80 {
+                    i + 1
                 } else {
-                    self.text_buffer_contains_non_whitespace = true;
-                    self.last_char_was_whitespace = false;
-                    self.just_closed_tag = false;
-
-                    if self.escape_ctx == 0 {
-                        if cc < 0x80 {
-                            text_buffer.push(cc as char);
-                        } else {
-                            if let Some(ch) = chunk[i..].chars().next() {
-                            text_buffer.push(ch);
-                            i += ch.len_utf8();
-                            } else { i += 1; }
-        
-                            continue;
-                        }
-                    } else if cc == PIPE_CHAR && (self.escape_ctx & ESC_TABLE) != 0 {
-                        text_buffer.push_str("\\|");
-                    } else if cc == BACKTICK_CHAR && (self.escape_ctx & ESC_CODE_PRE) != 0 {
-                        text_buffer.push_str("\\`");
-                    } else if cc == OPEN_BRACKET_CHAR && (self.escape_ctx & ESC_LINK) != 0 {
-                        text_buffer.push_str("\\[");
-                    } else if cc == CLOSE_BRACKET_CHAR && (self.escape_ctx & ESC_LINK) != 0 {
-                        text_buffer.push_str("\\]");
-                    } else if cc == GT_CHAR && (self.escape_ctx & ESC_BLOCKQUOTE) != 0 {
-                        text_buffer.push_str("\\>");
-                    } else if cc < 0x80 {
-                        text_buffer.push(cc as char);
-                    } else if let Some(ch) = chunk[i..].chars().next() {
-                        text_buffer.push(ch);
-                        i += ch.len_utf8();
-    
-                        continue;
-                    }
-
-                }
-                i += 1;
+                    i + chunk[i..].chars().next().map_or(1, char::len_utf8)
+                };
+                self.append_text_content(&chunk[i..end], &mut text_buffer);
+                i = end;
                 continue;
             }
 
@@ -511,20 +460,24 @@ impl ConvertState {
 
             if next == EXCLAMATION_CHAR {
                 let remaining = &chunk[i..];
-                // CDATA is dropped by default but can be surfaced via
-                // tagOverrides["#cdata-section"]. Handle it before the generic
-                // comment/doctype scan, which would otherwise stop at the first
-                // `>` inside `]]>` and discard the content. We already matched
-                // `<!`, so only the `[CDATA[` tail is checked; `strip_prefix`
-                // short-circuits on the third byte for the common comment and
-                // doctype cases.
+                // CDATA markup is omitted by default, while its inner text is
+                // emitted. Handle it before the generic comment/doctype scan,
+                // which would otherwise stop at the first `>` inside `]]>` and
+                // discard the content. We already matched `<!`, so only the
+                // `[CDATA[` tail is checked; `strip_prefix` short-circuits on
+                // the third byte for the common comment and doctype cases.
                 if let Some(after_open) = chunk[i + 2..].strip_prefix("[CDATA[") {
                     if let Some(rel) = after_open.find("]]>") {
-                        if !text_buffer.is_empty() {
-                            self.process_text_buffer(&mut text_buffer);
-                            text_buffer.clear();
+                        let content = &after_open[..rel];
+                        if self.has_cdata_section_override() {
+                            if !text_buffer.is_empty() {
+                                self.process_text_buffer(&mut text_buffer);
+                                text_buffer.clear();
+                            }
+                            self.process_cdata_section(content);
+                        } else {
+                            self.append_text_content(content, &mut text_buffer);
                         }
-                        self.process_cdata_section(&after_open[..rel]);
                         i += "<![CDATA[".len() + rel + 3;
                         continue;
                     }

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -878,15 +878,11 @@ impl ConvertState {
 
     /// Handle a CDATA section's inner content.
     ///
-    /// CDATA is discarded by default (matching the HTML spec, where `<![CDATA[`
-    /// outside foreign content is a bogus comment). Callers opt in by registering
-    /// a `#cdata-section` entry in `tagOverrides`; the leading `#` makes the
-    /// pseudo-tag impossible to collide with a real HTML element name. When an
-    /// override exists the content is emitted as a synthetic `#cdata-section`
-    /// element whose rendering follows the override (alias tag and/or
-    /// enter/exit strings).
+    /// CDATA markup is omitted by default while the inner content is emitted as
+    /// text. Callers can register a `#cdata-section` entry in `tagOverrides` to
+    /// render a synthetic pseudo-element instead; the leading `#` makes it
+    /// impossible to collide with a real HTML element name.
     pub(crate) fn process_cdata_section(&mut self, content: &str) {
-        if !self.has_tag_overrides { return; }
         let Some(tag_id) = self.options.plugins.as_ref()
             .and_then(|p| p.tag_overrides.as_ref())
             .and_then(|ovs| ovs.iter().find(|(k, _)| k == "#cdata-section"))
@@ -911,6 +907,86 @@ impl ConvertState {
         }
         if !result.self_closing {
             self.close_node();
+        }
+    }
+
+    pub(crate) fn has_cdata_section_override(&self) -> bool {
+        self.options.plugins.as_ref()
+            .and_then(|p| p.tag_overrides.as_ref())
+            .is_some_and(|ovs| ovs.iter().any(|(k, _)| k == "#cdata-section"))
+    }
+
+    /// Append already-classified text into the pending text buffer.
+    ///
+    /// This applies the normal whitespace, entity, and markdown escaping rules,
+    /// but does not parse `<` as markup. The main scanner passes text ranges;
+    /// CDATA passes its inner content so only the delimiters are omitted.
+    #[inline]
+    pub(crate) fn append_text_content(&mut self, content: &str, text_buffer: &mut String) {
+        let bytes = content.as_bytes();
+        let mut i = 0;
+
+        while i < bytes.len() {
+            let cc = bytes[i];
+
+            if cc == AMPERSAND_CHAR {
+                self.has_encoded_html_entity = true;
+            }
+
+            if is_whitespace(cc) {
+                if self.just_closed_tag {
+                    self.just_closed_tag = false;
+                    self.last_char_was_whitespace = false;
+                }
+
+                if !self.in_pre && self.last_char_was_whitespace {
+                    i += 1;
+                    continue;
+                }
+
+                if self.in_pre {
+                    text_buffer.push(cc as char);
+                } else if cc == SPACE_CHAR || !self.last_char_was_whitespace {
+                    text_buffer.push(' ');
+                }
+
+                self.last_char_was_whitespace = true;
+                self.text_buffer_contains_whitespace = true;
+                i += 1;
+                continue;
+            }
+
+            self.text_buffer_contains_non_whitespace = true;
+            self.last_char_was_whitespace = false;
+            self.just_closed_tag = false;
+
+            if self.escape_ctx == 0 {
+                if cc < 0x80 {
+                    text_buffer.push(cc as char);
+                } else if let Some(ch) = content[i..].chars().next() {
+                    text_buffer.push(ch);
+                    i += ch.len_utf8();
+                    continue;
+                }
+            } else if cc == PIPE_CHAR && (self.escape_ctx & ESC_TABLE) != 0 {
+                text_buffer.push_str("\\|");
+            } else if cc == BACKTICK_CHAR && (self.escape_ctx & ESC_CODE_PRE) != 0 {
+                text_buffer.push_str("\\`");
+            } else if cc == OPEN_BRACKET_CHAR && (self.escape_ctx & ESC_LINK) != 0 {
+                text_buffer.push_str("\\[");
+            } else if cc == CLOSE_BRACKET_CHAR && (self.escape_ctx & ESC_LINK) != 0 {
+                text_buffer.push_str("\\]");
+            } else if cc == GT_CHAR && (self.escape_ctx & ESC_BLOCKQUOTE) != 0 {
+                text_buffer.push_str("\\>");
+            } else if cc < 0x80 {
+                text_buffer.push(cc as char);
+            } else if let Some(ch) = content[i..].chars().next() {
+                text_buffer.push(ch);
+                i += ch.len_utf8();
+                continue;
+            }
+
+            i += 1;
         }
     }
 

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -1644,10 +1644,23 @@ fn script_with_cdata_like_content() {
 }
 
 #[test]
-fn cdata_dropped_by_default() {
-    // CDATA sections are discarded unless opted into via tagOverrides.
-    let md = convert("before <![CDATA[secret payload]]> after");
-    assert!(!md.contains("secret payload"), "CDATA leaked into output: {md}");
+fn cdata_omits_markup_by_default() {
+    let md = convert("<body><p>before<![CDATA[secret payload]]>after</p></body>");
+    assert_eq!(md, "beforesecret payloadafter");
+    assert!(!md.contains("<![CDATA["), "CDATA opener leaked into output: {md}");
+    assert!(!md.contains("]]>"), "CDATA closer leaked into output: {md}");
+}
+
+#[test]
+fn cdata_uses_text_pipeline_by_default() {
+    let md = convert("<body><p>a &amp; <![CDATA[b &amp; c]]></p></body>");
+    assert_eq!(md, "a & b & c");
+}
+
+#[test]
+fn cdata_omits_markup_in_code_block_by_default() {
+    let md = convert("<body><pre><code><![CDATA[\none two\nthree four\n]]></code></pre></body>");
+    assert_eq!(md, "```\none two\nthree four\n```");
 }
 
 #[test]

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -479,82 +479,12 @@ function parseHtmlInternal(
 
     // If not starting a tag, add to text buffer and continue
     if (currentCharCode !== LT_CHAR) {
-      if (currentCharCode === AMPERSAND_CHAR) {
-        state.hasEncodedHtmlEntity = true
-      }
-
-      // Whitespace handling optimization
-      if (isWhitespace(currentCharCode)) {
-        const inPreTag = (state.depthMap[TAG_PRE] || 0) > 0
-
-        // Handle space after a tag
-        if (state.justClosedTag) {
-          state.justClosedTag = false
-          state.lastCharWasWhitespace = false
-        }
-
-        // Skip if last character was whitespace and we're not in a pre tag
-        if (!inPreTag && state.lastCharWasWhitespace) {
-          i++
-          continue
-        }
-
-        // Preserve original whitespace in pre tags
-        if (inPreTag) {
-          textBuffer += htmlChunk[i]
-        }
-        else {
-          if (currentCharCode === SPACE_CHAR || !state.lastCharWasWhitespace) {
-            textBuffer += ' '
-          }
-        }
-        state.lastCharWasWhitespace = true
-        state.textBufferContainsWhitespace = true
-        state.lastCharWasBackslash = false
-      }
-      else {
-        state.textBufferContainsNonWhitespace = true
-        state.lastCharWasWhitespace = false
-        state.justClosedTag = false
-
-        // Handle special characters that need escaping
-        if (currentCharCode === PIPE_CHAR && state.depthMap[TAG_TABLE]) {
-          textBuffer += '\\|'
-        }
-        else if (currentCharCode === BACKTICK_CHAR && (state.depthMap[TAG_CODE] || state.depthMap[TAG_PRE])) {
-          textBuffer += '\\`'
-        }
-        else if (currentCharCode === OPEN_BRACKET_CHAR && state.depthMap[TAG_A]) {
-          textBuffer += '\\['
-        }
-        else if (currentCharCode === CLOSE_BRACKET_CHAR && state.depthMap[TAG_A]) {
-          textBuffer += '\\]'
-        }
-        else if (currentCharCode === GT_CHAR && state.depthMap[TAG_BLOCKQUOTE]) {
-          textBuffer += '\\>'
-        }
-        else {
-          textBuffer += htmlChunk[i]
-        }
-
-        // Track quote state for quote-aware rawtext tags (script/style only)
-        if (state.inRawTextQuoteAware) {
-          if (!state.lastCharWasBackslash) {
-            if (currentCharCode === APOS_CHAR && !state.inDoubleQuote && !state.inBacktick) {
-              state.inSingleQuote = !state.inSingleQuote
-            }
-            else if (currentCharCode === QUOTE_CHAR && !state.inSingleQuote && !state.inBacktick) {
-              state.inDoubleQuote = !state.inDoubleQuote
-            }
-            else if (currentCharCode === BACKTICK_CHAR && !state.inSingleQuote && !state.inDoubleQuote) {
-              state.inBacktick = !state.inBacktick
-            }
-          }
-        }
-
-        state.lastCharWasBackslash = currentCharCode === BACKSLASH_CHAR && !state.lastCharWasBackslash
-      }
+      const textStart = i
       i++
+      while (i < chunkLength && htmlChunk.charCodeAt(i) !== LT_CHAR) {
+        i++
+      }
+      textBuffer += serializeTextContent(htmlChunk, state, textStart, i)
       continue
     }
 
@@ -571,10 +501,9 @@ function parseHtmlInternal(
       // Discriminate on the third char: '[' is a CDATA section, anything else
       // is a comment/doctype. Only the rare '[' case pays for the string work.
       if (htmlChunk.charCodeAt(i + 2) === OPEN_BRACKET_CHAR) {
-        // CDATA is dropped by default but can be surfaced via
-        // tagOverrides['#cdata-section']. Handle it before the generic
-        // comment/doctype scan, which would otherwise stop at the first `>`
-        // inside `]]>` and discard the content.
+        // CDATA markup is omitted by default, while its inner text is emitted.
+        // Handle it before the generic comment/doctype scan, which would
+        // otherwise stop at the first `>` inside `]]>` and discard the content.
         if (htmlChunk.startsWith('<![CDATA[', i)) {
           const end = htmlChunk.indexOf(']]>', i + 9)
           if (end === -1) {
@@ -582,11 +511,17 @@ function parseHtmlInternal(
             textBuffer += htmlChunk.substring(i)
             break
           }
-          if (textBuffer.length > 0) {
-            processTextBuffer(textBuffer, state, handleEvent)
-            textBuffer = ''
+          const content = htmlChunk.substring(i + 9, end)
+          if (state.tagOverrideHandlers?.has('#cdata-section')) {
+            if (textBuffer.length > 0) {
+              processTextBuffer(textBuffer, state, handleEvent)
+              textBuffer = ''
+            }
+            processCdataSection(content, state, handleEvent)
           }
-          processCdataSection(htmlChunk.substring(i + 9, end), state, handleEvent)
+          else {
+            textBuffer += serializeTextContent(content, state)
+          }
           i = end + 3
           continue
         }
@@ -617,7 +552,7 @@ function parseHtmlInternal(
       if (state.currentNode?.tagHandler?.isNonNesting) {
         const inQuotes = state.inRawTextQuoteAware && (state.inSingleQuote || state.inDoubleQuote || state.inBacktick)
         if (inQuotes) {
-          textBuffer += htmlChunk[i]
+          textBuffer += serializeTextContent(htmlChunk, state, i, i + 1)
           i++
           continue
         }
@@ -632,7 +567,8 @@ function parseHtmlInternal(
         const peekTagName = htmlChunk.substring(i + 2, peekEnd).toLowerCase() as keyof typeof TagIdMap
         const peekTagId = TagIdMap[peekTagName] ?? -1
         if (peekTagId !== state.currentNode.tagId) {
-          textBuffer += htmlChunk[i++]
+          textBuffer += serializeTextContent(htmlChunk, state, i, i + 1)
+          i++
           continue
         }
       }
@@ -678,12 +614,14 @@ function parseHtmlInternal(
       // Inside a non-nesting element (script/style/title/textarea) no opening
       // tag is a real element; a nested `<script>` is literal text (issue #93).
       if (state.currentNode?.tagHandler?.isNonNesting) {
-        textBuffer += htmlChunk[i++]
+        textBuffer += serializeTextContent(htmlChunk, state, i, i + 1)
+        i++
         continue
       }
 
       if (!tagName) {
-        textBuffer += htmlChunk[i++]
+        textBuffer += serializeTextContent(htmlChunk, state, i, i + 1)
+        i++
         continue
       }
 
@@ -695,7 +633,8 @@ function parseHtmlInternal(
       const result = processOpeningTag(tagName, tagId, htmlChunk, i2, state, handleEvent)
 
       if (result.skip) {
-        textBuffer += htmlChunk[i++]
+        textBuffer += serializeTextContent(htmlChunk, state, i, i + 1)
+        i++
       }
       else if (result.complete) {
         i = result.newPosition
@@ -995,12 +934,10 @@ function processCommentOrDoctype(htmlChunk: string, position: number): {
 /**
  * Handle a CDATA section's inner content.
  *
- * CDATA is discarded by default (matching the HTML spec, where `<![CDATA[`
- * outside foreign content is a bogus comment). Callers opt in by registering a
- * `#cdata-section` entry in `tagOverrides`; the leading `#` makes the pseudo-tag
- * impossible to collide with a real HTML element name. When an override exists
- * the content is emitted as a synthetic `#cdata-section` element whose rendering
- * follows the override handler.
+ * CDATA markup is omitted by default while the inner content is emitted as text.
+ * Callers can register a `#cdata-section` entry in `tagOverrides` to render a
+ * synthetic pseudo-element instead; the leading `#` makes it impossible to
+ * collide with a real HTML element name.
  */
 function processCdataSection(
   content: string,
@@ -1037,6 +974,101 @@ function processCdataSection(
   }
 
   closeNode(state.currentNode ?? null, state, handleEvent)
+}
+
+/**
+ * Append already-classified text into the pending text buffer.
+ *
+ * This applies the normal whitespace, entity, rawtext quote, and markdown
+ * escaping rules, but does not parse `<` as markup. The main scanner passes
+ * text ranges; CDATA passes its inner content so only the delimiters are
+ * omitted.
+ */
+function serializeTextContent(
+  content: string,
+  state: ParseState,
+  start = 0,
+  end = content.length,
+): string {
+  let textBuffer = ''
+  const inPreTag = (state.depthMap[TAG_PRE] || 0) > 0
+  const inCodeOrPre = !!(state.depthMap[TAG_CODE] || state.depthMap[TAG_PRE])
+  const inLink = !!state.depthMap[TAG_A]
+  const inTable = !!state.depthMap[TAG_TABLE]
+  const inBlockquote = !!state.depthMap[TAG_BLOCKQUOTE]
+
+  for (let i = start; i < end; i++) {
+    const currentCharCode = content.charCodeAt(i)
+
+    if (currentCharCode === AMPERSAND_CHAR) {
+      state.hasEncodedHtmlEntity = true
+    }
+
+    if (isWhitespace(currentCharCode)) {
+      if (state.justClosedTag) {
+        state.justClosedTag = false
+        state.lastCharWasWhitespace = false
+      }
+
+      if (!inPreTag && state.lastCharWasWhitespace) {
+        continue
+      }
+
+      if (inPreTag) {
+        textBuffer += content[i]
+      }
+      else if (currentCharCode === SPACE_CHAR || !state.lastCharWasWhitespace) {
+        textBuffer += ' '
+      }
+
+      state.lastCharWasWhitespace = true
+      state.textBufferContainsWhitespace = true
+      state.lastCharWasBackslash = false
+      continue
+    }
+
+    state.textBufferContainsNonWhitespace = true
+    state.lastCharWasWhitespace = false
+    state.justClosedTag = false
+
+    if (currentCharCode === PIPE_CHAR && inTable) {
+      textBuffer += '\\|'
+    }
+    else if (currentCharCode === BACKTICK_CHAR && inCodeOrPre) {
+      textBuffer += '\\`'
+    }
+    else if (currentCharCode === OPEN_BRACKET_CHAR && inLink) {
+      textBuffer += '\\['
+    }
+    else if (currentCharCode === CLOSE_BRACKET_CHAR && inLink) {
+      textBuffer += '\\]'
+    }
+    else if (currentCharCode === GT_CHAR && inBlockquote) {
+      textBuffer += '\\>'
+    }
+    else {
+      textBuffer += content[i]
+    }
+
+    // Track quote state for quote-aware rawtext tags (script/style only)
+    if (state.inRawTextQuoteAware) {
+      if (!state.lastCharWasBackslash) {
+        if (currentCharCode === APOS_CHAR && !state.inDoubleQuote && !state.inBacktick) {
+          state.inSingleQuote = !state.inSingleQuote
+        }
+        else if (currentCharCode === QUOTE_CHAR && !state.inSingleQuote && !state.inBacktick) {
+          state.inDoubleQuote = !state.inDoubleQuote
+        }
+        else if (currentCharCode === BACKTICK_CHAR && !state.inSingleQuote && !state.inDoubleQuote) {
+          state.inBacktick = !state.inBacktick
+        }
+      }
+    }
+
+    state.lastCharWasBackslash = currentCharCode === BACKSLASH_CHAR && !state.lastCharWasBackslash
+  }
+
+  return textBuffer
 }
 
 /**

--- a/packages/mdream/test/unit/nodes/code.test.ts
+++ b/packages/mdream/test/unit/nodes/code.test.ts
@@ -170,13 +170,12 @@ Text without newline above.
     expect(markdown).toBe('```javascript\nconst x = 1;\n```')
   })
 
-  // Regression guard for issue #98: a CDATA section inside <pre><code> must be
-  // dropped by default (no tagOverrides), leaving the code block intact rather
-  // than leaking the content or breaking the surrounding markup.
-  it('drops CDATA sections inside code blocks by default (issue #98)', async () => {
+  // Regression guard for issue #98: a CDATA section inside <pre><code> should
+  // omit the CDATA delimiters by default while preserving the code text.
+  it('emits CDATA content inside code blocks without markup by default (issue #98)', async () => {
     const engine = await resolveEngine(engineConfig.engine)
     const html = '<pre><code><![CDATA[\none two\nthree four\n]]></code></pre>'
     const markdown = htmlToMarkdown(html, { engine })
-    expect(markdown).toBe('```\n\n```')
+    expect(markdown).toBe('```\none two\nthree four\n```')
   })
 })

--- a/packages/mdream/test/unit/plugins/tag-overrides.test.ts
+++ b/packages/mdream/test/unit/plugins/tag-overrides.test.ts
@@ -130,14 +130,22 @@ describe.each(engines)('tagOverrides $name', (engineConfig) => {
     expect(extracted).toEqual(['italic'])
   })
 
-  it('drops CDATA sections by default', async () => {
+  it('emits CDATA content without markup by default', async () => {
     const engine = await resolveEngine(engineConfig.engine)
     const markdown = htmlToMarkdown('<p>before<![CDATA[secret payload]]>after</p>', {
       engine,
     })
-    expect(markdown).not.toContain('secret payload')
-    expect(markdown).toContain('before')
-    expect(markdown).toContain('after')
+    expect(markdown).toBe('beforesecret payloadafter')
+    expect(markdown).not.toContain('<![CDATA[')
+    expect(markdown).not.toContain(']]>')
+  })
+
+  it('sends CDATA content through the text pipeline by default', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const markdown = htmlToMarkdown('<p>a &amp; <![CDATA[b &amp; c]]></p>', {
+      engine,
+    })
+    expect(markdown).toBe('a & b & c')
   })
 
   it('emits CDATA content via #cdata-section enter/exit override', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #98

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

CDATA support exists, but the default path still dropped the section payload. This changes the Rust and JS parsers to emit CDATA inner content through the normal text pipeline while omitting only the `<![CDATA[` / `]]>` delimiters.

The `#cdata-section` override remains available for custom wrappers or aliases. Tests cover default inline output, entity handling through the text pipeline, default code-block output, explicit override output, and conditional comments such as `<![if !IE]>`.

### ✅ Verification

- `cargo test --manifest-path crates/Cargo.toml -p mdream`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec vitest test packages/mdream/test/unit/plugins/tag-overrides.test.ts packages/mdream/test/unit/nodes/code.test.ts --project node`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CDATA sections are now handled more consistently during HTML-to-markdown conversion: the CDATA wrapper is removed, and the inner content is preserved by default.
  * CDATA payload now goes through the normal text/entity pipeline, including inside `<pre><code>`, where it renders as code text without CDATA delimiters.
  * When a custom CDATA override is enabled, pending buffered text is handled correctly.
* **Tests**
  * Updated and expanded conversion and tag-override tests to reflect the new default CDATA behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->