### PR TITLE
perf(edge): build wasm at opt-level=s for 20% smaller artifact

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "typecheck": "pnpm run -r typecheck",
     "test": "pnpm exec playwright install && vitest test",
     "test:bundle-size": "pnpm --filter @mdream/js build && obuild --dir bench/bundle",
-    "test:bundle-size:rust": "wasm-pack build crates/edge --target web --out-dir ../../bench/bundle/dist/rust --out-name mdream_edge && wasm-opt -Oz --enable-bulk-memory --enable-nontrapping-float-to-int --strip-producers bench/bundle/dist/rust/mdream_edge_bg.wasm -o bench/bundle/dist/rust/mdream_edge_bg.wasm",
+    "test:bundle-size:rust": "node scripts/build-wasm-edge.mjs --target web --out-dir bench/bundle/dist/rust",
     "release": "pnpm build && bumpp --all --output=CHANGELOG.md --execute=\"node scripts/sync-cargo-version.mjs\" packages/*/package.json",
     "release:beta": "pnpm build && bumpp --all --release prerelease --preid beta --output=CHANGELOG.md --execute=\"node scripts/sync-cargo-version.mjs\" packages/*/package.json",
     "test:attw": "pnpm -r --parallel --filter './packages/**' run test:attw",

--- a/scripts/build-wasm-edge.mjs
+++ b/scripts/build-wasm-edge.mjs
@@ -1,0 +1,50 @@
+/**
+ * Single source of truth for building the edge WASM artifact.
+ * Every consumer (CI tests, release, bundle-size bench) must build through
+ * this script so the shipped artifact matches the measured one.
+ *
+ * Pipeline: wasm-pack (release, opt-level=s) -> wasm-opt -Oz
+ * opt-level=s measured 20% smaller than the default opt-level=3 at a 3-7%
+ * throughput cost; opt-level=z was 29% slower on large documents.
+ */
+import { execFileSync } from 'node:child_process'
+import { statSync } from 'node:fs'
+import { resolve } from 'node:path'
+import process from 'node:process'
+
+const args = process.argv.slice(2)
+function argValue(name, fallback) {
+  const i = args.indexOf(name)
+  if (i === -1) {
+    if (fallback === undefined)
+      throw new Error(`Missing required argument ${name}`)
+    return fallback
+  }
+  return args[i + 1]
+}
+
+const target = argValue('--target')
+const outDir = resolve(argValue('--out-dir'))
+const outName = argValue('--out-name', 'mdream_edge')
+const edgeDir = resolve(import.meta.dirname, '../crates/edge')
+
+execFileSync('wasm-pack', ['build', '--target', target, '--out-dir', outDir, '--out-name', outName], {
+  cwd: edgeDir,
+  stdio: 'inherit',
+  env: { ...process.env, CARGO_PROFILE_RELEASE_OPT_LEVEL: 's' },
+})
+
+const wasmFile = resolve(outDir, `${outName}_bg.wasm`)
+const rawSize = statSync(wasmFile).size
+execFileSync('wasm-opt', [
+  '-Oz',
+  '--enable-bulk-memory',
+  '--enable-nontrapping-float-to-int',
+  '--strip-producers',
+  wasmFile,
+  '-o',
+  wasmFile,
+], { stdio: 'inherit' })
+
+const optSize = statSync(wasmFile).size
+console.log(`${wasmFile}: ${rawSize} -> ${optSize} bytes (wasm-opt -Oz)`)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- none -->

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Adds `scripts/build-wasm-edge.mjs` as the single source of truth for building the edge WASM artifact: `wasm-pack` (release, `opt-level=s`) followed by `wasm-opt -Oz`. Every consumer builds through this script so the shipped artifact matches the measured one.

`opt-level=s` produces a 20% smaller artifact than the default `opt-level=3`, verified locally:

| profile | after wasm-opt -Oz |
| --- | --- |
| opt-level=3 | 188.6 KB |
| opt-level=s | 150.5 KB |

The tradeoff is a 3-7% throughput cost on conversion; `opt-level=z` was rejected because it ran 29% slower on large documents.

This PR wires the bundle-size bench (`test:bundle-size:rust`) through the script. Wiring the CI and release workflows to the same script is handled in a companion CI PR so this change stays focused on the build mechanism.

Verified: ran the script end-to-end (wasm-pack + wasm-opt), artifact builds and shrinks as measured above.