### PR TITLE
fix: inline `<button>` to prevent stray paragraph breaks

### DIFF
--- a/crates/core/src/tags.rs
+++ b/crates/core/src/tags.rs
@@ -236,11 +236,7 @@ static TAG_HANDLERS: [Option<TagHandler>; MAX_TAG_ID] = {
   t[TAG_DFN as usize] = Some(INLINE_COLLAPSE);
   t[TAG_FIGCAPTION as usize] = Some(INLINE_COLLAPSE);
 
-  t[TAG_BUTTON as usize] = Some(TagHandler {
-    collapses_inner_white_space: true,
-    is_inline: true,
-    ..NONE
-  });
+  t[TAG_BUTTON as usize] = Some(INLINE_COLLAPSE);
 
   // Block no-spacing
   t[TAG_BODY as usize] = Some(BLOCK_NO_SPACING);

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -2016,6 +2016,15 @@ fn unknown_inline_tag_does_not_fragment_paragraph() {
 }
 
 #[test]
+fn adjacent_buttons_stay_inline() {
+    // <button> is inline but previously inherited block-default spacing, so it
+    // injected a paragraph break that stranded trailing text/punctuation and
+    // split adjacent buttons across lines. Regression guard for issue #133.
+    assert_eq!(convert("<button>One</button><button>Two</button>"), "OneTwo");
+    assert_eq!(convert("<p>Click <button>Go</button>!</p>"), "Click Go!");
+}
+
+#[test]
 fn tag_override_alias_preserves_trailing_siblings() {
   // A string-shorthand tagOverride (`ex` aliased to `em`) used to drop every
   // sibling emitted after `</ex>` because the closing-tag lookup did not

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -693,6 +693,7 @@ export const tagHandlers: Record<number, TagHandler> = {
   },
   [TAG_BUTTON]: {
     collapsesInnerWhiteSpace: true,
+    spacing: NO_SPACING,
     isInline: true,
   },
   [TAG_BODY]: { spacing: NO_SPACING },

--- a/packages/js/test/unit/button-inline.test.ts
+++ b/packages/js/test/unit/button-inline.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { htmlToMarkdown } from '../../src/index'
+
+// <button> is inline but previously inherited block-default spacing, so it
+// injected a paragraph break that stranded trailing text/punctuation and split
+// adjacent buttons across lines (issue #133). Mirrors the Rust engine's
+// `adjacent_buttons_stay_inline` regression.
+
+describe('<button> inline spacing', () => {
+  it('keeps adjacent buttons on one line', () => {
+    expect(htmlToMarkdown('<button>One</button><button>Two</button>')).toBe('OneTwo')
+  })
+
+  it('does not strand trailing punctuation', () => {
+    expect(htmlToMarkdown('<p>Click <button>Go</button>!</p>')).toBe('Click Go!')
+  })
+})

--- a/packages/mdream/test/unit/templates/__snapshots__/wiki.test.ts.snap
+++ b/packages/mdream/test/unit/templates/__snapshots__/wiki.test.ts.snap
@@ -5,9 +5,7 @@ exports[`tables { name: 'JavaScript Engine', engine: { htmlToMarkdown: [Function
 
 Main menu
 
-move to sidebar
-
-hide"
+move to sidebar hide"
 `;
 
 exports[`tables { name: 'JavaScript Engine', engine: { htmlToMarkdown: [Function htmlToMarkdown], streamHtmlToMarkdown: [Function streamHtmlToMarkdown] } } > headings 1`] = `
@@ -40,9 +38,7 @@ exports[`tables { name: 'Rust Engine', engine: { htmlToMarkdown: [Function rustH
 
 Main menu
 
-move to sidebar
-
-hide"
+move to sidebar hide"
 `;
 
 exports[`tables { name: 'Rust Engine', engine: { htmlToMarkdown: [Function rustHtmlToMarkdown], streamHtmlToMarkdown: [Function rustStreamHtmlToMarkdown] } } > headings 1`] = `


### PR DESCRIPTION
Fixes #133

### Description

`<button>` is an inline element, but its tag handler set `isInline` without a
spacing override, so it fell back to the block-level default. That default puts
a paragraph break around the element, which stranded trailing text and
punctuation and pushed adjacent buttons onto separate lines.

`<button>One</button><button>Two</button>`

Before: `One\n\nTwo` — After: `OneTwo`

Every other inline element (`span`, `label`, `a`, …) pairs inline with
no-spacing, so this just brings `<button>` in line with them.

The fix is applied to both engines to keep them in parity:

- **Rust** (`crates/core/src/tags.rs`): `TAG_BUTTON` now uses the shared
  `INLINE_COLLAPSE` handler (no-spacing + inline + collapse whitespace).
- **JS** (`packages/js/src/tags.ts`): add `spacing: NO_SPACING` to the `button`
  handler.

### Additional context

Added a regression test in each engine covering adjacent buttons and trailing
punctuation (`adjacent_buttons_stay_inline`, `button-inline.test.ts`). The
`wiki.test.ts` snapshot also updated — its "breaking test" is real
Wikipedia markup with two adjacent toggle buttons ("move to sidebar" / "hide")
that were being split by the bug; both engines now render them inline. Worth a
glance to confirm the new snapshot is the intended output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Markdown conversion so adjacent buttons remain inline without unwanted paragraph breaks, line breaks, or spacing.
  * Preserved punctuation and surrounding text when buttons appear within paragraphs.

* **Tests**
  * Added regression coverage for inline button rendering in core and JavaScript conversion tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->