### PR TITLE
fix: bound pathological element nesting

### DIFF
--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -260,6 +260,7 @@ pub struct ConvertState {
   script_data_state: u8,
   escape_ctx: u8,
   in_pre: bool,
+  depth_limit_reached: bool,
   /// Filter: depth of the shallowest currently-open visually-hidden element, or
   /// None. Lets the parser skip a hidden subtree in O(1) without re-checking
   /// styles per node, and keeps this state off the public `ElementNode`.
@@ -403,6 +404,7 @@ impl ConvertState {
       script_data_state: SCRIPT_DATA,
       escape_ctx: 0,
       in_pre: false,
+      depth_limit_reached: false,
       hidden_since_depth: None,
       collapse_non_span_depth: 0,
       collapse_span_depth: 0,
@@ -586,6 +588,9 @@ impl ConvertState {
   }
 
   pub fn process_html(&mut self, chunk: &str) -> String {
+    if self.depth_limit_reached {
+      return String::new();
+    }
     // Reuse text_buffer allocation from previous call if available
     let mut text_buffer = std::mem::take(&mut self.parse_text_buffer);
     text_buffer.clear();
@@ -606,7 +611,7 @@ impl ConvertState {
         .unwrap_or(chunk_length);
     }
 
-    while i < chunk_length {
+    while i < chunk_length && !self.depth_limit_reached {
       let cc = bytes[i];
 
       if cc != LT_CHAR {

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -2,6 +2,11 @@
 
 use super::*;
 
+// Firefox and Chromium flatten DOM trees beyond this practical depth. Stop
+// conversion at the same boundary instead of growing the parser stack without
+// limit. Output produced before the boundary remains available to the caller.
+const MAX_ELEMENT_DEPTH: usize = 512;
+
 /// Tags valid inside `<head>` per the HTML parser's "in head" insertion mode.
 /// Any other start tag implies the end of `<head>` and the start of the body, so
 /// an unclosed head is auto-closed when one appears. Unknown tags (`None`) are
@@ -593,6 +598,16 @@ impl ConvertState {
           }
         }
       }
+    }
+
+    if !self_closing && self.stack.len() >= MAX_ELEMENT_DEPTH {
+      self.depth_limit_reached = true;
+      return OpeningTagResult {
+        complete: true,
+        new_position,
+        self_closing: false,
+        skip: true,
+      };
     }
 
     if let Some(id) = tag_id {

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -1298,7 +1298,7 @@ impl ConvertState {
     };
 
     let result = self.process_opening_tag("#cdata-section", tag_id, false, ">", 0);
-    if !result.complete {
+    if !result.complete || result.skip {
       return;
     }
 

--- a/crates/core/tests/depth_limit.rs
+++ b/crates/core/tests/depth_limit.rs
@@ -1,0 +1,63 @@
+use mdream::{HTMLToMarkdownOptions, MarkdownStreamProcessor, html_to_markdown};
+
+const LIMIT: usize = 512;
+
+#[test]
+fn content_below_the_limit_is_unchanged() {
+  let html = format!("{}deep{}", "<div>".repeat(LIMIT), "</div>".repeat(LIMIT));
+  assert_eq!(
+    html_to_markdown(&html, HTMLToMarkdownOptions::default()),
+    "deep"
+  );
+}
+
+#[test]
+fn conversion_stops_when_nesting_exceeds_the_limit() {
+  let html = format!("<p>before</p>{}discarded", "<div>".repeat(100_000),);
+  assert_eq!(
+    html_to_markdown(&html, HTMLToMarkdownOptions::default()),
+    "before",
+  );
+}
+
+#[test]
+fn self_closing_elements_at_the_limit_do_not_stop_conversion() {
+  let html = format!(
+    "{}<br>kept{}",
+    "<div>".repeat(LIMIT),
+    "</div>".repeat(LIMIT),
+  );
+  let output = html_to_markdown(&html, HTMLToMarkdownOptions::default());
+  assert!(output.contains("kept"), "got: {output:?}");
+}
+
+#[test]
+fn implied_end_recovery_does_not_trigger_the_limit() {
+  let html = "<p>item".repeat(1_000);
+  let output = html_to_markdown(&html, HTMLToMarkdownOptions::default());
+  assert_eq!(output.matches("item").count(), 1_000);
+}
+
+#[test]
+fn streaming_stops_consuming_after_the_limit() {
+  let mut stream = MarkdownStreamProcessor::new(HTMLToMarkdownOptions::default());
+  let mut output = stream.process_chunk("<p>before</p>");
+  for _ in 0..10_000 {
+    output.push_str(&stream.process_chunk("<div>"));
+  }
+  output.push_str(&stream.process_chunk("discarded"));
+  output.push_str(&stream.finish());
+  assert_eq!(output.trim_end(), "before");
+}
+
+#[test]
+fn content_hidden_at_the_limit_cannot_leak() {
+  let html = format!(
+    "{}<template><strong>hidden</strong></template><p>discarded</p>",
+    "<div>".repeat(LIMIT - 1),
+  );
+  assert_eq!(
+    html_to_markdown(&html, HTMLToMarkdownOptions::default()),
+    ""
+  );
+}

--- a/crates/core/tests/depth_limit.rs
+++ b/crates/core/tests/depth_limit.rs
@@ -1,4 +1,6 @@
-use mdream::{HTMLToMarkdownOptions, MarkdownStreamProcessor, html_to_markdown};
+use mdream::{
+  HTMLToMarkdownOptions, MarkdownStreamProcessor, PluginConfig, TagOverrideConfig, html_to_markdown,
+};
 
 const LIMIT: usize = 512;
 
@@ -60,4 +62,27 @@ fn content_hidden_at_the_limit_cannot_leak() {
     html_to_markdown(&html, HTMLToMarkdownOptions::default()),
     ""
   );
+}
+
+#[test]
+fn skipped_cdata_override_does_not_emit_or_pop_its_parent() {
+  let html = format!(
+    "{}<![CDATA[hidden]]><p>discarded</p>",
+    "<div>".repeat(LIMIT),
+  );
+  let options = HTMLToMarkdownOptions {
+    plugins: Some(PluginConfig {
+      tag_overrides: Some(vec![(
+        "#cdata-section".to_string(),
+        TagOverrideConfig {
+          enter: Some("[".to_string()),
+          exit: Some("]".to_string()),
+          ..Default::default()
+        },
+      )]),
+      ..Default::default()
+    }),
+    ..Default::default()
+  };
+  assert_eq!(html_to_markdown(&html, options), "");
 }

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -99,6 +99,11 @@ const SCRIPT_SEQUENCE_NO_MATCH = -1
 const SCRIPT_SEQUENCE_INCOMPLETE = -2
 const SCRIPT_SCAN_COMPLETE = -1
 
+// Firefox and Chromium flatten DOM trees beyond this practical depth. Stop
+// conversion at the same boundary instead of growing the parser's parent chain
+// without limit on pathologically nested input.
+const MAX_ELEMENT_DEPTH = 512
+
 // Tags that are valid inside <head>. Per the HTML parser's "in head" insertion
 // mode, any start tag NOT in this set implies the end of <head> and the start of
 // the body, so we auto-close an unclosed <head> when one appears (browser
@@ -472,6 +477,8 @@ export interface ParseState {
   depthMap: Uint8Array
   /** Current overall nesting depth */
   depth: number
+  /** Whether parsing stopped after reaching the practical browser depth limit. */
+  depthLimitReached?: boolean
   /** Currently processing element node */
   currentNode?: ElementNode | null
   /** Whether current content contains HTML entities that need decoding */
@@ -734,6 +741,9 @@ function parseHtmlInternal(
   state: ParseState,
   handleEvent: (event: NodeEvent) => void,
 ): string {
+  if (state.depthLimitReached)
+    return ''
+
   let textBuffer = '' // Buffer to accumulate text content
 
   // Initialize state
@@ -754,7 +764,7 @@ function parseHtmlInternal(
     i = scanResult
   }
 
-  while (i < chunkLength) {
+  while (i < chunkLength && !state.depthLimitReached) {
     const currentCharCode = htmlChunk.charCodeAt(i)
 
     // If not starting a tag, add to text buffer and continue
@@ -1302,7 +1312,7 @@ function processCdataSection(
   // `>` at position 0 and exits immediately, so the synthetic tag has no
   // attributes to parse. Mirrors the Rust engine's synthetic-tag handling.
   const open = processOpeningTag('#cdata-section', -1, '>', 0, state, handleEvent)
-  if (!open.complete || open.selfClosing) {
+  if (!open.complete || open.selfClosing || open.skip) {
     return
   }
 
@@ -1466,6 +1476,17 @@ function processOpeningTag(
           closeImpliedTo(state, DT_DD, DL_SCOPE_BOUNDARY, handleEvent)
         }
       }
+    }
+  }
+
+  if (!result.selfClosing && state.depth >= MAX_ELEMENT_DEPTH) {
+    state.depthLimitReached = true
+    return {
+      complete: true,
+      newPosition: result.newPosition,
+      remainingText: '',
+      selfClosing: false,
+      skip: true,
     }
   }
 

--- a/packages/js/test/unit/depth-limit.test.ts
+++ b/packages/js/test/unit/depth-limit.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { htmlToMarkdown, streamHtmlToMarkdown } from '../../src/index'
+
+const LIMIT = 512
+
+async function streamConvert(chunks: string[]): Promise<string> {
+  const stream = new ReadableStream<string>({
+    start(controller) {
+      for (const chunk of chunks)
+        controller.enqueue(chunk)
+      controller.close()
+    },
+  })
+  let output = ''
+  for await (const chunk of streamHtmlToMarkdown(stream))
+    output += chunk
+  return output
+}
+
+describe('element depth limit', () => {
+  it('leaves content at the limit unchanged', () => {
+    const html = `${'<div>'.repeat(LIMIT)}deep${'</div>'.repeat(LIMIT)}`
+    expect(htmlToMarkdown(html)).toBe('deep')
+  })
+
+  it('stops conversion when nesting exceeds the limit', () => {
+    const html = `<p>before</p>${'<div>'.repeat(100_000)}discarded`
+    expect(htmlToMarkdown(html)).toBe('before')
+  })
+
+  it('does not count self-closing elements at the limit', () => {
+    const html = `${'<div>'.repeat(LIMIT)}<br>kept${'</div>'.repeat(LIMIT)}`
+    expect(htmlToMarkdown(html)).toContain('kept')
+  })
+
+  it('applies implied-end recovery before checking the limit', () => {
+    const output = htmlToMarkdown('<p>item'.repeat(1_000))
+    expect(output.match(/item/g)).toHaveLength(1_000)
+  })
+
+  it('stops consuming streamed chunks after reaching the limit', async () => {
+    const chunks = ['<p>before</p>', ...Array.from({ length: 10_000 }).fill('<div>'), 'discarded']
+    expect((await streamConvert(chunks)).trimEnd()).toBe('before')
+  })
+
+  it('does not leak content hidden at the limit', () => {
+    const html = `${'<div>'.repeat(LIMIT - 1)}<template><strong>hidden</strong></template><p>discarded</p>`
+    expect(htmlToMarkdown(html)).toBe('')
+  })
+
+  it('does not emit or pop a parent for a skipped CDATA override', () => {
+    const html = `${'<div>'.repeat(LIMIT)}<![CDATA[hidden]]><p>discarded</p>`
+    expect(htmlToMarkdown(html, {
+      plugins: {
+        tagOverrides: {
+          '#cdata-section': { enter: '[', exit: ']', isInline: true, spacing: [0, 0] },
+        },
+      },
+    })).toBe('')
+  })
+})

--- a/packages/js/test/unit/depth-limit.test.ts
+++ b/packages/js/test/unit/depth-limit.test.ts
@@ -39,7 +39,10 @@ describe('element depth limit', () => {
   })
 
   it('stops consuming streamed chunks after reaching the limit', async () => {
-    const chunks = ['<p>before</p>', ...Array.from({ length: 10_000 }).fill('<div>'), 'discarded']
+    const chunks = ['<p>before</p>']
+    for (let i = 0; i < 10_000; i++)
+      chunks.push('<div>')
+    chunks.push('discarded')
     expect((await streamConvert(chunks)).trimEnd()).toBe('before')
   })
 


### PR DESCRIPTION
### 🔗 Linked issue

Supersedes #141. Thanks @edevil for identifying and characterizing the memory amplification.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Pathologically nested HTML grows both the Rust element stack and the pure-JavaScript parser parent chain without limit. A 5 MB stream reached about 212 MB RSS in a local Rust release build. The unguarded JS engine was still processing a one-million-element input after 76 seconds and 112 MB RSS; the guarded build finished in about 0.02 seconds at 56 MB RSS, including the input.

Stop conversion in both engines after 512 simultaneously open elements, matching the practical depth where Firefox and Chromium flatten DOM trees. Output produced before the limit remains available, while void and self-closing elements do not consume depth.

Regression coverage includes one-shot and streaming conversion, implied-end recovery, void elements, hidden template content, and synthetic CDATA overrides.

CI measures 49 to 51 bytes of extra gzip per JavaScript bundle (0.3 to 0.4%, net 0.1 kB), no Rust WASM size change, and no significant performance change.