### PR TITLE
fix: emit literal newlines for br

### DIFF
--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -46,7 +46,7 @@ impl ConvertState {
     let tag_id: Option<u8>;
     let is_inline: bool;
     let node_spacing: Option<[u8; 2]>;
-    let output: Option<Cow<'static, str>>;
+    let mut output: Option<Cow<'static, str>>;
     // True when `output` is a user-supplied override enter string — emit it
     // verbatim without synthesizing a separating space (issue #93).
     let enter_is_literal: bool;
@@ -141,6 +141,22 @@ impl ConvertState {
           self.last_node_is_inline = is_inline;
           return;
         }
+      }
+    }
+
+    // Whitespace immediately before <br> has no visual effect in HTML. Let the
+    // explicit line boundary subsume it so the output has no trailing spaces.
+    if tag_id == Some(TAG_BR)
+      && !enter_is_literal
+      && self.depth_map[TAG_PRE as usize] == 0
+      && output
+        .as_deref()
+        .is_some_and(|value| value.starts_with('\n'))
+    {
+      let trimmed_len = self.buffer.trim_end_matches(' ').len();
+      self.buffer.truncate(trimmed_len);
+      if output.as_deref() == Some("\n") && self.buffer.ends_with("\n\n") {
+        output = None;
       }
     }
 
@@ -696,24 +712,6 @@ impl ConvertState {
     p
   }
 
-  /// Emit the canonical Markdown hard-break marker, accounting for source
-  /// whitespace already at the end of the current line.
-  fn hard_break(&self, prefix: &str) -> Cow<'static, str> {
-    let bytes = self.buffer.as_bytes();
-    let marker = if bytes.ends_with(b"  ") {
-      "\n"
-    } else if bytes.ends_with(b" ") {
-      " \n"
-    } else {
-      "  \n"
-    };
-    if prefix.is_empty() {
-      Cow::Borrowed(marker)
-    } else {
-      Cow::Owned(format!("{marker}{prefix}"))
-    }
-  }
-
   /// Push `text` into the buffer, hard-wrapping on spaces so no output line
   /// exceeds `self.wrap_width` characters. Words are never split, so a single
   /// token longer than the width (e.g. a URL) overflows rather than breaking.
@@ -789,14 +787,10 @@ impl ConvertState {
           Some(Cow::Borrowed("<br>"))
         } else {
           let prefix = self.continuation_prefix();
-          if self.depth_map[TAG_PRE as usize] > 0 {
-            if prefix.is_empty() {
-              Some(Cow::Borrowed("\n"))
-            } else {
-              Some(Cow::Owned(format!("\n{prefix}")))
-            }
+          if prefix.is_empty() {
+            Some(Cow::Borrowed("\n"))
           } else {
-            Some(self.hard_break(&prefix))
+            Some(Cow::Owned(format!("\n{prefix}")))
           }
         }
       }

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -2328,32 +2328,32 @@ fn wrap_preserves_inline_spacing() {
   );
 }
 
-// ── HTML hard breaks (issue #128) ──
+// ── HTML line breaks (issue #128) ──
 
 #[test]
