### PR TITLE
fix(core): don't slice the streaming buffer mid-codepoint

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -21,6 +21,7 @@ jobs:
           - fuzz_options
           - fuzz_splitter
           - fuzz_streaming
+          - fuzz_streaming_chunks
     steps:
       - uses: actions/checkout@v6
 

--- a/crates/core/fuzz/Cargo.toml
+++ b/crates/core/fuzz/Cargo.toml
@@ -31,6 +31,13 @@ doc = false
 bench = false
 
 [[bin]]
+name = "fuzz_streaming_chunks"
+path = "fuzz_targets/fuzz_streaming_chunks.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "fuzz_splitter"
 path = "fuzz_targets/fuzz_splitter.rs"
 test = false

--- a/crates/core/fuzz/fuzz_targets/fuzz_streaming_chunks.rs
+++ b/crates/core/fuzz/fuzz_targets/fuzz_streaming_chunks.rs
@@ -1,0 +1,28 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use mdream::{MarkdownStreamProcessor, types::HTMLToMarkdownOptions};
+
+// Feeds one HTML document through the streaming processor split into small,
+// fixed-width chunks (rounded up to char boundaries). Unlike `fuzz_streaming`
+// (arbitrary `Vec<String>`), this drives narrow chunk boundaries through the
+// drain, where multibyte codepoints straddle internal buffer offsets. Seed
+// corpus entries are plain text: first byte = chunk width, rest = HTML.
+fuzz_target!(|data: &[u8]| {
+  let Some((&width, html_bytes)) = data.split_first() else {
+    return;
+  };
+  let width = (width as usize).max(1);
+  let html = String::from_utf8_lossy(html_bytes);
+
+  let mut processor = MarkdownStreamProcessor::new(HTMLToMarkdownOptions::default());
+  let mut start = 0;
+  while start < html.len() {
+    let mut end = (start + width).min(html.len());
+    while end < html.len() && !html.is_char_boundary(end) {
+      end += 1;
+    }
+    let _ = processor.process_chunk(&html[start..end]);
+    start = end;
+  }
+  let _ = processor.finish();
+});

--- a/crates/core/src/bin.rs
+++ b/crates/core/src/bin.rs
@@ -69,6 +69,8 @@ fn main() -> io::Result<()> {
   let stdout = io::stdout();
   let mut out = stdout.lock();
   let mut buf = [0u8; 8192];
+  // A codepoint can straddle a read boundary; carry the incomplete tail over.
+  let mut carry: Vec<u8> = Vec::new();
   let mut total_in: usize = 0;
   let mut total_out: usize = 0;
 
@@ -78,14 +80,30 @@ fn main() -> io::Result<()> {
       break;
     }
     total_in += n;
-    let chunk =
-      std::str::from_utf8(&buf[..n]).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-    let md = processor.process_chunk(chunk);
-    if !md.is_empty() {
-      total_out += md.len();
-      out.write_all(md.as_bytes())?;
-      out.flush()?;
+    carry.extend_from_slice(&buf[..n]);
+
+    let valid_up_to = match std::str::from_utf8(&carry) {
+      Ok(s) => s.len(),
+      Err(e) if e.error_len().is_none() => e.valid_up_to(),
+      Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidData, e)),
+    };
+    if valid_up_to > 0 {
+      let chunk = std::str::from_utf8(&carry[..valid_up_to]).unwrap();
+      let md = processor.process_chunk(chunk);
+      if !md.is_empty() {
+        total_out += md.len();
+        out.write_all(md.as_bytes())?;
+        out.flush()?;
+      }
+      carry.drain(..valid_up_to);
     }
+  }
+
+  if !carry.is_empty() {
+    return Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "stream ended with an incomplete UTF-8 codepoint",
+    ));
   }
 
   let remaining = processor.finish();

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -1042,7 +1042,20 @@ impl ConvertState {
       stable_end = stable_end.min(p);
     }
     // `last_yielded_length` is an absolute buffer offset (see drain below).
-    let start = self.last_yielded_length.max(leading);
+    let mut start = self.last_yielded_length.max(leading);
+    if start >= stable_end {
+      self.drain_streamed_prefix();
+      return String::new();
+    }
+    // Offsets here derive from marker positions and drain rebasing that need not
+    // fall on a UTF-8 boundary; slicing mid-codepoint panics. Clamp both bounds
+    // down to a boundary, holding any partial codepoint for the next chunk.
+    while stable_end > start && !self.buffer.is_char_boundary(stable_end) {
+      stable_end -= 1;
+    }
+    while start > 0 && !self.buffer.is_char_boundary(start) {
+      start -= 1;
+    }
     if start >= stable_end {
       self.drain_streamed_prefix();
       return String::new();

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -59,6 +59,23 @@ fn stream_chunks(html: &str, chunk: usize, opts: HTMLToMarkdownOptions) -> Strin
   out
 }
 
