### PR TITLE
fix: omit CDATA markup by default without hot-loop regression

### DIFF
--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -516,20 +516,26 @@ impl ConvertState {
 
             if next == EXCLAMATION_CHAR {
                 let remaining = &chunk[i..];
-                // CDATA is dropped by default but can be surfaced via
-                // tagOverrides["#cdata-section"]. Handle it before the generic
-                // comment/doctype scan, which would otherwise stop at the first
-                // `>` inside `]]>` and discard the content. We already matched
-                // `<!`, so only the `[CDATA[` tail is checked; `strip_prefix`
-                // short-circuits on the third byte for the common comment and
-                // doctype cases.
+                // CDATA delimiters are omitted; the inner content is emitted
+                // through the normal text pipeline (`append_text_content`), or
+                // as a synthetic element when tagOverrides["#cdata-section"] is
+                // registered. Handle it before the generic comment/doctype scan,
+                // which would otherwise stop at the first `>` inside `]]>` and
+                // discard the content. We already matched `<!`, so only the
+                // `[CDATA[` tail is checked; `strip_prefix` short-circuits on the
+                // third byte for the common comment and doctype cases.
                 if let Some(after_open) = chunk[i + 2..].strip_prefix("[CDATA[") {
                     if let Some(rel) = after_open.find("]]>") {
-                        if !text_buffer.is_empty() {
-                            self.process_text_buffer(&mut text_buffer);
-                            text_buffer.clear();
+                        let content = &after_open[..rel];
+                        if self.has_cdata_section_override() {
+                            if !text_buffer.is_empty() {
+                                self.process_text_buffer(&mut text_buffer);
+                                text_buffer.clear();
+                            }
+                            self.process_cdata_section(content);
+                        } else {
+                            self.append_text_content(content, &mut text_buffer);
                         }
-                        self.process_cdata_section(&after_open[..rel]);
                         i += "<![CDATA[".len() + rel + 3;
                         continue;
                     }

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -887,15 +887,99 @@ impl ConvertState {
         CloseTagResult { complete: true, new_position: i + 1, remaining_start: 0 }
     }
 
-    /// Handle a CDATA section's inner content.
+    /// Whether a `#cdata-section` entry is registered in `tagOverrides`.
     ///
-    /// CDATA is discarded by default (matching the HTML spec, where `<![CDATA[`
-    /// outside foreign content is a bogus comment). Callers opt in by registering
-    /// a `#cdata-section` entry in `tagOverrides`; the leading `#` makes the
-    /// pseudo-tag impossible to collide with a real HTML element name. When an
-    /// override exists the content is emitted as a synthetic `#cdata-section`
-    /// element whose rendering follows the override (alias tag and/or
-    /// enter/exit strings).
+    /// When present the caller emits CDATA as a synthetic element via
+    /// `process_cdata_section`; otherwise the delimiters are omitted and the
+    /// inner content flows through the normal text pipeline
+    /// (`append_text_content`).
+    pub(crate) fn has_cdata_section_override(&self) -> bool {
+        self.has_tag_overrides
+            && self.options.plugins.as_ref()
+                .and_then(|p| p.tag_overrides.as_ref())
+                .is_some_and(|ovs| ovs.iter().any(|(k, _)| k == "#cdata-section"))
+    }
+
+    /// Append CDATA inner content into the pending text buffer.
+    ///
+    /// Runs the same per-character whitespace, entity, and markdown-escaping
+    /// rules as the main text scanner, but treats `<` as literal text. Only the
+    /// `<![CDATA[` / `]]>` delimiters are omitted; the content is otherwise
+    /// indistinguishable from surrounding text (issue #98). Kept separate from
+    /// the main scan loop so that hot path stays a tight inline loop.
+    pub(crate) fn append_text_content(&mut self, content: &str, text_buffer: &mut String) {
+        let bytes = content.as_bytes();
+        let mut i = 0;
+
+        while i < bytes.len() {
+            let cc = bytes[i];
+
+            if cc == AMPERSAND_CHAR {
+                self.has_encoded_html_entity = true;
+            }
+
+            if is_whitespace(cc) {
+                if self.just_closed_tag {
+                    self.just_closed_tag = false;
+                    self.last_char_was_whitespace = false;
+                }
+                if !self.in_pre && self.last_char_was_whitespace {
+                    i += 1;
+                    continue;
+                }
+                if self.in_pre {
+                    text_buffer.push(cc as char);
+                } else if cc == SPACE_CHAR || !self.last_char_was_whitespace {
+                    text_buffer.push(' ');
+                }
+                self.last_char_was_whitespace = true;
+                self.text_buffer_contains_whitespace = true;
+                i += 1;
+                continue;
+            }
+
+            self.text_buffer_contains_non_whitespace = true;
+            self.last_char_was_whitespace = false;
+            self.just_closed_tag = false;
+
+            if self.escape_ctx == 0 {
+                if cc < 0x80 {
+                    text_buffer.push(cc as char);
+                } else if let Some(ch) = content[i..].chars().next() {
+                    text_buffer.push(ch);
+                    i += ch.len_utf8();
+                    continue;
+                }
+            } else if cc == PIPE_CHAR && (self.escape_ctx & ESC_TABLE) != 0 {
+                text_buffer.push_str("\\|");
+            } else if cc == BACKTICK_CHAR && (self.escape_ctx & ESC_CODE_PRE) != 0 {
+                text_buffer.push_str("\\`");
+            } else if cc == OPEN_BRACKET_CHAR && (self.escape_ctx & ESC_LINK) != 0 {
+                text_buffer.push_str("\\[");
+            } else if cc == CLOSE_BRACKET_CHAR && (self.escape_ctx & ESC_LINK) != 0 {
+                text_buffer.push_str("\\]");
+            } else if cc == GT_CHAR && (self.escape_ctx & ESC_BLOCKQUOTE) != 0 {
+                text_buffer.push_str("\\>");
+            } else if cc < 0x80 {
+                text_buffer.push(cc as char);
+            } else if let Some(ch) = content[i..].chars().next() {
+                text_buffer.push(ch);
+                i += ch.len_utf8();
+                continue;
+            }
+
+            i += 1;
+        }
+    }
+
+    /// Handle a CDATA section's inner content when a `#cdata-section` override
+    /// is registered.
+    ///
+    /// The content is emitted as a synthetic `#cdata-section` element whose
+    /// rendering follows the override (alias tag and/or enter/exit strings); the
+    /// leading `#` makes the pseudo-tag impossible to collide with a real HTML
+    /// element name. Without an override the caller omits the delimiters and
+    /// routes the content through `append_text_content` instead.
     pub(crate) fn process_cdata_section(&mut self, content: &str) {
         if !self.has_tag_overrides { return; }
         let Some(tag_id) = self.options.plugins.as_ref()

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -1694,10 +1694,35 @@ fn script_with_cdata_like_content() {
 }
 
 #[test]
-fn cdata_dropped_by_default() {
-    // CDATA sections are discarded unless opted into via tagOverrides.
-    let md = convert("before <![CDATA[secret payload]]> after");
-    assert!(!md.contains("secret payload"), "CDATA leaked into output: {md}");
+fn cdata_omits_markup_by_default() {
+    // Only the <![CDATA[ / ]]> delimiters are omitted; the content flows through
+    // the normal text pipeline (issue #98).
+    let md = convert("<body><p>before<![CDATA[secret payload]]>after</p></body>");
+    assert_eq!(md, "beforesecret payloadafter");
+    assert!(!md.contains("<![CDATA["), "CDATA opener leaked: {md}");
+    assert!(!md.contains("]]>"), "CDATA closer leaked: {md}");
+}
+
+#[test]
+fn cdata_preserves_surrounding_whitespace() {
+    // Real whitespace between text and a CDATA section survives; the content is
+    // not glued to its neighbours.
+    let md = convert("<body><p>a &amp; <![CDATA[b &amp; c]]></p></body>");
+    assert_eq!(md, "a & b & c");
+}
+
+#[test]
+fn cdata_treats_angle_brackets_as_text() {
+    // `<` inside CDATA is literal, never parsed as markup.
+    let md = convert("<body><p><![CDATA[1 < 2 <b>x</b>]]></p></body>");
+    assert_eq!(md, "1 < 2 <b>x</b>");
+}
+
+#[test]
+fn cdata_omits_markup_in_code_block_by_default() {
+    // Issue #98: a CDATA-wrapped code block keeps its content and newlines.
+    let md = convert("<body><pre><code><![CDATA[\none two\nthree four\n]]></code></pre></body>");
+    assert_eq!(md, "```\none two\nthree four\n```");
 }
 
 #[test]

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -588,10 +588,11 @@ function parseHtmlInternal(
       // Discriminate on the third char: '[' is a CDATA section, anything else
       // is a comment/doctype. Only the rare '[' case pays for the string work.
       if (htmlChunk.charCodeAt(i + 2) === OPEN_BRACKET_CHAR) {
-        // CDATA is dropped by default but can be surfaced via
-        // tagOverrides['#cdata-section']. Handle it before the generic
-        // comment/doctype scan, which would otherwise stop at the first `>`
-        // inside `]]>` and discard the content.
+        // CDATA delimiters are omitted; the inner content is emitted through
+        // the normal text pipeline (serializeTextContent), or as a synthetic
+        // element when tagOverrides['#cdata-section'] is registered. Handle it
+        // before the generic comment/doctype scan, which would otherwise stop
+        // at the first `>` inside `]]>` and discard the content.
         if (htmlChunk.startsWith('<![CDATA[', i)) {
           const end = htmlChunk.indexOf(']]>', i + 9)
           if (end === -1) {
@@ -599,11 +600,17 @@ function parseHtmlInternal(
             textBuffer += htmlChunk.substring(i)
             break
           }
-          if (textBuffer.length > 0) {
-            processTextBuffer(textBuffer, state, handleEvent)
-            textBuffer = ''
+          const content = htmlChunk.substring(i + 9, end)
+          if (state.tagOverrideHandlers?.has('#cdata-section')) {
+            if (textBuffer.length > 0) {
+              processTextBuffer(textBuffer, state, handleEvent)
+              textBuffer = ''
+            }
+            processCdataSection(content, state, handleEvent)
           }
-          processCdataSection(htmlChunk.substring(i + 9, end), state, handleEvent)
+          else {
+            textBuffer += serializeTextContent(content, state)
+          }
           i = end + 3
           continue
         }
@@ -1033,14 +1040,99 @@ function processCommentOrDoctype(htmlChunk: string, position: number): {
 }
 
 /**
- * Handle a CDATA section's inner content.
+ * Append CDATA inner content into the pending text buffer.
  *
- * CDATA is discarded by default (matching the HTML spec, where `<![CDATA[`
- * outside foreign content is a bogus comment). Callers opt in by registering a
- * `#cdata-section` entry in `tagOverrides`; the leading `#` makes the pseudo-tag
- * impossible to collide with a real HTML element name. When an override exists
- * the content is emitted as a synthetic `#cdata-section` element whose rendering
- * follows the override handler.
+ * Runs the same per-character whitespace, entity, rawtext-quote, and markdown
+ * escaping rules as the main text scanner, but treats `<` as literal text. Only
+ * the `<![CDATA[` / `]]>` delimiters are omitted; the content is otherwise
+ * indistinguishable from surrounding text (issue #98). Kept separate from the
+ * main scan loop so that hot path stays a tight inline loop.
+ */
+function serializeTextContent(content: string, state: ParseState): string {
+  let textBuffer = ''
+  const inPreTag = (state.depthMap[TAG_PRE] || 0) > 0
+  const inCodeOrPre = !!(state.depthMap[TAG_CODE] || state.depthMap[TAG_PRE])
+  const inLink = !!state.depthMap[TAG_A]
+  const inTable = !!state.depthMap[TAG_TABLE]
+  const inBlockquote = !!state.depthMap[TAG_BLOCKQUOTE]
+
+  for (let i = 0; i < content.length; i++) {
+    const currentCharCode = content.charCodeAt(i)
+
+    if (currentCharCode === AMPERSAND_CHAR) {
+      state.hasEncodedHtmlEntity = true
+    }
+
+    if (isWhitespace(currentCharCode)) {
+      if (state.justClosedTag) {
+        state.justClosedTag = false
+        state.lastCharWasWhitespace = false
+      }
+      if (!inPreTag && state.lastCharWasWhitespace) {
+        continue
+      }
+      if (inPreTag) {
+        textBuffer += content[i]
+      }
+      else if (currentCharCode === SPACE_CHAR || !state.lastCharWasWhitespace) {
+        textBuffer += ' '
+      }
+      state.lastCharWasWhitespace = true
+      state.textBufferContainsWhitespace = true
+      state.lastCharWasBackslash = false
+      continue
+    }
+
+    state.textBufferContainsNonWhitespace = true
+    state.lastCharWasWhitespace = false
+    state.justClosedTag = false
+
+    if (currentCharCode === PIPE_CHAR && inTable) {
+      textBuffer += '\\|'
+    }
+    else if (currentCharCode === BACKTICK_CHAR && inCodeOrPre) {
+      textBuffer += '\\`'
+    }
+    else if (currentCharCode === OPEN_BRACKET_CHAR && inLink) {
+      textBuffer += '\\['
+    }
+    else if (currentCharCode === CLOSE_BRACKET_CHAR && inLink) {
+      textBuffer += '\\]'
+    }
+    else if (currentCharCode === GT_CHAR && inBlockquote) {
+      textBuffer += '\\>'
+    }
+    else {
+      textBuffer += content[i]
+    }
+
+    // Track quote state for quote-aware rawtext tags (script/style only)
+    if (state.inRawTextQuoteAware && !state.lastCharWasBackslash) {
+      if (currentCharCode === APOS_CHAR && !state.inDoubleQuote && !state.inBacktick) {
+        state.inSingleQuote = !state.inSingleQuote
+      }
+      else if (currentCharCode === QUOTE_CHAR && !state.inSingleQuote && !state.inBacktick) {
+        state.inDoubleQuote = !state.inDoubleQuote
+      }
+      else if (currentCharCode === BACKTICK_CHAR && !state.inSingleQuote && !state.inDoubleQuote) {
+        state.inBacktick = !state.inBacktick
+      }
+    }
+
+    state.lastCharWasBackslash = currentCharCode === BACKSLASH_CHAR && !state.lastCharWasBackslash
+  }
+
+  return textBuffer
+}
+
+/**
+ * Handle a CDATA section's inner content when a `#cdata-section` override is
+ * registered.
+ *
+ * The content is emitted as a synthetic `#cdata-section` element whose rendering
+ * follows the override handler; the leading `#` makes the pseudo-tag impossible
+ * to collide with a real HTML element name. Without an override the caller omits
+ * the delimiters and routes the content through `serializeTextContent` instead.
  */
 function processCdataSection(
   content: string,

--- a/packages/mdream/test/unit/nodes/code.test.ts
+++ b/packages/mdream/test/unit/nodes/code.test.ts
@@ -170,13 +170,13 @@ Text without newline above.
     expect(markdown).toBe('```javascript\nconst x = 1;\n```')
   })
 
-  // Regression guard for issue #98: a CDATA section inside <pre><code> must be
-  // dropped by default (no tagOverrides), leaving the code block intact rather
-  // than leaking the content or breaking the surrounding markup.
-  it('drops CDATA sections inside code blocks by default (issue #98)', async () => {
+  // Regression guard for issue #98: a CDATA section inside <pre><code> keeps
+  // its content by default (no tagOverrides), omitting only the delimiters so
+  // the code block renders the payload verbatim.
+  it('emits CDATA content inside code blocks without markup by default (issue #98)', async () => {
     const engine = await resolveEngine(engineConfig.engine)
     const html = '<pre><code><![CDATA[\none two\nthree four\n]]></code></pre>'
     const markdown = htmlToMarkdown(html, { engine })
-    expect(markdown).toBe('```\n\n```')
+    expect(markdown).toBe('```\none two\nthree four\n```')
   })
 })

--- a/packages/mdream/test/unit/plugins/tag-overrides.test.ts
+++ b/packages/mdream/test/unit/plugins/tag-overrides.test.ts
@@ -130,14 +130,22 @@ describe.each(engines)('tagOverrides $name', (engineConfig) => {
     expect(extracted).toEqual(['italic'])
   })
 
-  it('drops CDATA sections by default', async () => {
+  it('emits CDATA content without markup by default', async () => {
     const engine = await resolveEngine(engineConfig.engine)
     const markdown = htmlToMarkdown('<p>before<![CDATA[secret payload]]>after</p>', {
       engine,
     })
-    expect(markdown).not.toContain('secret payload')
-    expect(markdown).toContain('before')
-    expect(markdown).toContain('after')
+    expect(markdown).toBe('beforesecret payloadafter')
+    expect(markdown).not.toContain('<![CDATA[')
+    expect(markdown).not.toContain(']]>')
+  })
+
+  it('sends CDATA content through the text pipeline by default', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const markdown = htmlToMarkdown('<p>a &amp; <![CDATA[b &amp; c]]></p>', {
+      engine,
+    })
+    expect(markdown).toBe('a & b & c')
   })
 
   it('emits CDATA content via #cdata-section enter/exit override', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #98

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

CDATA sections were dropped entirely by default, so content like `<pre><code><![CDATA[...]]></code></pre>` lost its payload (#98). This routes the inner content through the normal text pipeline, omitting only the `<![CDATA[` / `]]>` delimiters. Content flows through the same whitespace, entity, and escaping rules as surrounding text, with `<` treated as literal so `<b>` inside CDATA is not parsed as markup.

The work happens in a CDATA-only helper (`append_text_content` in Rust, `serializeTextContent` in JS) called from the CDATA branch. Both engines' per-character scan loops are left byte-for-byte unchanged, so there is no throughput regression (benchmarks match `main`: github-docs ~725 MB/s, wikipedia-10x ~415 MB/s). This is an alternative to #115, which produced the same behavior but refactored the hot loop and cost 10-25% throughput.

The `#cdata-section` tagOverride still renders a synthetic element for callers who want a custom wrapper.

Verified: 7 Rust CDATA tests, full JS suite (1028 passing), both engines produce identical output across basic inline, preserved surrounding whitespace, literal angle brackets, code blocks, and the override path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - CDATA content is now preserved and emitted as regular text by default.
  - CDATA markers are omitted from converted output.
  - CDATA text follows standard whitespace, escaping, entity, and code-block handling.
  - Existing `#cdata-section` overrides continue to support custom processing.

- **Bug Fixes**
  - Preserved CDATA content inside code blocks and surrounding text.
  - Correctly treats `<` and `>` within CDATA as literal characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->