-fn br_preserves_a_hard_break_with_and_without_wrapping() {
+fn br_preserves_a_line_break_with_and_without_wrapping() {
   let html = "<div>abc def ghi jkl mno<br/>111 222 333 444 555 666 777 888 999 000 abc</div>";
 
   assert_eq!(
     convert(html),
-    "abc def ghi jkl mno  \n111 222 333 444 555 666 777 888 999 000 abc"
+    "abc def ghi jkl mno\n111 222 333 444 555 666 777 888 999 000 abc"
   );
   assert_eq!(
     convert_wrapped(html, 40),
-    "abc def ghi jkl mno  \n111 222 333 444 555 666 777 888 999 000\nabc"
+    "abc def ghi jkl mno\n111 222 333 444 555 666 777 888 999 000\nabc"
   );
-  assert_eq!(convert("<p>first <br>second</p>"), "first  \nsecond");
+  assert_eq!(convert("<p>first <br>second</p>"), "first\nsecond");
 }
 
 #[test]
 fn br_keeps_nested_block_continuation_prefixes() {
   assert_eq!(
     convert("<ul><li>first<br>second</li></ul>"),
-    "- first  \n  second"
+    "- first\n  second"
   );
   assert_eq!(
     convert("<blockquote><p>first<br>second</p></blockquote>"),
-    "> first  \n> second"
+    "> first\n> second"
   );
   assert_eq!(
     convert("<address>first<br>second</address>"),

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -536,6 +536,14 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
         output = [res]
     }
 
+    // A <br> can introduce one blank line, but never needs 3+ consecutive
+    // newlines in normalized prose. Preserve every newline inside <pre>.
+    if (element.tagId === TAG_BR && !state.depthMap[TAG_PRE]
+      && output?.length === 1 && output[0] === '\n'
+      && lastChar === '\n' && secondLastChar === '\n') {
+      output = undefined
+    }
+
     // Handle newlines
     const newLineConfig = calculateNewLineConfig(node as ElementNode, state.depthMap, state.plainText === true)
     const configuredNewLines = newLineConfig[eventType] || 0
@@ -619,7 +627,8 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
           const isBlockElement = !isInlineElement && !collapsesWhiteSpace && configuredNewLines > 0
           // Don't trim before elements that have collapsesInnerWhiteSpace on enter
           // Also don't trim before block elements that have their own spacing configuration
-          const shouldTrim = (!isInlineElement || eventType === NodeEventExit) && !isBlockElement && !(collapsesWhiteSpace && eventType === NodeEventEnter) && !(hasSpacing && eventType === NodeEventEnter)
+          const shouldTrim = (element.tagId === TAG_BR && output?.[0]?.[0] === '\n' && !parentInPre)
+            || ((!isInlineElement || eventType === NodeEventExit) && !isBlockElement && !(collapsesWhiteSpace && eventType === NodeEventEnter) && !(hasSpacing && eventType === NodeEventEnter))
 
           if (shouldTrim) {
             const originalLength = lastFragment.length

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -186,19 +186,6 @@ function isInsideRawHtmlBlock(state: HandlerContext['state']): boolean {
     || depthMap[TAG_DD])
 }
 
-function hardBreak(buffer: string[], prefix: string): string {
-  let spacesNeeded = 2
-  for (let i = buffer.length - 1; i >= 0 && spacesNeeded > 0; i--) {
-    const fragment = buffer[i]!
-    for (let j = fragment.length - 1; j >= 0 && spacesNeeded > 0; j--) {
-      if (fragment.charCodeAt(j) !== 32)
-        return `${' '.repeat(spacesNeeded)}\n${prefix}`
-      spacesNeeded--
-    }
-  }
-  return `${' '.repeat(spacesNeeded)}\n${prefix}`
-}
-
 // Helper function to get language from code class attribute
 function getLanguageFromClass(className: string | undefined): string {
   if (!className)
@@ -307,8 +294,8 @@ export const tagHandlers: Record<number, TagHandler> = {
   },
   [TAG_BR]: {
     enter: ({ node, state }) => {
-      // A Markdown hard break would terminate a table row/ATX heading or be
-      // ignored inside a raw HTML block, so preserve the inline HTML there.
+      // A literal newline would terminate a table row/ATX heading or collapse
+      // inside a raw HTML block, so preserve the inline HTML there.
       const depthMap = state.depthMap!
       if (isInsideTableCell(state) || isInsideRawHtmlBlock(state)
         || depthMap[TAG_H1]
@@ -321,9 +308,7 @@ export const tagHandlers: Record<number, TagHandler> = {
       }
 
       const prefix = continuationPrefix(node, state.listIndentWidths || [])
-      // Inside a fenced block, the literal newline is already meaningful and
-      // trailing spaces would become part of the code.
-      return depthMap[TAG_PRE] ? `\n${prefix}` : hardBreak(state.buffer, prefix)
+      return `\n${prefix}`
     },
     isSelfClosing: true,
     spacing: NO_SPACING,

--- a/packages/js/test/unit/wrap-width.test.ts
+++ b/packages/js/test/unit/wrap-width.test.ts
@@ -23,28 +23,28 @@ describe('wrap width (issue #106)', () => {
       .toBe('see _this_ word and more words after the\nemphasis here please now')
   })
 
-  it('preserves br as a hard break with and without wrapping (issue #128)', () => {
+  it('preserves br as a line break with and without wrapping (issue #128)', () => {
     const html = '<div>abc def ghi jkl mno<br/>111 222 333 444 555 666 777 888 999 000 abc</div>'
 
     expect(htmlToMarkdown(html))
-      .toBe('abc def ghi jkl mno  \n111 222 333 444 555 666 777 888 999 000 abc')
+      .toBe('abc def ghi jkl mno\n111 222 333 444 555 666 777 888 999 000 abc')
     expect(wrap(html, 40))
-      .toBe('abc def ghi jkl mno  \n111 222 333 444 555 666 777 888 999 000\nabc')
+      .toBe('abc def ghi jkl mno\n111 222 333 444 555 666 777 888 999 000\nabc')
     expect(htmlToMarkdown('<p>first <br>second</p>'))
-      .toBe('first  \nsecond')
+      .toBe('first\nsecond')
   })
 
   it('keeps nested block continuation prefixes after br', () => {
     expect(htmlToMarkdown('<ul><li>first<br>second</li></ul>'))
-      .toBe('- first  \n  second')
+      .toBe('- first\n  second')
     expect(htmlToMarkdown('<blockquote><p>first<br>second</p></blockquote>'))
-      .toBe('> first  \n> second')
+      .toBe('> first\n> second')
     expect(htmlToMarkdown('<address>first<br>second</address>'))
       .toBe('<address>first<br>second</address>')
     expect(htmlToMarkdown('<h1>first<br>second</h1>'))
       .toBe('# first<br>second')
-    expect(htmlToMarkdown('<pre>first<br>second</pre>'))
-      .toBe('```\nfirst\nsecond\n```')
+    expect(htmlToMarkdown('<pre>first  <br>second</pre>'))
+      .toBe('```\nfirst  \nsecond\n```')
   })
 
   it('never splits an oversized token', () => {

--- a/packages/mdream/test/unit/nodes/html-to-markdown-parity.test.ts
+++ b/packages/mdream/test/unit/nodes/html-to-markdown-parity.test.ts
@@ -59,7 +59,7 @@ describe.each(engines)('html-to-markdown parity $name', (engineConfig) => {
   Output a message: <br/>
   <code>console.log("hello")</code>
 </p>
-`, { engine })).toBe('Output a message:  \n`console.log("hello")`')
+`, { engine })).toBe('Output a message:\n`console.log("hello")`')
 
     // We need to pass the backtick testing for now
     const result = htmlToMarkdown(`<code>with \`\` backticks</code>`, { engine })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #128

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore

### 📚 Description

Emit a literal newline for `<br>` in normal prose instead of a two-space Markdown hard-break marker. This matches the output reported in #128 and keeps wrapping the following text independently.

The shared output path trims source whitespace before the break and caps repeated breaks without adding a dedicated helper. Table cells, headings, raw HTML blocks, list and quote prefixes, and `<pre>` content keep their existing context-specific behavior.

### 🧪 Verification

- `pnpm lint && pnpm typecheck && pnpm build`
- 955 JS/package tests passed; 16 skipped
- 353 Rust tests and doctests passed
- Rust clippy and formatting checks passed

### 📊 Performance

Compared with `main` using the repository benchmark harness:

- gzip: core -36 B, minimal -37 B, stream -36 B; Rust WASM unchanged
- CPU: core -1.2%, minimal -2.8%, stream -0.6%, Rust WASM -0.2%
- deterministic JS allocations: +9 KB, +36 KB, -11 KB; all below the 64 KiB gate
- Rust peak linear memory: unchanged at 8,323,072 bytes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated HTML `<br>` conversion to produce standard newline breaks instead of Markdown hard breaks.
  * Prevented redundant blank lines when multiple breaks occur in prose.
  * Preserved whitespace more accurately inside code blocks and `<pre>` content.
  * Improved line-break formatting within lists, blockquotes, and wrapped Markdown output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->