+// Splits on char boundaries so multibyte input can be fed in small chunks.
+fn stream_chars(html: &str, max_bytes: usize, opts: HTMLToMarkdownOptions) -> String {
+  let mut p = MarkdownStreamProcessor::new(opts);
+  let mut out = String::new();
+  let mut start = 0;
+  while start < html.len() {
+    let mut end = (start + max_bytes.max(1)).min(html.len());
+    while end < html.len() && !html.is_char_boundary(end) {
+      end += 1;
+    }
+    out.push_str(&p.process_chunk(&html[start..end]));
+    start = end;
+  }
+  out.push_str(&p.finish());
+  out
+}
+
 // Compares chunked streaming against one-shot, so it excludes the
 // rewrite-after-yield constructs (autolink text==url, self-link headings,
 // redundant `[url](url)`) that diverge from one-shot even on `main`. Drain
@@ -93,6 +110,46 @@ fn streamed_output_matches_one_shot() {
           "mismatch: chunk={chunk} html={html:?}"
         );
       }
+    }
+  }
+}
+
+// Regression: the streaming buffer was sliced/drained on raw byte offsets that
+// could land mid-codepoint, panicking on non-ASCII input.
+#[test]
+fn multibyte_drain_matches_one_shot() {
+  const UNIT: &str = r#"<div><a href="/a">link</a> <span>&ldquo;Create&rdquo;</span></div>"#;
+  let doc = format!("<article>{}</article>", UNIT.repeat(40));
+  let opts = HTMLToMarkdownOptions {
+    clean: Some(safe_clean()),
+    ..Default::default()
+  };
+
+  let expected = html_to_markdown(&doc, opts.clone());
+  assert!(expected.contains('“') && !expected.is_empty());
+  for max_bytes in [1usize, 2, 3, 5, 8, 64] {
+    let got = stream_chars(&doc, max_bytes, opts.clone());
+    assert_eq!(
+      got.trim(),
+      expected.trim(),
+      "mismatch at max_bytes={max_bytes}"
+    );
+  }
+}
+
+// A rewrite-after-yield can leave a chunk/drain offset inside a multibyte
+// codepoint; the streaming buffer must never be sliced there. A panic here
+// fails the test.
+#[test]
+fn streaming_multibyte_never_panics() {
+  const CASES: &[&str] = &[
+    "<blockquote>”<br>\n</><p>🎉",
+    "<a href=\"/x\">link</a>“<strong></strong>—漢字",
+    "<ul><li>é<a href=\"/x\"></a>…</li></ul>🎉&mdash;",
+  ];
+  for &html in CASES {
+    for max_bytes in [1usize, 2, 3, 4, 5, 7, 11] {
+      let _ = stream_chars(html, max_bytes, HTMLToMarkdownOptions::default());
     }
   }
 }


### PR DESCRIPTION
## Problem

The streaming path panics on non-ASCII input. A rewrite-after-yield can shift `last_yielded_length` (or a held marker offset) inside a multibyte codepoint, so `get_markdown_chunk` slices `self.buffer[start..stable_end]` mid-codepoint and aborts.

Reproduces on `main`:
```
"<blockquote>”<br>\n</><p>🎉"   fed in <=5-byte chunks
```

## Fix

- **core**: clamp the streaming slice bounds down to char boundaries, holding a partial codepoint until the rest arrives.
- **cli**: the 8192-byte stdin loop ran `from_utf8` per raw read and errored when a codepoint straddled a read boundary; carry the incomplete tail into the next read.

## Tests

- `streaming_drain.rs`: `streaming_multibyte_never_panics` (panics pre-fix at the slice site) + `multibyte_drain_matches_one_shot`.
- New `fuzz_streaming_chunks` target: splits one document into narrow char-safe chunks (seedable as `[width byte][HTML]`); reproduces the crash from a seed pre-fix, clean after. Wired into the weekly fuzz matrix.

Full suite, clippy (`-D warnings`), MSRV 1.95, and wasm build all pass. No change to one-shot output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming conversion for UTF-8 characters split across input chunks.
  * Prevented crashes and malformed output when processing multibyte characters during streaming.
  * Added clearer handling for incomplete UTF-8 input at the end of a stream.

* **Tests**
  * Added regression coverage for multibyte streaming input, including small chunk sizes and varied Unicode content.
  * Expanded fuzz testing for streaming chunk processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->