### PR TITLE
refactor(crates): inherit crate version from workspace.package

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -8,6 +8,7 @@ exclude = [ "core/fuzz" ]
 resolver = "2"
 
 [workspace.package]
+version = "1.4.1"
 edition = "2024"
 license = "MIT"
 rust-version = "1.95"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "mdream"
+
 version.workspace = true
 
 edition.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdream"
-version = "1.4.1"
+version.workspace = true
 
 edition.workspace = true
 

--- a/crates/edge/Cargo.toml
+++ b/crates/edge/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "mdream-edge"
+
 version.workspace = true
 
 edition.workspace = true

--- a/crates/edge/Cargo.toml
+++ b/crates/edge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdream-edge"
-version = "1.4.1"
+version.workspace = true
 
 edition.workspace = true
 

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "mdream-node"
+
 version.workspace = true
 
 edition.workspace = true

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdream-node"
-version = "1.4.1"
+version.workspace = true
 
 edition.workspace = true
 

--- a/scripts/sync-cargo-version.mjs
+++ b/scripts/sync-cargo-version.mjs
@@ -5,21 +5,19 @@ import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
 const rootPkg = JSON.parse(readFileSync('packages/mdream/package.json', 'utf8'))
 const version = rootPkg.version
 
-const cargoFiles = [
-  'crates/core/Cargo.toml',
-  'crates/node/Cargo.toml',
-  'crates/edge/Cargo.toml',
-]
+// Crate versions are inherited from [workspace.package] in crates/Cargo.toml
+const cargoFiles = ['crates/Cargo.toml', 'crates/Cargo.lock']
 
-for (const file of cargoFiles) {
-  const content = readFileSync(file, 'utf8')
-  const updated = content.replace(
-    /^(version\s*=\s*)"[^"]*"/m,
-    `$1"${version}"`,
-  )
-  writeFileSync(file, updated)
-  console.log(`Updated ${file} to ${version}`)
-}
+const workspaceManifest = readFileSync('crates/Cargo.toml', 'utf8')
+const updatedManifest = workspaceManifest.replace(
+  /^(version\s*=\s*)"[^"]*"/m,
+  `$1"${version}"`,
+)
+writeFileSync('crates/Cargo.toml', updatedManifest)
+console.log(`Updated crates/Cargo.toml to ${version}`)
+
+// Keep Cargo.lock in sync so --locked builds don't fail after the bump
+execSync('cargo update --workspace --offline', { cwd: 'crates', stdio: 'inherit' })
 
 // Sync platform package versions
 const platformDir = 'crates/node/npm'


### PR DESCRIPTION
### 🔗 Linked issue

<!-- none -->

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Consolidates the three crate versions into a single source. Adds `version = "1.4.1"` to `[workspace.package]` and switches `mdream`, `mdream-node`, and `mdream-edge` to `version.workspace = true`, so a release bump touches one line instead of three.

`sync-cargo-version.mjs` is updated to match: it now writes the version to `crates/Cargo.toml` and runs `cargo update --workspace --offline` afterward, keeping `Cargo.lock` in sync so `--locked` builds don't fail after a bump.

Verified: `cargo metadata` resolves all three crates to 1.4.1 via the inherited version; `Cargo.lock` is unchanged since the resolved versions don't move.