### PR TITLE
fix(node): carry split UTF-8 byte chunks

### DIFF
--- a/crates/core/fuzz/.gitignore
+++ b/crates/core/fuzz/.gitignore
@@ -1,4 +1,7 @@
 target
-corpus
+corpus/*
+!corpus/fuzz_streaming_chunks/
+corpus/fuzz_streaming_chunks/*
+!corpus/fuzz_streaming_chunks/utf8-rewrite
 artifacts
 coverage

--- a/crates/core/fuzz/corpus/fuzz_streaming_chunks/utf8-rewrite
+++ b/crates/core/fuzz/corpus/fuzz_streaming_chunks/utf8-rewrite
@@ -1,0 +1,2 @@
+5<blockquote>”<br>
+</><p>🎉

--- a/crates/core/fuzz/fuzz_targets/fuzz_streaming_chunks.rs
+++ b/crates/core/fuzz/fuzz_targets/fuzz_streaming_chunks.rs
@@ -6,12 +6,17 @@ use mdream::{MarkdownStreamProcessor, types::HTMLToMarkdownOptions};
 // fixed-width chunks (rounded up to char boundaries). Unlike `fuzz_streaming`
 // (arbitrary `Vec<String>`), this drives narrow chunk boundaries through the
 // drain, where multibyte codepoints straddle internal buffer offsets. Seed
-// corpus entries are plain text: first byte = chunk width, rest = HTML.
+// corpus entries are plain text: first byte = chunk width, rest = HTML. ASCII
+// digits 1-9 encode their numeric width so regression seeds remain readable.
 fuzz_target!(|data: &[u8]| {
   let Some((&width, html_bytes)) = data.split_first() else {
     return;
   };
-  let width = (width as usize).max(1);
+  let width = if width.is_ascii_digit() && width != b'0' {
+    (width - b'0') as usize
+  } else {
+    (width as usize).max(1)
+  };
   let html = String::from_utf8_lossy(html_bytes);
 
   let mut processor = MarkdownStreamProcessor::new(HTMLToMarkdownOptions::default());

--- a/crates/core/src/bin.rs
+++ b/crates/core/src/bin.rs
@@ -66,6 +66,7 @@ fn main() -> io::Result<()> {
 
   let mut processor = MarkdownStreamProcessor::new_with_format(options, format);
   let stdin = io::stdin();
+  let mut input = stdin.lock();
   let stdout = io::stdout();
   let mut out = stdout.lock();
   let mut buf = [0u8; 8192];
@@ -75,7 +76,7 @@ fn main() -> io::Result<()> {
   let mut total_out: usize = 0;
 
   loop {
-    let n = stdin.lock().read(&mut buf)?;
+    let n = input.read(&mut buf)?;
     if n == 0 {
       break;
     }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -270,6 +270,7 @@ pub fn html_to_markdown_bytes(
 #[napi]
 pub struct MarkdownStream {
   inner: mdream::MarkdownStreamProcessor,
+  utf8_carry: Vec<u8>,
 }
 
 #[napi]
@@ -279,25 +280,73 @@ impl MarkdownStream {
     let (opts, format) = to_core_opts(options);
     Self {
       inner: mdream::MarkdownStreamProcessor::new_with_format(opts, format),
+      utf8_carry: Vec::new(),
     }
   }
 
   #[napi]
   #[allow(clippy::needless_pass_by_value)]
-  pub fn process_chunk(&mut self, chunk: String) -> String {
-    self.inner.process_chunk(&chunk)
+  pub fn process_chunk(&mut self, chunk: String) -> Result<String> {
+    if !self.utf8_carry.is_empty() {
+      return Err(napi::Error::new(
+        napi::Status::InvalidArg,
+        "Cannot process a string chunk while an incomplete UTF-8 byte sequence is buffered",
+      ));
+    }
+    Ok(self.inner.process_chunk(&chunk))
   }
 
   #[napi(js_name = "processChunkBytes")]
   pub fn process_chunk_bytes(&mut self, chunk: &[u8]) -> Result<String> {
-    let text = std::str::from_utf8(chunk)
-      .map_err(|e| napi::Error::new(napi::Status::InvalidArg, format!("Invalid UTF-8: {e}")))?;
-    Ok(self.inner.process_chunk(text))
+    if self.utf8_carry.is_empty() {
+      return match std::str::from_utf8(chunk) {
+        Ok(text) => Ok(self.inner.process_chunk(text)),
+        Err(error) if error.error_len().is_none() => {
+          let valid_up_to = error.valid_up_to();
+          let text = std::str::from_utf8(&chunk[..valid_up_to])
+            .expect("valid_up_to must end at a UTF-8 boundary");
+          let markdown = self.inner.process_chunk(text);
+          self.utf8_carry.extend_from_slice(&chunk[valid_up_to..]);
+          Ok(markdown)
+        }
+        Err(error) => Err(napi::Error::new(
+          napi::Status::InvalidArg,
+          format!("Invalid UTF-8: {error}"),
+        )),
+      };
+    }
+
+    self.utf8_carry.extend_from_slice(chunk);
+    let valid_up_to = match std::str::from_utf8(&self.utf8_carry) {
+      Ok(text) => text.len(),
+      Err(error) if error.error_len().is_none() => error.valid_up_to(),
+      Err(error) => {
+        return Err(napi::Error::new(
+          napi::Status::InvalidArg,
+          format!("Invalid UTF-8: {error}"),
+        ));
+      }
+    };
+    if valid_up_to == 0 {
+      return Ok(String::new());
+    }
+
+    let text = std::str::from_utf8(&self.utf8_carry[..valid_up_to])
+      .expect("valid_up_to must end at a UTF-8 boundary");
+    let markdown = self.inner.process_chunk(text);
+    self.utf8_carry.drain(..valid_up_to);
+    Ok(markdown)
   }
 
   #[napi]
-  pub fn finish(&mut self) -> String {
-    self.inner.finish()
+  pub fn finish(&mut self) -> Result<String> {
+    if !self.utf8_carry.is_empty() {
+      return Err(napi::Error::new(
+        napi::Status::InvalidArg,
+        "Stream ended with an incomplete UTF-8 byte sequence",
+      ));
+    }
+    Ok(self.inner.finish())
   }
 }
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -303,6 +303,10 @@ impl MarkdownStream {
         Ok(text) => Ok(self.inner.process_chunk(text)),
         Err(error) if error.error_len().is_none() => {
           let valid_up_to = error.valid_up_to();
+          if valid_up_to == 0 {
+            self.utf8_carry.extend_from_slice(chunk);
+            return Ok(String::new());
+          }
           let text = std::str::from_utf8(&chunk[..valid_up_to])
             .expect("valid_up_to must end at a UTF-8 boundary");
           let markdown = self.inner.process_chunk(text);

--- a/packages/js/test/unit/streaming-utf8.test.ts
+++ b/packages/js/test/unit/streaming-utf8.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { htmlToMarkdown, streamHtmlToMarkdown } from '../../src/index'
+
+async function streamBytes(html: string): Promise<string> {
+  const bytes = new TextEncoder().encode(html)
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (let index = 0; index < bytes.length; index++)
+        controller.enqueue(bytes.subarray(index, index + 1))
+      controller.close()
+    },
+  })
+  let markdown = ''
+  for await (const chunk of streamHtmlToMarkdown(stream))
+    markdown += chunk
+  return markdown
+}
+
+describe('streaming UTF-8', () => {
+  it.each([
+    '<blockquote>”<br>\n</><p>🎉',
+    '<a href="/x">link</a>“<strong></strong>—漢字',
+    '<ul><li>é<a href="/x"></a>…</li></ul>🎉&mdash;',
+  ])('matches one-shot output for %s', async (html) => {
+    expect((await streamBytes(html)).trim()).toBe(htmlToMarkdown(html).trim())
+  })
+})

--- a/packages/mdream/test/unit/streaming/streaming.test.ts
+++ b/packages/mdream/test/unit/streaming/streaming.test.ts
@@ -1,9 +1,38 @@
 import { ReadableStream } from 'node:stream/web'
 import { describe, expect, it, vi } from 'vitest'
+import { MarkdownStream as NativeMarkdownStream } from '../../../napi/index.mjs'
 import { engines, resolveEngine, streamHtmlToMarkdown } from '../../utils/engines'
 
 const RE_BOLD_TEXT = /\*\*bold text\*\*/
 const RE_LINK_WITH_URL = /\[Link text\]\(https:\/\/example\.com\)/
