### PR TITLE
feat(crawl): add --sitemap override and harden sitemap detection

### DIFF
--- a/packages/crawl/README.md
+++ b/packages/crawl/README.md
@@ -49,6 +49,7 @@ npx @mdream/crawl -u https://docs.example.com
 | `--crawl-delay <seconds>` | | Delay between requests in seconds | from `robots.txt` or none |
 | `--exclude <pattern>` | | Exclude URLs matching glob patterns (repeatable) | none |
 | `--skip-sitemap` | | Skip `sitemap.xml` and `robots.txt` discovery | `false` |
+| `--sitemap <url>` | | Use an explicit sitemap URL instead of auto-discovery (repeatable for multi-part sitemaps) | auto-discovered |
 | `--allow-subdomains` | | Crawl across subdomains of the same root domain | `false` |
 | `--verbose` | `-v` | Enable verbose logging | `false` |
 | `--help` | `-h` | Show help message | |
@@ -131,6 +132,7 @@ const results = await crawlAndGenerate({
 | `exclude` | `string[]` | `[]` | Glob patterns for URLs to exclude |
 | `crawlDelay` | `number` | from `robots.txt` | Delay between requests in seconds |
 | `skipSitemap` | `boolean` | `false` | Skip `sitemap.xml` and `robots.txt` discovery |
+| `sitemapUrls` | `string[]` | auto-discovered | Explicit sitemap URL(s) to use instead of auto-discovery. Supports non-standard locations and multiple parts (all loaded and merged). Ignored when `skipSitemap` is set |
 | `allowSubdomains` | `boolean` | `false` | Crawl across subdomains of the same root domain (e.g. `docs.example.com` + `blog.example.com`). Output files are namespaced by hostname to avoid collisions |
 | `useChrome` | `boolean` | `false` | Use system Chrome instead of Playwright's bundled browser (Playwright driver only) |
 | `chunkSize` | `number` | | Chunk size passed to mdream for markdown conversion |
@@ -294,6 +296,7 @@ CLI arguments override config file values. Array options like `exclude` are conc
 | `maxPages` | `number` | Maximum pages to crawl |
 | `crawlDelay` | `number` | Delay between requests (seconds) |
 | `skipSitemap` | `boolean` | Skip sitemap discovery |
+| `sitemap` | `string \| string[]` | Explicit sitemap URL(s) to use instead of auto-discovery |
 | `allowSubdomains` | `boolean` | Crawl across subdomains |
 | `verbose` | `boolean` | Enable verbose logging |
 | `artifacts` | `string[]` | Output formats: `llms.txt`, `llms-full.txt`, `markdown` |
@@ -437,15 +440,46 @@ Waits for `networkidle` before extracting content. Automatically detects and use
 By default, the crawler performs sitemap discovery before crawling:
 
 1. Fetches `robots.txt` to find `Sitemap:` directives and `Crawl-delay` values
-2. Loads sitemaps referenced in `robots.txt`
+2. Loads sitemaps referenced in `robots.txt` (authoritative, tried first)
 3. Falls back to `/sitemap.xml`
 4. Tries common alternatives: `/sitemap_index.xml`, `/sitemaps.xml`, `/sitemap-index.xml`
-5. Supports sitemap index files (recursively loads child sitemaps)
+5. Supports sitemap index files (recursively loads child sitemaps, with cycle protection)
 6. Filters discovered URLs against glob patterns and exclusion rules
+
+The first candidate that yields matching URLs wins, so a `robots.txt` sitemap is never overwritten by a well-known fallback. `<loc>` values are CDATA-unwrapped and XML-entity-decoded (`&amp;` → `&`).
 
 The home page is always included for metadata extraction (site name, description).
 
 Disable with `--skip-sitemap` or `skipSitemap: true`.
+
+### Overriding the sitemap location
+
+When a site keeps its sitemap at a non-standard URL, or splits it across several links, pin the location(s) explicitly instead of relying on discovery:
+
+```bash
+# Single non-standard location
+npx @mdream/crawl -u example.com --sitemap https://example.com/custom/sitemap.xml
+
+# Multiple parts (repeatable), all loaded and merged
+npx @mdream/crawl -u example.com \
+  --sitemap https://example.com/sitemap-posts.xml \
+  --sitemap https://example.com/sitemap-pages.xml
+```
+
+Or in `mdream.config.ts`:
+
+```ts
+import { defineConfig } from '@mdream/crawl'
+
+export default defineConfig({
+  sitemap: [
+    'https://example.com/sitemap-posts.xml',
+    'https://example.com/sitemap-pages.xml',
+  ],
+})
+```
+
+An explicit sitemap replaces auto-discovery entirely (`robots.txt` is still read for `Crawl-delay`).
 
 ## Output Formats
 

--- a/packages/crawl/src/cli.ts
+++ b/packages/crawl/src/cli.ts
@@ -466,6 +466,13 @@ Examples:
 
   // Explicit sitemap override(s). Repeatable; each is normalized to https.
   const sitemapUrls = getArgValues('--sitemap').map(u => withHttps(u))
+  // getArgValues drops a --sitemap with no following value; catch that so a
+  // typo can't silently fall through to auto-discovery.
+  const sitemapFlagCount = args.filter(a => a === '--sitemap' || a === '-sitemap').length
+  if (sitemapFlagCount > sitemapUrls.length) {
+    logger.error('Error: --sitemap requires a URL value')
+    process.exit(1)
+  }
   for (const sitemapUrl of sitemapUrls) {
     try {
       // eslint-disable-next-line no-new

--- a/packages/crawl/src/cli.ts
+++ b/packages/crawl/src/cli.ts
@@ -289,6 +289,7 @@ Options:
   --crawl-delay <seconds>     Crawl delay in seconds
   --exclude <pattern>         Exclude URLs matching glob patterns (can be used multiple times)
   --skip-sitemap              Skip sitemap.xml and robots.txt discovery
+  --sitemap <url>             Use an explicit sitemap URL instead of auto-discovery (repeatable for multi-part sitemaps)
   --allow-subdomains          Crawl across subdomains of the same root domain
   --keep-boilerplate          Keep repeated site chrome (nav/footer) in per-page output (default: stripped)
   --boilerplate-threshold <n> Fraction of pages a block must repeat in to count as chrome (0-1, default: ${DEFAULT_BOILERPLATE_THRESHOLD})
@@ -305,6 +306,7 @@ Examples:
   @mdream/crawl -u example.com --exclude "*/admin/*" --exclude "*/api/*"
   @mdream/crawl -u example.com --verbose
   @mdream/crawl -u example.com --skip-sitemap
+  @mdream/crawl -u example.com --sitemap https://example.com/custom/sitemap.xml
   @mdream/crawl -u example.com --driver playwright --single-page
 `)
     process.exit(0)
@@ -462,6 +464,19 @@ Examples:
   // Check for skip-sitemap flag
   const skipSitemap = args.includes('--skip-sitemap')
 
+  // Explicit sitemap override(s). Repeatable; each is normalized to https.
+  const sitemapUrls = getArgValues('--sitemap').map(u => withHttps(u))
+  for (const sitemapUrl of sitemapUrls) {
+    try {
+      // eslint-disable-next-line no-new
+      new URL(sitemapUrl)
+    }
+    catch {
+      logger.error(`Error: Invalid sitemap URL: ${sitemapUrl}`)
+      process.exit(1)
+    }
+  }
+
   // Check for allow-subdomains flag
   const allowSubdomains = args.includes('--allow-subdomains')
 
@@ -503,6 +518,7 @@ Examples:
     exclude: excludePatterns.length > 0 ? excludePatterns : undefined,
     verbose,
     skipSitemap,
+    sitemapUrls: sitemapUrls.length > 0 ? sitemapUrls : undefined,
     allowSubdomains,
     stripBoilerplate,
     boilerplateThreshold,
@@ -538,6 +554,10 @@ async function main() {
       maxDepth: cliOptions.maxDepth ?? fileConfig.maxDepth,
       crawlDelay: cliOptions.crawlDelay ?? fileConfig.crawlDelay,
       skipSitemap: cliOptions.skipSitemap || fileConfig.skipSitemap || false,
+      sitemapUrls: cliOptions.sitemapUrls
+        ?? (fileConfig.sitemap
+          ? (Array.isArray(fileConfig.sitemap) ? fileConfig.sitemap : [fileConfig.sitemap])
+          : undefined),
       allowSubdomains: cliOptions.allowSubdomains || fileConfig.allowSubdomains || false,
       stripBoilerplate: cliOptions.stripBoilerplate ?? fileConfig.stripBoilerplate ?? true,
       boilerplateThreshold: cliOptions.boilerplateThreshold ?? fileConfig.boilerplateThreshold,
@@ -567,6 +587,7 @@ async function main() {
       `Formats: ${formats.join(', ')}`,
       options.exclude && options.exclude.length > 0 && `Exclude: ${options.exclude.join(', ')}`,
       options.skipSitemap && `Skip sitemap: Yes`,
+      options.sitemapUrls && options.sitemapUrls.length > 0 && `Sitemap: ${options.sitemapUrls.join(', ')}`,
       options.allowSubdomains && `Allow subdomains: Yes`,
       options.verbose && `Verbose: Enabled`,
     ].filter(Boolean)

--- a/packages/crawl/src/crawl.ts
+++ b/packages/crawl/src/crawl.ts
@@ -87,6 +87,28 @@ function extractCdataUrl(url: string): string {
   return url
 }
 
+/**
+ * Decode the 5 XML predefined entities that the sitemap spec requires inside
+ * `<loc>` (https://www.sitemaps.org/protocol.html#escaping). Without this, URLs
+ * with query strings (`?a=1&amp;b=2`) are extracted with a literal `&amp;`.
+ * `&amp;` is decoded last so an already-single `&` isn't double-processed.
+ */
+function decodeXmlEntities(value: string): string {
+  if (!value.includes('&'))
+    return value
+  return value
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, '\'')
+    .replace(/&amp;/g, '&')
+}
+
+/** Extract, un-CDATA and entity-decode a `<loc>` value in one step. */
+function cleanLoc(raw: string): string {
+  return decodeXmlEntities(extractCdataUrl(raw.trim()))
+}
+
 /** Strip tracking params, fragments, and trailing slashes from a URL */
 export function normalizeUrl(resolved: URL): string {
   resolved.hash = ''
@@ -101,7 +123,13 @@ export function normalizeUrl(resolved: URL): string {
   return resolved.href.replace(URL_TRAILING_SLASH_RE, '') || resolved.href
 }
 
-async function loadSitemap(sitemapUrl: string): Promise<string[]> {
+async function loadSitemap(sitemapUrl: string, visited: Set<string> = new Set()): Promise<string[]> {
+  // Cycle guard: a sitemap index that references itself (directly or via a
+  // child) would otherwise recurse forever.
+  if (visited.has(sitemapUrl))
+    return []
+  visited.add(sitemapUrl)
+
   const xmlContent = await ofetch(sitemapUrl, {
     headers: FETCH_HEADERS,
     timeout: 10000,
@@ -121,11 +149,11 @@ async function loadSitemap(sitemapUrl: string): Promise<string[]> {
       match = SITEMAP_INDEX_LOC_RE.exec(xmlContent)
       if (match === null)
         break
-      childSitemaps.push(extractCdataUrl(match[1]))
+      childSitemaps.push(cleanLoc(match[1]))
     }
 
     const childResults = await Promise.allSettled(
-      childSitemaps.map(url => loadSitemap(url)),
+      childSitemaps.map(url => loadSitemap(url, visited)),
     )
 
     const allUrls: string[] = []
@@ -144,7 +172,7 @@ async function loadSitemap(sitemapUrl: string): Promise<string[]> {
     match = SITEMAP_URL_LOC_RE.exec(xmlContent)
     if (match === null)
       break
-    urls.push(extractCdataUrl(match[1]))
+    urls.push(cleanLoc(match[1]))
   }
   return urls
 }
@@ -292,6 +320,7 @@ export async function crawlAndGenerate(options: CrawlOptions, onProgress?: (prog
     descriptionOverride,
     verbose = false,
     skipSitemap = false,
+    sitemapUrls: explicitSitemapUrls,
     allowSubdomains = false,
     stripBoilerplate = true,
     boilerplateThreshold,
@@ -339,10 +368,13 @@ export async function crawlAndGenerate(options: CrawlOptions, onProgress?: (prog
   if (startingUrls.length > 0 && !skipSitemap && !singlePageMode) {
     const baseUrl = new URL(startingUrls[0]).origin
     const homePageUrl = baseUrl
+    const hasExplicitSitemaps = !!explicitSitemapUrls && explicitSitemapUrls.length > 0
 
     onProgress?.(progress)
 
-    // Fetch robots.txt
+    // robots.txt is still fetched even with an explicit sitemap override, since
+    // it also carries the Crawl-delay directive. Its Sitemap: entries only feed
+    // discovery when the user hasn't pinned a location.
     let robotsContent: string | null = null
     try {
       robotsContent = await ofetch(`${baseUrl}/robots.txt`, {
@@ -363,99 +395,81 @@ export async function crawlAndGenerate(options: CrawlOptions, onProgress?: (prog
       }
     }
 
-    if (robotsContent) {
-      const sitemapMatches = robotsContent.match(ROBOTS_SITEMAP_RE)
-      if (sitemapMatches && sitemapMatches.length > 0) {
-        progress.sitemap.found = sitemapMatches.length
-        progress.sitemap.status = 'processing'
-        onProgress?.(progress)
-
-        const robotsSitemaps = sitemapMatches.map(match => match.replace(ROBOTS_SITEMAP_PREFIX_RE, '').trim())
-
-        for (const sitemapUrl of robotsSitemaps) {
-          try {
-            const robotsUrls = await loadSitemap(sitemapUrl)
-            sitemapAttempts.push({ url: sitemapUrl, success: true })
-
-            const filteredUrls = filterSitemapUrls(robotsUrls, hasGlobPatterns, exclude, patterns, allowSubdomains)
-
-            if (hasGlobPatterns) {
-              startingUrls = filteredUrls
-              progress.sitemap.processed = filteredUrls.length
-              onProgress?.(progress)
-              break
-            }
-            else if (filteredUrls.length > 0) {
-              startingUrls = filteredUrls
-              progress.sitemap.processed = filteredUrls.length
-              onProgress?.(progress)
-              break
-            }
-          }
-          catch (error) {
-            sitemapAttempts.push({ url: sitemapUrl, success: false, error: error instanceof Error ? error.message : 'Unknown error' })
-          }
+    // Assemble the ordered list of sitemap URLs to try. An explicit override
+    // replaces discovery entirely; otherwise robots.txt Sitemap: entries take
+    // priority (authoritative) and well-known paths are the fallback.
+    const candidateSitemaps: string[] = []
+    if (hasExplicitSitemaps) {
+      candidateSitemaps.push(...explicitSitemapUrls)
+    }
+    else {
+      if (robotsContent) {
+        const sitemapMatches = robotsContent.match(ROBOTS_SITEMAP_RE)
+        if (sitemapMatches) {
+          for (const m of sitemapMatches)
+            candidateSitemaps.push(m.replace(ROBOTS_SITEMAP_PREFIX_RE, '').trim())
         }
       }
+      candidateSitemaps.push(
+        `${baseUrl}/sitemap.xml`,
+        `${baseUrl}/sitemap_index.xml`,
+        `${baseUrl}/sitemaps.xml`,
+        `${baseUrl}/sitemap-index.xml`,
+      )
     }
 
-    let mainSitemapProcessed = false
-    const mainSitemapUrl = `${baseUrl}/sitemap.xml`
-    try {
-      const sitemapUrls = await loadSitemap(mainSitemapUrl)
-      sitemapAttempts.push({ url: mainSitemapUrl, success: true })
+    if (candidateSitemaps.length > 0) {
+      progress.sitemap.status = 'processing'
+      progress.sitemap.found = candidateSitemaps.length
+      onProgress?.(progress)
+    }
 
-      const filteredUrls = filterSitemapUrls(sitemapUrls, hasGlobPatterns, exclude, patterns, allowSubdomains)
-
-      if (hasGlobPatterns) {
-        startingUrls = filteredUrls
-        progress.sitemap.found = sitemapUrls.length
-        progress.sitemap.processed = filteredUrls.length
-        onProgress?.(progress)
-        mainSitemapProcessed = true
+    if (hasExplicitSitemaps) {
+      // Multiple explicit sitemaps are treated as parts of one crawl surface:
+      // load them all and merge, rather than stopping at the first match.
+      const merged: string[] = []
+      for (const sitemapUrl of candidateSitemaps) {
+        try {
+          merged.push(...await loadSitemap(sitemapUrl))
+          sitemapAttempts.push({ url: sitemapUrl, success: true })
+        }
+        catch (error) {
+          sitemapAttempts.push({ url: sitemapUrl, success: false, error: error instanceof Error ? error.message : 'Unknown error' })
+        }
       }
-      else if (filteredUrls.length > 0) {
+      const dedupedUrls = merged.length > 0 ? [...new Set(merged)] : merged
+      const filteredUrls = filterSitemapUrls(dedupedUrls, hasGlobPatterns, exclude, patterns, allowSubdomains)
+      if (hasGlobPatterns || filteredUrls.length > 0) {
         startingUrls = filteredUrls
-        progress.sitemap.found = sitemapUrls.length
+        progress.sitemap.found = dedupedUrls.length
         progress.sitemap.processed = filteredUrls.length
         onProgress?.(progress)
-        mainSitemapProcessed = true
       }
     }
-    catch (error) {
-      sitemapAttempts.push({ url: mainSitemapUrl, success: false, error: error instanceof Error ? error.message : 'Unknown error' })
-      if (!mainSitemapProcessed) {
-        const commonSitemaps = [
-          `${baseUrl}/sitemap_index.xml`,
-          `${baseUrl}/sitemaps.xml`,
-          `${baseUrl}/sitemap-index.xml`,
-        ]
+    else {
+      // Auto-discovery: try candidates in priority order, stop at the first that
+      // yields usable URLs (or any success in glob mode, where an empty result
+      // still defines the crawl surface).
+      const seenCandidates = new Set<string>()
+      for (const sitemapUrl of candidateSitemaps) {
+        if (seenCandidates.has(sitemapUrl))
+          continue
+        seenCandidates.add(sitemapUrl)
+        try {
+          const foundUrls = await loadSitemap(sitemapUrl)
+          sitemapAttempts.push({ url: sitemapUrl, success: true })
 
-        for (const sitemapUrl of commonSitemaps) {
-          try {
-            const altUrls = await loadSitemap(sitemapUrl)
-            sitemapAttempts.push({ url: sitemapUrl, success: true })
-
-            const filteredUrls = filterSitemapUrls(altUrls, hasGlobPatterns, exclude, patterns, allowSubdomains)
-
-            if (hasGlobPatterns) {
-              startingUrls = filteredUrls
-              progress.sitemap.found = altUrls.length
-              progress.sitemap.processed = filteredUrls.length
-              onProgress?.(progress)
-              break
-            }
-            else if (filteredUrls.length > 0) {
-              startingUrls = filteredUrls
-              progress.sitemap.found = altUrls.length
-              progress.sitemap.processed = filteredUrls.length
-              onProgress?.(progress)
-              break
-            }
+          const filteredUrls = filterSitemapUrls(foundUrls, hasGlobPatterns, exclude, patterns, allowSubdomains)
+          if (hasGlobPatterns || filteredUrls.length > 0) {
+            startingUrls = filteredUrls
+            progress.sitemap.found = foundUrls.length
+            progress.sitemap.processed = filteredUrls.length
+            onProgress?.(progress)
+            break
           }
-          catch (error) {
-            sitemapAttempts.push({ url: sitemapUrl, success: false, error: error instanceof Error ? error.message : 'Unknown error' })
-          }
+        }
+        catch (error) {
+          sitemapAttempts.push({ url: sitemapUrl, success: false, error: error instanceof Error ? error.message : 'Unknown error' })
         }
       }
     }

--- a/packages/crawl/src/crawl.ts
+++ b/packages/crawl/src/crawl.ts
@@ -87,26 +87,38 @@ function extractCdataUrl(url: string): string {
   return url
 }
 
+const XML_ENTITIES: Record<string, string> = {
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&apos;': '\'',
+  '&amp;': '&',
+}
+const XML_ENTITY_RE = /&(?:lt|gt|quot|apos|amp);/g
+
 /**
  * Decode the 5 XML predefined entities that the sitemap spec requires inside
  * `<loc>` (https://www.sitemaps.org/protocol.html#escaping). Without this, URLs
  * with query strings (`?a=1&amp;b=2`) are extracted with a literal `&amp;`.
- * `&amp;` is decoded last so an already-single `&` isn't double-processed.
+ * Single left-to-right pass, so `&amp;lt;` decodes to a literal `&` plus `lt;`
+ * rather than being re-scanned into `<`.
  */
 function decodeXmlEntities(value: string): string {
   if (!value.includes('&'))
     return value
-  return value
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, '\'')
-    .replace(/&amp;/g, '&')
+  return value.replace(XML_ENTITY_RE, m => XML_ENTITIES[m])
 }
 
-/** Extract, un-CDATA and entity-decode a `<loc>` value in one step. */
+/**
+ * Normalize a `<loc>` value. Entities inside CDATA are literal text per the XML
+ * spec, so a CDATA-wrapped URL is only unwrapped; everything else is
+ * entity-decoded.
+ */
 function cleanLoc(raw: string): string {
-  return decodeXmlEntities(extractCdataUrl(raw.trim()))
+  const value = raw.trim()
+  if (value.startsWith('<![CDATA[') && value.endsWith(']]>'))
+    return extractCdataUrl(value)
+  return decodeXmlEntities(value)
 }
 
 /** Strip tracking params, fragments, and trailing slashes from a URL */
@@ -477,6 +489,13 @@ export async function crawlAndGenerate(options: CrawlOptions, onProgress?: (prog
     // Log sitemap discovery results
     const successfulSitemaps = sitemapAttempts.filter(a => a.success)
     const failedSitemaps = sitemapAttempts.filter(a => !a.success)
+
+    // Explicit sitemaps jointly define the crawl surface, so a failed part means
+    // the crawl is incomplete. Auto-discovery failures are expected (we probe
+    // several well-known paths), so they stay quiet.
+    if (hasExplicitSitemaps && failedSitemaps.length > 0) {
+      logger.warn(`Sitemap: ${failedSitemaps.length} explicit sitemap(s) failed to load; crawl may be incomplete: ${failedSitemaps.map(a => `${a.url} (${a.error})`).join(', ')}`)
+    }
 
     if (successfulSitemaps.length > 0 && progress.sitemap.processed > 0) {
       sitemapProvidedUrls = true

--- a/packages/crawl/src/types.ts
+++ b/packages/crawl/src/types.ts
@@ -36,6 +36,12 @@ export interface CrawlOptions {
   descriptionOverride?: string
   verbose?: boolean
   skipSitemap?: boolean
+  /**
+   * Explicit sitemap URL(s) to use instead of auto-discovery (robots.txt +
+   * well-known paths). Accepts non-standard locations and multiple parts, which
+   * are all loaded and merged. Ignored when `skipSitemap` is set.
+   */
+  sitemapUrls?: string[]
   allowSubdomains?: boolean
   /**
    * Strip repeated site chrome (top nav, footer, newsletter walls) from per-page
@@ -74,6 +80,8 @@ export interface MdreamCrawlConfig {
   maxPages?: number
   crawlDelay?: number
   skipSitemap?: boolean
+  /** Explicit sitemap URL(s) to use instead of auto-discovery. Supports non-standard locations and multiple parts. */
+  sitemap?: string | string[]
   allowSubdomains?: boolean
   /** Strip repeated site chrome from per-page output. Defaults to true. */
   stripBoilerplate?: boolean

--- a/packages/crawl/test/unit/sitemap-override.test.ts
+++ b/packages/crawl/test/unit/sitemap-override.test.ts
@@ -1,0 +1,149 @@
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const fetchedUrls: string[] = []
+
+// Sitemap responses keyed by exact URL. Anything not present 404s.
+const sitemapRegistry: Record<string, string> = {}
+
+function html(title: string): string {
+  return `<html><head><title>${title}</title></head><body><p>${title}</p></body></html>`
+}
+
+vi.mock('ofetch', () => {
+  const mockOfetch = Object.assign(
+    async (url: string) => {
+      fetchedUrls.push(url)
+      if (url.endsWith('/robots.txt'))
+        return sitemapRegistry.__robots__ ?? ''
+      if (url in sitemapRegistry)
+        return sitemapRegistry[url]
+      throw new Error('404')
+    },
+    {
+      raw: async (url: string, _opts?: any) => {
+        fetchedUrls.push(url)
+        return {
+          _data: html(new URL(url).pathname),
+          headers: new Headers({ 'content-type': 'text/html' }),
+        }
+      },
+    },
+  )
+  return { ofetch: mockOfetch }
+})
+
+vi.mock('@mdream/js/llms-txt', () => ({
+  generateLlmsTxtArtifacts: async () => ({ llmsTxt: '# llms.txt', llmsFullTxt: '# llms-full.txt' }),
+}))
+
+vi.mock('@clack/prompts', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), success: vi.fn() },
+  note: vi.fn(),
+  spinner: () => ({ start: vi.fn(), stop: vi.fn(), message: vi.fn() }),
+}))
+
+const { crawlAndGenerate } = await import('../../src/crawl.ts')
+
+function tmpOut(): string {
+  return join(tmpdir(), `mdream-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+}
+
+function urlset(...locs: string[]): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${locs.map(l => `  <url><loc>${l}</loc></url>`).join('\n')}
+</urlset>`
+}
+
+afterEach(() => {
+  fetchedUrls.length = 0
+  for (const key of Object.keys(sitemapRegistry))
+    delete sitemapRegistry[key]
+})
+
+const baseOpts = {
+  maxDepth: 1,
+  followLinks: false,
+  generateLlmsTxt: false,
+  generateLlmsFullTxt: false,
+  generateIndividualMd: false,
+}
+
+describe('sitemap override (#116)', () => {
+  it('uses an explicit sitemap URL and skips default /sitemap.xml discovery', async () => {
+    sitemapRegistry['https://example.com/custom/sitemap.xml'] = urlset(
+      'https://example.com/alpha',
+      'https://example.com/beta',
+    )
+    // A default sitemap also exists but must NOT be consulted.
+    sitemapRegistry['https://example.com/sitemap.xml'] = urlset('https://example.com/should-not-appear')
+
+    const results = await crawlAndGenerate({
+      ...baseOpts,
+      urls: ['https://example.com'],
+      outputDir: tmpOut(),
+      sitemapUrls: ['https://example.com/custom/sitemap.xml'],
+    })
+
+    const successPaths = results.filter(r => r.success).map(r => new URL(r.url).pathname)
+    expect(successPaths).toContain('/alpha')
+    expect(successPaths).toContain('/beta')
+    expect(successPaths).not.toContain('/should-not-appear')
+    // Default sitemap path was never fetched.
+    expect(fetchedUrls.includes('https://example.com/sitemap.xml')).toBe(false)
+  })
+
+  it('merges multiple explicit sitemap parts', async () => {
+    sitemapRegistry['https://example.com/sitemap-1.xml'] = urlset('https://example.com/one')
+    sitemapRegistry['https://example.com/sitemap-2.xml'] = urlset('https://example.com/two')
+
+    const results = await crawlAndGenerate({
+      ...baseOpts,
+      urls: ['https://example.com'],
+      outputDir: tmpOut(),
+      sitemapUrls: [
+        'https://example.com/sitemap-1.xml',
+        'https://example.com/sitemap-2.xml',
+      ],
+    })
+
+    const successPaths = results.filter(r => r.success).map(r => new URL(r.url).pathname)
+    expect(successPaths).toContain('/one')
+    expect(successPaths).toContain('/two')
+  })
+
+  it('decodes XML entities in <loc> query strings', async () => {
+    sitemapRegistry['https://example.com/sitemap.xml'] = urlset(
+      'https://example.com/search?a=1&amp;b=2',
+    )
+
+    await crawlAndGenerate({
+      ...baseOpts,
+      urls: ['https://example.com'],
+      outputDir: tmpOut(),
+    })
+
+    // The decoded URL should be fetched, not the literal &amp; form.
+    expect(fetchedUrls).toContain('https://example.com/search?a=1&b=2')
+    expect(fetchedUrls.some(u => u.includes('&amp;'))).toBe(false)
+  })
+
+  it('prefers robots.txt sitemap over well-known /sitemap.xml (no overwrite)', async () => {
+    sitemapRegistry.__robots__ = 'Sitemap: https://example.com/robots-sitemap.xml\n'
+    sitemapRegistry['https://example.com/robots-sitemap.xml'] = urlset('https://example.com/from-robots')
+    // A default sitemap also exists; it must not replace the robots.txt result.
+    sitemapRegistry['https://example.com/sitemap.xml'] = urlset('https://example.com/from-default')
+
+    const results = await crawlAndGenerate({
+      ...baseOpts,
+      urls: ['https://example.com'],
+      outputDir: tmpOut(),
+    })
+
+    const successPaths = results.filter(r => r.success).map(r => new URL(r.url).pathname)
+    expect(successPaths).toContain('/from-robots')
+    expect(successPaths).not.toContain('/from-default')
+  })
+})

--- a/packages/crawl/test/unit/sitemap-override.test.ts
+++ b/packages/crawl/test/unit/sitemap-override.test.ts
@@ -57,6 +57,13 @@ ${locs.map(l => `  <url><loc>${l}</loc></url>`).join('\n')}
 </urlset>`
 }
 
+function sitemapindex(...locs: string[]): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${locs.map(l => `  <sitemap><loc>${l}</loc></sitemap>`).join('\n')}
+</sitemapindex>`
+}
+
 afterEach(() => {
   fetchedUrls.length = 0
   for (const key of Object.keys(sitemapRegistry))
@@ -145,5 +152,49 @@ describe('sitemap override (#116)', () => {
     const successPaths = results.filter(r => r.success).map(r => new URL(r.url).pathname)
     expect(successPaths).toContain('/from-robots')
     expect(successPaths).not.toContain('/from-default')
+  })
+
+  it('terminates on a cyclic sitemap index and merges child URLs', async () => {
+    // A indexes B (+ child-a), B indexes A (+ child-b). The A->B->A cycle must be
+    // broken by the visited guard while both leaf urlsets are still collected.
+    sitemapRegistry['https://example.com/sitemap-a.xml'] = sitemapindex(
+      'https://example.com/child-a.xml',
+      'https://example.com/sitemap-b.xml',
+    )
+    sitemapRegistry['https://example.com/sitemap-b.xml'] = sitemapindex(
+      'https://example.com/child-b.xml',
+      'https://example.com/sitemap-a.xml',
+    )
+    sitemapRegistry['https://example.com/child-a.xml'] = urlset('https://example.com/a-page')
+    sitemapRegistry['https://example.com/child-b.xml'] = urlset('https://example.com/b-page')
+
+    const results = await crawlAndGenerate({
+      ...baseOpts,
+      urls: ['https://example.com'],
+      outputDir: tmpOut(),
+      sitemapUrls: ['https://example.com/sitemap-a.xml'],
+    })
+
+    const successPaths = results.filter(r => r.success).map(r => new URL(r.url).pathname)
+    expect(successPaths).toContain('/a-page')
+    expect(successPaths).toContain('/b-page')
+    // Each sitemap fetched at most once despite the cycle.
+    expect(fetchedUrls.filter(u => u === 'https://example.com/sitemap-a.xml').length).toBe(1)
+    expect(fetchedUrls.filter(u => u === 'https://example.com/sitemap-b.xml').length).toBe(1)
+  })
+
+  it('keeps entity text literal inside CDATA (no decode)', async () => {
+    // Inside CDATA the URL is literal text, so &amp; must survive verbatim.
+    sitemapRegistry['https://example.com/sitemap.xml'] = urlset(
+      '<![CDATA[https://example.com/path?a=1&amp;b=2]]>',
+    )
+
+    await crawlAndGenerate({
+      ...baseOpts,
+      urls: ['https://example.com'],
+      outputDir: tmpOut(),
+    })
+
+    expect(fetchedUrls).toContain('https://example.com/path?a=1&amp;b=2')
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #116

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Some sites keep their sitemap at a non-standard URL, or split it across several links, so auto-discovery (`robots.txt` + well-known paths) never finds it. This adds a `--sitemap <url>` flag (repeatable) and a `sitemap` config key to pin the location(s) explicitly. Multiple explicit sitemaps are loaded and merged into one crawl surface. An explicit sitemap replaces discovery entirely; `robots.txt` is still read for `Crawl-delay`.

While auditing detection, fixed three issues in `crawl.ts`:

- **robots.txt result was silently overwritten.** After a `robots.txt` `Sitemap:` entry succeeded and set the starting URLs, the code unconditionally fetched `/sitemap.xml` and overwrote them. Candidates are now tried in priority order (robots.txt first, well-known paths as fallback) and the first that yields matching URLs wins.
- **`<loc>` values were not entity-decoded.** URLs with query strings (`?a=1&amp;b=2`) came out with a literal `&amp;` and resolved to the wrong page. They are now XML-entity-decoded per the sitemap spec.
- **Sitemap-index recursion had no cycle guard.** A self-referencing index looped forever; it now tracks visited URLs.

Added `sitemap-override.test.ts` covering explicit single/multi-part sitemaps, entity decoding, and robots.txt priority (77 crawl unit tests pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added repeatable `--sitemap <url>` CLI support for specifying one or more sitemap locations.
  * Added sitemap configuration options for programmatic and config-file usage.
  * Explicit sitemaps now replace automatic discovery while still honoring crawl settings from `robots.txt`.

* **Bug Fixes**
  * Improved sitemap URL decoding and prevented recursive sitemap indexes from causing loops.
  * Enhanced sitemap discovery priority and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->