### PR TITLE
fix: preserve br hard breaks

### DIFF
--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -612,12 +612,27 @@ impl ConvertState {
     self.depth_map[TAG_PRE as usize] == 0
       && self.depth_map[TAG_CODE as usize] == 0
       && !self.in_table_cell()
-      && self.depth_map[TAG_H1 as usize] == 0
-      && self.depth_map[TAG_H2 as usize] == 0
-      && self.depth_map[TAG_H3 as usize] == 0
-      && self.depth_map[TAG_H4 as usize] == 0
-      && self.depth_map[TAG_H5 as usize] == 0
-      && self.depth_map[TAG_H6 as usize] == 0
+      && !self.in_heading()
+  }
+
+  #[inline]
+  fn in_heading(&self) -> bool {
+    self.depth_map[TAG_H1 as usize] > 0
+      || self.depth_map[TAG_H2 as usize] > 0
+      || self.depth_map[TAG_H3 as usize] > 0
+      || self.depth_map[TAG_H4 as usize] > 0
+      || self.depth_map[TAG_H5 as usize] > 0
+      || self.depth_map[TAG_H6 as usize] > 0
+  }
+
+  #[inline]
+  fn in_raw_html_block(&self) -> bool {
+    self.depth_map[TAG_DETAILS as usize] > 0
+      || self.depth_map[TAG_SUMMARY as usize] > 0
+      || self.depth_map[TAG_ADDRESS as usize] > 0
+      || self.depth_map[TAG_DL as usize] > 0
+      || self.depth_map[TAG_DT as usize] > 0
+      || self.depth_map[TAG_DD as usize] > 0
   }
 
   /// Character count of the current (unterminated) buffer line, i.e. since the
@@ -633,13 +648,13 @@ impl ConvertState {
     self.buffer[i..].chars().count()
   }
 
-  /// Continuation prefix re-emitted at the start of each wrapped line so the
-  /// wrapped text stays inside its block context. Built by walking the open
+  /// Continuation prefix re-emitted at the start of each continued line so the
+  /// content stays inside its block context. Built by walking the open
   /// ancestor stack outermost-first so blockquote markers (`> `) and list-item
   /// indentation interleave in the real nesting order: `<li><blockquote>` →
   /// `  > `, `<blockquote><li>` → `>   `. A flat "all quotes then all indent"
   /// prefix would corrupt the Markdown structure of nested blocks.