+
+describe('native byte streaming', () => {
+  it('carries incomplete UTF-8 across byte chunks', () => {
+    const bytes = new TextEncoder().encode('<p>🎉</p>')
+    const stream = new NativeMarkdownStream()
+    let markdown = ''
+
+    for (let index = 0; index < bytes.length; index++)
+      markdown += stream.processChunkBytes(bytes.subarray(index, index + 1))
+    markdown += stream.finish()
+
+    expect(markdown.trim()).toBe('🎉')
+  })
+
+  it('rejects an incomplete UTF-8 sequence at the end of a byte stream', () => {
+    const stream = new NativeMarkdownStream()
+    stream.processChunkBytes(new Uint8Array([0xF0]))
+
+    expect(() => stream.finish()).toThrow('incomplete UTF-8 byte sequence')
+  })
+
+  it('rejects string chunks while an incomplete byte sequence is buffered', () => {
+    const stream = new NativeMarkdownStream()
+    stream.processChunkBytes(new Uint8Array([0xF0]))
+
+    expect(() => stream.processChunk('text')).toThrow('incomplete UTF-8 byte sequence')
+  })
+})
 
 describe.each(engines)('hTML to Markdown Streaming $name', (engineConfig) => {
   describe('basic Stream Functionality', () => {
@@ -97,6 +126,26 @@ describe.each(engines)('hTML to Markdown Streaming $name', (engineConfig) => {
       // Check that the binary content was correctly decoded and processed
       const combined = result.join('')
       expect(combined).toContain('# Encoded title')
+    })
+
+    it('preserves multibyte rewrites one input byte at a time', async () => {
+      const engine = await resolveEngine(engineConfig.engine)
+      const html = '<blockquote>”<br>\n</><p>🎉'
+      const bytes = new TextEncoder().encode(html)
+      const htmlStream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (let index = 0; index < bytes.length; index++)
+            controller.enqueue(bytes.subarray(index, index + 1))
+          controller.close()
+        },
+      })
+
+      let streamed = ''
+      for await (const chunk of streamHtmlToMarkdown(htmlStream, { engine }))
+        streamed += chunk
+
+      expect(streamed).toContain('”')
+      expect(streamed).toContain('🎉')
     })
   })
 


### PR DESCRIPTION
### 🔗 Linked issue

Related to #155

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore

### 📚 Description

PR #155 fixed UTF-8 boundaries in the Rust stream and CLI, but the native `processChunkBytes` binding still rejected valid codepoints split across chunks. This carries incomplete byte sequences in the NAPI stream, seeds the original fuzz reproducer, and adds native plus pure JS regression coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved streaming conversion to correctly handle UTF-8 characters split across input chunks, including native byte-by-byte streaming with multibyte characters and emoji.
  * Added stricter handling so streams report errors when invalid UTF-8 is received or when UTF-8 ends mid-sequence.
* **Bug Fixes**
  * Prevented corrupted output when UTF-8 sequences span multiple chunks.
* **Tests**
  * Expanded coverage for byte-at-a-time streaming, incomplete/invalid UTF-8 behavior, and native N-API byte streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->