### PR TITLE
ci: wasm-target lint, MSRV job, idempotent release, fuzz workflow

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,49 @@
+name: Fuzz
+
+on:
+  schedule:
+    # Weekly smoke run; the parser is hand-rolled so keep fuzz coverage alive.
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: Fuzz ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - fuzz_html_to_markdown
+          - fuzz_options
+          - fuzz_splitter
+          - fuzz_streaming
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install cargo-fuzz
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: crates/core/fuzz -> target
+
+      - name: Run fuzzer
+        working-directory: crates/core
+        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=300
+
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: fuzz-artifacts-${{ matrix.target }}
+          path: crates/core/fuzz/artifacts/
+          if-no-files-found: ignore

--- a/.github/workflows/release-cargo.yml
+++ b/.github/workflows/release-cargo.yml
@@ -14,17 +14,50 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: crates -> target
+
+      - name: Resolve crate version
+        id: version
+        working-directory: crates
+        run: |
+          CRATE_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "mdream") | .version')
+          echo "crate=$CRATE_VERSION" >> "$GITHUB_OUTPUT"
+
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            TAG_VERSION=${GITHUB_REF#refs/tags/v}
+            if [ "$TAG_VERSION" != "$CRATE_VERSION" ]; then
+              echo "::error::Tag v$TAG_VERSION does not match crate version $CRATE_VERSION. Did the version bump run scripts/sync-cargo-version.mjs?"
+              exit 1
+            fi
+          fi
+
+          if curl -sf "https://crates.io/api/v1/crates/mdream/$CRATE_VERSION" >/dev/null; then
+            echo "mdream@$CRATE_VERSION is already on crates.io; skipping publish."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Test crate
+        if: steps.version.outputs.publish == 'true'
+        working-directory: crates
+        run: cargo test -p mdream --locked
 
       - name: Authenticate with crates.io
-        uses: rust-lang/crates-io-auth-action@v1
+        if: steps.version.outputs.publish == 'true'
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth
 
       - name: Publish to crates.io
+        if: steps.version.outputs.publish == 'true'
         working-directory: crates/core
-        run: cargo publish
+        run: cargo publish --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -25,18 +25,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: pnpm
@@ -71,16 +71,16 @@ jobs:
           ls -la packages/mdream/napi/
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY_GHCR }}
           username: ${{ github.actor }}
@@ -119,7 +119,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
@@ -141,7 +141,7 @@ jobs:
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
 
       - name: Build and push crawl image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           file: Dockerfile.crawl
@@ -191,19 +191,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY_GHCR }}
           username: ${{ github.actor }}
@@ -231,7 +231,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
@@ -246,7 +246,7 @@ jobs:
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
 
       - name: Build and push core image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           file: Dockerfile.core

--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -48,13 +48,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: pnpm
@@ -64,13 +64,13 @@ jobs:
 
       - name: Install zig
         if: matrix.use_zigbuild
-        uses: mlugg/setup-zig@v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.15.2
 
       - name: Install cargo-zigbuild
         if: matrix.use_zigbuild
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
         with:
           tool: cargo-zigbuild
 
@@ -85,11 +85,11 @@ jobs:
           fi
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: crates -> target
 
@@ -120,7 +120,7 @@ jobs:
 
       - name: Install wasm-opt
         if: startsWith(matrix.target, 'wasm')
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
         with:
           tool: wasm-opt
 
@@ -132,7 +132,7 @@ jobs:
           node ./scripts/move-artifacts.mjs
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: bindings-${{ matrix.target }}
           path: |
@@ -147,13 +147,13 @@ jobs:
     name: Build WASM Edge
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: pnpm
@@ -162,27 +162,26 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           targets: wasm32-unknown-unknown
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: crates -> target
 
-      - name: Install wasm-pack
-        uses: taiki-e/install-action@v2
+      - name: Install wasm-pack and wasm-opt
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
         with:
-          tool: wasm-pack
+          tool: wasm-pack,wasm-opt
 
       - name: Build WASM edge module
-        working-directory: crates/edge
         run: |
-          wasm-pack build --target web --out-dir ../../packages/mdream/wasm --out-name mdream_edge
-          wasm-pack build --target bundler --out-dir ../../packages/mdream/wasm-bundler --out-name mdream_edge
+          node scripts/build-wasm-edge.mjs --target web --out-dir packages/mdream/wasm
+          node scripts/build-wasm-edge.mjs --target bundler --out-dir packages/mdream/wasm-bundler
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: wasm-edge
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: [native]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6.0.1
 
       - name: Set node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: pnpm
@@ -43,7 +43,7 @@ jobs:
         run: pnpm i
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
 
@@ -87,11 +87,23 @@ jobs:
 
       - name: Publish platform packages
         run: |
+          failed=""
           for pkg in crates/node/npm/*/; do
             if [ -f "$pkg/package.json" ]; then
-              pnpm publish --access public --no-git-checks --provenance ${{ steps.dist-tag.outputs.tag }} --filter "$(node -p "require('./$pkg/package.json').name")" || true
+              name=$(node -p "require('./$pkg/package.json').name")
+              version=$(node -p "require('./$pkg/package.json').version")
+              # Idempotent on re-runs: skip versions that are already live.
+              if npm view "$name@$version" version >/dev/null 2>&1; then
+                echo "Skipping $name@$version (already published)"
+                continue
+              fi
+              pnpm publish --access public --no-git-checks --provenance ${{ steps.dist-tag.outputs.tag }} --filter "$name" || failed="$failed $name"
             fi
           done
+          if [ -n "$failed" ]; then
+            echo "::error::Failed to publish platform packages:$failed"
+            exit 1
+          fi
 
       - name: Publish all other packages
         run: pnpm publish -r --access public --no-git-checks --provenance --filter '!@mdream/rust-*' ${{ steps.dist-tag.outputs.tag }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,14 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
-  # ── Rust clippy lint check ──
+  # ── Rust lint (fmt + clippy, host and wasm targets) ──
   rust-lint:
-    name: Rust Clippy
+    name: Rust Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -25,14 +29,41 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+          targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: crates -> target
 
+      # pedantic/nursery stay warn-only in CI so new lints on fresh stable
+      # releases can't break unrelated builds; they still surface locally.
       - name: Run clippy
         working-directory: crates
-        run: cargo clippy --workspace --exclude mdream-edge -- -D warnings
+        run: cargo clippy --workspace --exclude mdream-edge --locked -- -D warnings -A clippy::pedantic -A clippy::nursery
+
+      - name: Run clippy (edge, wasm target)
+        working-directory: crates
+        run: cargo clippy -p mdream-edge --target wasm32-unknown-unknown --locked -- -D warnings -A clippy::pedantic -A clippy::nursery
+
+  # ── MSRV check (keep in sync with rust-version in crates/Cargo.toml) ──
+  rust-msrv:
+    name: Rust MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install MSRV Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.95'
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: crates -> target
+
+      - name: Check workspace builds on MSRV
+        working-directory: crates
+        run: cargo check --workspace --locked
 
   # ── Rust unit tests (all OSes on main, Linux-only on PRs) ──
   rust-test:
@@ -76,12 +107,13 @@ jobs:
         working-directory: crates
         run: cargo build -p mdream-edge --target wasm32-unknown-unknown
 
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Install wasm-pack and wasm-opt
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack,wasm-opt
 
-      - name: Full wasm-pack build
-        working-directory: crates/edge
-        run: wasm-pack build --target web --out-dir /tmp/wasm-test --out-name mdream_edge
+      - name: Full edge WASM build
+        run: node scripts/build-wasm-edge.mjs --target web --out-dir /tmp/wasm-test
 
   # ── WASM browser tests (wasm-bindgen-test in headless Chrome) ──
   wasm-browser-test:
@@ -100,7 +132,9 @@ jobs:
           workspaces: crates -> target
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
 
       - name: Run WASM tests in headless Chrome
         working-directory: crates/edge
@@ -132,14 +166,15 @@ jobs:
         with:
           workspaces: crates -> target
 
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Install wasm-pack and wasm-opt
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack,wasm-opt
 
       - name: Build WASM for Workers
-        working-directory: crates/edge
         run: |
-          wasm-pack build --target web --out-dir test-worker/wasm --out-name mdream_edge
-          wasm-pack build --target web --out-dir ../../packages/mdream/wasm --out-name mdream_edge
+          node scripts/build-wasm-edge.mjs --target web --out-dir crates/edge/test-worker/wasm
+          node scripts/build-wasm-edge.mjs --target web --out-dir packages/mdream/wasm
 
       - run: pnpm install
 
@@ -169,7 +204,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
 
-      - name: Use Node.js 22
+      - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -185,10 +220,10 @@ jobs:
         with:
           workspaces: crates -> target
 
-      - name: Install wasm-pack
+      - name: Install wasm-pack and wasm-opt
         uses: taiki-e/install-action@v2
         with:
-          tool: wasm-pack
+          tool: wasm-pack,wasm-opt
 
       - run: pnpm i
 
@@ -197,9 +232,8 @@ jobs:
 
       - name: Build WASM web & bundler
         run: |
-          wasm-pack build --target web --out-dir ../../packages/mdream/wasm --out-name mdream_edge
-          wasm-pack build --target bundler --out-dir ../../packages/mdream/wasm-bundler --out-name mdream_edge
-        working-directory: crates/edge
+          node scripts/build-wasm-edge.mjs --target web --out-dir packages/mdream/wasm
+          node scripts/build-wasm-edge.mjs --target bundler --out-dir packages/mdream/wasm-bundler
 
       - name: Build
         run: pnpm run build

--- a/Dockerfile.core
+++ b/Dockerfile.core
@@ -13,7 +13,7 @@ COPY crates/ ./crates/
 # rust:alpine targets x86_64-unknown-linux-musl by default, so this produces
 # a statically linked binary that runs on `scratch` with no dependencies.
 WORKDIR /build/crates
-RUN cargo build --release -p mdream --bin mdream
+RUN cargo build --release --locked -p mdream --bin mdream
 
 FROM scratch
 COPY --from=builder /build/crates/target/release/mdream /mdream


### PR DESCRIPTION
### 🔗 Linked issue

<!-- none -->

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

CI hardening, split out of the original `perf(edge): optimize wasm` commit.

- **Lint:** the Rust lint job installs the wasm target and runs clippy for `mdream-edge` on `wasm32-unknown-unknown` (previously only the host was linted). `pedantic`/`nursery` are allowed in CI so new lints on fresh stable can't break unrelated builds.
- **MSRV:** new job running `cargo check --workspace --locked` on 1.95, and `--locked` added to clippy and the Docker build so a stale `Cargo.lock` fails fast.
- **WASM builds:** test and release workflows build the edge WASM through `scripts/build-wasm-edge.mjs`, so CI and release ship the same optimized artifact the bundle-size bench measures.
- **Release:** concurrency cancellation, CI Node bumped to 24, npm publish made idempotent on re-run, and a guard that the release tag matches the crate version.
- **Fuzz:** weekly `cargo-fuzz` smoke workflow for the hand-rolled parser (schedule + manual dispatch only).

**Stacked on #124** (needs `scripts/build-wasm-edge.mjs`); base is `perf/optimize-wasm` and retargets to `main` once #124 merges.

The `cargo fmt --all --check` step from the original commit is intentionally left out: the tree is not yet rustfmt-clean, so it belongs with the formatting PR.

Verified locally against origin/main's code: host clippy, edge wasm-target clippy, and `cargo check --workspace --locked` all pass; every workflow YAML parses; all four fuzz targets exist.