-  fn wrap_continuation_prefix(&self) -> String {
+  fn continuation_prefix(&self) -> String {
     if self.plain_text {
       return String::new();
     }
@@ -664,6 +679,24 @@ impl ConvertState {
     p
   }
 
+  /// Emit the canonical Markdown hard-break marker, accounting for source
+  /// whitespace already at the end of the current line.
+  fn hard_break(&self, prefix: &str) -> Cow<'static, str> {
+    let bytes = self.buffer.as_bytes();
+    let marker = if bytes.ends_with(b"  ") {
+      "\n"
+    } else if bytes.ends_with(b" ") {
+      " \n"
+    } else {
+      "  \n"
+    };
+    if prefix.is_empty() {
+      Cow::Borrowed(marker)
+    } else {
+      Cow::Owned(format!("{marker}{prefix}"))
+    }
+  }
+
   /// Push `text` into the buffer, hard-wrapping on spaces so no output line
   /// exceeds `self.wrap_width` characters. Words are never split, so a single
   /// token longer than the width (e.g. a URL) overflows rather than breaking.
@@ -678,7 +711,7 @@ impl ConvertState {
     let leading_space = text.starts_with(' ');
     let trailing_space = text.ends_with(' ');
     let first_needs_space = leading_space || self.should_add_spacing_before_text(last_char, text);
-    let prefix = self.wrap_continuation_prefix();
+    let prefix = self.continuation_prefix();
     let prefix_len = prefix.chars().count();
     let buf_start = self.buffer.len();
     let mut col = self.current_column();
@@ -735,10 +768,19 @@ impl ConvertState {
       TAG_DETAILS => Some(Cow::Borrowed("<details>")),
       TAG_SUMMARY => Some(Cow::Borrowed("<summary>")),
       TAG_BR => {
-        if self.in_table_cell() {
+        if self.in_table_cell() || self.in_heading() || self.in_raw_html_block() {
           Some(Cow::Borrowed("<br>"))
         } else {
-          None
+          let prefix = self.continuation_prefix();
+          if self.depth_map[TAG_PRE as usize] > 0 {
+            if prefix.is_empty() {
+              Some(Cow::Borrowed("\n"))
+            } else {
+              Some(Cow::Owned(format!("\n{prefix}")))
+            }
+          } else {
+            Some(self.hard_break(&prefix))
+          }
         }
       }
       TAG_H1 | TAG_H2 | TAG_H3 | TAG_H4 | TAG_H5 | TAG_H6 => {

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -2206,6 +2206,44 @@ fn wrap_preserves_inline_spacing() {
   );
 }
 
+// ── HTML hard breaks (issue #128) ──
+
+#[test]
+fn br_preserves_a_hard_break_with_and_without_wrapping() {
+  let html = "<div>abc def ghi jkl mno<br/>111 222 333 444 555 666 777 888 999 000 abc</div>";
+
+  assert_eq!(
+    convert(html),
+    "abc def ghi jkl mno  \n111 222 333 444 555 666 777 888 999 000 abc"
+  );
+  assert_eq!(
+    convert_wrapped(html, 40),
+    "abc def ghi jkl mno  \n111 222 333 444 555 666 777 888 999 000\nabc"
+  );
+  assert_eq!(convert("<p>first <br>second</p>"), "first  \nsecond");
+}
+
+#[test]
+fn br_keeps_nested_block_continuation_prefixes() {
+  assert_eq!(
+    convert("<ul><li>first<br>second</li></ul>"),
+    "- first  \n  second"
+  );
+  assert_eq!(
+    convert("<blockquote><p>first<br>second</p></blockquote>"),
+    "> first  \n> second"
+  );
+  assert_eq!(
+    convert("<address>first<br>second</address>"),
+    "<address>first<br>second</address>"
+  );
+  assert_eq!(convert("<h1>first<br>second</h1>"), "# first<br>second");
+  assert_eq!(
+    convert("<pre>first<br>second</pre>"),
+    "```\nfirst\nsecond\n```"
+  );
+}
+
 #[test]
 fn wrap_never_splits_a_long_token() {
   let out = convert_wrapped(

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -28,6 +28,7 @@ import {
 } from './const'
 import { finalizeParse, parseHtmlStream } from './parse'
 import { processPluginsForEvent } from './plugin-processor'
+import { continuationPrefix } from './utils'
 
 export interface MarkdownState {
   /** Configuration options for conversion */
@@ -184,39 +185,6 @@ function currentColumn(buffer: string[]): number {
     col += [...s].length
   }
   return col
-}
-
-/**
- * Continuation prefix re-emitted at the start of each wrapped line so wrapped
- * text stays inside its block context. Built by walking the node's open
- * ancestors outermost-first so blockquote markers (`> `) and list-item
- * indentation interleave in the real nesting order: `<li><blockquote>` → `  > `,
- * `<blockquote><li>` → `>   `. A flat "all quotes then all indent" prefix would
- * corrupt the Markdown structure of nested blocks.
- */
-function wrapContinuationPrefix(state: MarkdownState, node: TextNode): string {
-  const chain: ElementNode[] = []
-  let cur = node.parent
-  while (cur) {
-    chain.push(cur)
-    cur = cur.parent
-  }
-  let p = ''
-  // chain is innermost-first; consume list widths from the end so the outermost
-  // <li> maps to listIndentWidths[0], matching the push order.
-  let liIdx = 0
-  for (let i = chain.length - 1; i >= 0; i--) {
-    const tagId = chain[i]!.tagId
-    if (tagId === TAG_BLOCKQUOTE) {
-      p += '> '
-    }
-    else if (tagId === TAG_LI) {
-      const w = state.listIndentWidths[liIdx] ?? 2
-      p += ' '.repeat(w)
-      liIdx++
-    }
-  }
-  return p
 }
 
 /**
@@ -497,7 +465,7 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
 
         const wrapWidth = state.options?.wrapWidth
         if (wrapWidth && canWrapHere(state.depthMap)) {
-          const wrapped = wrapText(textNode.value, currentColumn(state.buffer), wrapWidth, wrapContinuationPrefix(state, textNode))
+          const wrapped = wrapText(textNode.value, currentColumn(state.buffer), wrapWidth, continuationPrefix(textNode, state.listIndentWidths))
           state.buffer.push(wrapped)
           state.lastContentCache = wrapped
         }

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -175,12 +175,13 @@ function isInsideTableCell(node: HandlerContext['node']): boolean {
 }
 
 function isInsideRawHtmlBlock(node: HandlerContext['node']): boolean {
-  return Boolean(node.depthMap[TAG_DETAILS]
-    || node.depthMap[TAG_SUMMARY]
-    || node.depthMap[TAG_ADDRESS]
-    || node.depthMap[TAG_DL]
-    || node.depthMap[TAG_DT]
-    || node.depthMap[TAG_DD])
+  const depthMap = node.depthMap
+  return Boolean(depthMap[TAG_DETAILS]
+    || depthMap[TAG_SUMMARY]
+    || depthMap[TAG_ADDRESS]
+    || depthMap[TAG_DL]
+    || depthMap[TAG_DT]
+    || depthMap[TAG_DD])
 }
 
 function hardBreak(buffer: string[], prefix: string): string {
@@ -306,20 +307,21 @@ export const tagHandlers: Record<number, TagHandler> = {
     enter: ({ node, state }) => {
       // A Markdown hard break would terminate a table row/ATX heading or be
       // ignored inside a raw HTML block, so preserve the inline HTML there.
+      const depthMap = node.depthMap
       if (isInsideTableCell(node) || isInsideRawHtmlBlock(node)
-        || node.depthMap[TAG_H1]
-        || node.depthMap[TAG_H2]
-        || node.depthMap[TAG_H3]
-        || node.depthMap[TAG_H4]
-        || node.depthMap[TAG_H5]
-        || node.depthMap[TAG_H6]) {
+        || depthMap[TAG_H1]
+        || depthMap[TAG_H2]
+        || depthMap[TAG_H3]
+        || depthMap[TAG_H4]
+        || depthMap[TAG_H5]
+        || depthMap[TAG_H6]) {
         return '<br>'
       }
 
       const prefix = continuationPrefix(node, state.listIndentWidths || [])
       // Inside a fenced block, the literal newline is already meaningful and
       // trailing spaces would become part of the code.
-      return node.depthMap[TAG_PRE] ? `\n${prefix}` : hardBreak(state.buffer, prefix)
+      return depthMap[TAG_PRE] ? `\n${prefix}` : hardBreak(state.buffer, prefix)
     },
     isSelfClosing: true,
     spacing: NO_SPACING,

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -117,6 +117,7 @@ import {
   TAG_XMP,
   TagIdMap,
 } from './const'
+import { continuationPrefix } from './utils'
 
 // Helper function to resolve URLs
 function resolveUrl(url: string, origin?: string): string {
@@ -171,6 +172,28 @@ function isAutolinkUri(s: string): boolean {
 // Helper function to check if we're inside a table cell
 function isInsideTableCell(node: HandlerContext['node']): boolean {
   return (node.depthMap[TAG_TD] || 0) > 0 || (node.depthMap[TAG_TH] || 0) > 0
+}
+
+function isInsideRawHtmlBlock(node: HandlerContext['node']): boolean {
+  return Boolean(node.depthMap[TAG_DETAILS]
+    || node.depthMap[TAG_SUMMARY]
+    || node.depthMap[TAG_ADDRESS]
+    || node.depthMap[TAG_DL]
+    || node.depthMap[TAG_DT]
+    || node.depthMap[TAG_DD])
+}
+
+function hardBreak(buffer: string[], prefix: string): string {
+  let spacesNeeded = 2
+  for (let i = buffer.length - 1; i >= 0 && spacesNeeded > 0; i--) {
+    const fragment = buffer[i]!
+    for (let j = fragment.length - 1; j >= 0 && spacesNeeded > 0; j--) {
+      if (fragment.charCodeAt(j) !== 32)
+        return `${' '.repeat(spacesNeeded)}\n${prefix}`
+      spacesNeeded--
+    }
+  }
+  return `${' '.repeat(spacesNeeded)}\n${prefix}`
 }
 
 // Helper function to get language from code class attribute
@@ -280,9 +303,23 @@ export const tagHandlers: Record<number, TagHandler> = {
     spacing: NO_SPACING,
   },
   [TAG_BR]: {
-    enter: ({ node }) => {
-      // Keep <br> inside table cells
-      return isInsideTableCell(node) ? '<br>' : undefined
+    enter: ({ node, state }) => {
+      // A Markdown hard break would terminate a table row/ATX heading or be
+      // ignored inside a raw HTML block, so preserve the inline HTML there.
+      if (isInsideTableCell(node) || isInsideRawHtmlBlock(node)
+        || node.depthMap[TAG_H1]
+        || node.depthMap[TAG_H2]
+        || node.depthMap[TAG_H3]
+        || node.depthMap[TAG_H4]
+        || node.depthMap[TAG_H5]
+        || node.depthMap[TAG_H6]) {
+        return '<br>'
+      }
+
+      const prefix = continuationPrefix(node, state.listIndentWidths || [])
+      // Inside a fenced block, the literal newline is already meaningful and
+      // trailing spaces would become part of the code.
+      return node.depthMap[TAG_PRE] ? `\n${prefix}` : hardBreak(state.buffer, prefix)
     },
     isSelfClosing: true,
     spacing: NO_SPACING,

--- a/packages/js/src/utils.ts
+++ b/packages/js/src/utils.ts
@@ -1,5 +1,34 @@
-import type { Node } from './types'
+import type { ElementNode, Node } from './types'
+import { TAG_BLOCKQUOTE, TAG_LI } from './const'
 import { HTML_ENTITIES } from './entities'
+
+/**
+ * Build the Markdown prefix needed to keep a continued line inside its open
+ * blockquotes and list items. Ancestors are emitted outermost-first so mixed
+ * nesting retains its real structure.
+ */
+export function continuationPrefix(node: Pick<Node, 'parent'>, listIndentWidths: readonly number[]): string {
+  const chain: ElementNode[] = []
+  let current = node.parent
+  while (current) {
+    chain.push(current)
+    current = current.parent
+  }
+
+  let prefix = ''
+  let listIndex = 0
+  for (let i = chain.length - 1; i >= 0; i--) {
+    const tagId = chain[i]!.tagId
+    if (tagId === TAG_BLOCKQUOTE) {
+      prefix += '> '
+    }
+    else if (tagId === TAG_LI) {
+      prefix += ' '.repeat(listIndentWidths[listIndex] ?? 2)
+      listIndex++
+    }
+  }
+  return prefix
+}
 
 /**
  * Decode HTML entities - single pass with O(1) named entity lookup

--- a/packages/js/test/unit/wrap-width.test.ts
+++ b/packages/js/test/unit/wrap-width.test.ts
@@ -23,6 +23,30 @@ describe('wrap width (issue #106)', () => {
       .toBe('see _this_ word and more words after the\nemphasis here please now')
   })
 
+  it('preserves br as a hard break with and without wrapping (issue #128)', () => {
+    const html = '<div>abc def ghi jkl mno<br/>111 222 333 444 555 666 777 888 999 000 abc</div>'
+
+    expect(htmlToMarkdown(html))
+      .toBe('abc def ghi jkl mno  \n111 222 333 444 555 666 777 888 999 000 abc')
+    expect(wrap(html, 40))
+      .toBe('abc def ghi jkl mno  \n111 222 333 444 555 666 777 888 999 000\nabc')
+    expect(htmlToMarkdown('<p>first <br>second</p>'))
+      .toBe('first  \nsecond')
+  })
+
+  it('keeps nested block continuation prefixes after br', () => {
+    expect(htmlToMarkdown('<ul><li>first<br>second</li></ul>'))
+      .toBe('- first  \n  second')
+    expect(htmlToMarkdown('<blockquote><p>first<br>second</p></blockquote>'))
+      .toBe('> first  \n> second')
+    expect(htmlToMarkdown('<address>first<br>second</address>'))
+      .toBe('<address>first<br>second</address>')
+    expect(htmlToMarkdown('<h1>first<br>second</h1>'))
+      .toBe('# first<br>second')
+    expect(htmlToMarkdown('<pre>first<br>second</pre>'))
+      .toBe('```\nfirst\nsecond\n```')
+  })
+
   it('never splits an oversized token', () => {
     const out = wrap('<p>A superlongunbreakabletokenthatislongerthanthewrapwidthsoitoverflows end.</p>', 40)
     expect(out).toContain('superlongunbreakabletokenthatislongerthanthewrapwidthsoitoverflows')

--- a/packages/mdream/test/unit/nodes/definition-lists.test.ts
+++ b/packages/mdream/test/unit/nodes/definition-lists.test.ts
@@ -11,7 +11,7 @@ describe.each(engines)('definition lists $name', (engineConfig) => {
         Anytown, CA 12345
       </address>
     `, { engine })
-    expect(result).toBe('<address>John Doe 123 Main St Anytown, CA 12345 </address>')
+    expect(result).toBe('<address>John Doe<br> 123 Main St<br> Anytown, CA 12345 </address>')
   })
 
   it('handles definition lists', async () => {

--- a/packages/mdream/test/unit/nodes/html-to-markdown-parity.test.ts
+++ b/packages/mdream/test/unit/nodes/html-to-markdown-parity.test.ts
@@ -59,7 +59,7 @@ describe.each(engines)('html-to-markdown parity $name', (engineConfig) => {
   Output a message: <br/>
   <code>console.log("hello")</code>
 </p>
-`, { engine })).toBe('Output a message:  `console.log("hello")`')
+`, { engine })).toBe('Output a message:  \n`console.log("hello")`')
 
     // We need to pass the backtick testing for now
     const result = htmlToMarkdown(`<code>with \`\` backticks</code>`, { engine })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #128

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`<br>` tags outside tables were dropped, joining adjacent text and preventing `wrapWidth` from starting a new line. Both converters now emit Markdown hard breaks, carry list and blockquote prefixes onto the next line, and retain `<br>` in tables, headings, and raw HTML blocks where a Markdown newline would alter the output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML `<br>` conversion to produce canonical Markdown hard breaks.
  * Updated behavior to preserve correct inline/block handling across headings, tables, raw HTML block contexts, lists, blockquotes, and `<pre>`.
  * Refined wrapping logic to keep consistent continuation prefixes and line-break placement.

* **Tests**
  * Added regression tests for `<br>` in both wrapped and unwrapped modes, including nested block structures.
  * Updated expected outputs for `<address>` and an inline `<code>` scenario around `<br/>`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->