### PR TITLE
fix(core): streaming output diverging from one-shot conversion

### DIFF
--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -1065,13 +1065,14 @@ impl ConvertState {
     let mut stable_end = self.buffer.trim_end_matches(' ').len();
     if stable_end < buf_len && self.depth_map[TAG_PRE as usize] != 0 {
       // Inside <pre> trailing spaces are usually significant code, so yield
-      // them. The exception is a line-leading run (preceded by a newline): a
-      // list continuation indent is emitted right after the closing fence, and
+      // them unless the last text node can still be trimmed by an inline
+      // rewrite. Another exception is a line-leading run preceded by a newline.
+      // A list continuation indent is emitted right after the closing fence, and
       // before the next sibling is known, while <pre>'s depth is still set.
       // That indent is speculative (the next <li> rewrites it to its marker),
       // so hold it back like any other trailing whitespace.
       let line_leading = stable_end == 0 || self.buffer.as_bytes()[stable_end - 1] == b'\n';
-      if !line_leading {
+      if !line_leading && !self.last_text_node_contains_whitespace {
         stable_end = buf_len;
       }
     }

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -89,6 +89,16 @@ enum ScriptScanBoundary {
   Complete,
 }
 
+/// Outcome of feeding one chunk to the script-data scanner.
+enum ScriptChunk {
+  /// The `</script` close tag was found; resume normal parsing at this index.
+  Closed(usize),
+  /// The chunk ended inside script data; carry the raw tail from this offset
+  /// into the next chunk (`chunk.len()` when everything was consumed, i.e.
+  /// nothing to carry).
+  Carry(usize),
+}
+
 struct ScriptScanResult {
   boundary: ScriptScanBoundary,
   state: u8,
@@ -560,12 +570,7 @@ impl ConvertState {
     self.script_text_buffer = script_text;
   }
 
-  fn process_script_chunk(
-    &mut self,
-    chunk: &str,
-    start: usize,
-    text_buffer: &mut String,
-  ) -> Option<usize> {
+  fn process_script_chunk(&mut self, chunk: &str, start: usize) -> ScriptChunk {
     let scan = find_script_end_tag(chunk.as_bytes(), start, self.script_data_state);
     self.script_data_state = scan.state;
     match scan.boundary {
@@ -573,16 +578,18 @@ impl ConvertState {
         self.push_script_text(&chunk[start..close_index]);
         self.flush_script_text();
         self.script_data_state = SCRIPT_DATA;
-        Some(close_index)
+        ScriptChunk::Closed(close_index)
       }
       ScriptScanBoundary::Pending(pending_start) => {
+        // Consume the script text before the partial `</scr…` and carry only
+        // that raw tail. Carrying from the script start instead would re-feed
+        // the text just pushed here, which the resume path would push again.
         self.push_script_text(&chunk[start..pending_start]);
-        text_buffer.push_str(&chunk[pending_start..]);
-        None
+        ScriptChunk::Carry(pending_start)
       }
       ScriptScanBoundary::Complete => {
         self.push_script_text(&chunk[start..]);
-        None
+        ScriptChunk::Carry(chunk.len())
       }
     }
   }
@@ -600,18 +607,31 @@ impl ConvertState {
     let bytes = chunk.as_bytes();
     let chunk_length = bytes.len();
     let mut i = 0;
+    // Raw start of the text/tag run currently held in `text_buffer`. Any tail
+    // carried to the next chunk is returned raw from here, never the decoded
+    // and escaped `text_buffer` (which would be re-escaped, multiplying `\`).
+    let mut run_start = 0usize;
+    let mut carry = false;
 
     if self
       .stack
       .last()
       .is_some_and(|node| node.tag_id == Some(TAG_SCRIPT) && node.custom_name.is_none())
     {
-      i = self
-        .process_script_chunk(chunk, i, &mut text_buffer)
-        .unwrap_or(chunk_length);
+      match self.process_script_chunk(chunk, i) {
+        ScriptChunk::Closed(close_index) => i = close_index,
+        ScriptChunk::Carry(from) => {
+          run_start = from;
+          carry = true;
+          i = chunk_length;
+        }
+      }
     }
 
     while i < chunk_length && !self.depth_limit_reached {
+      if text_buffer.is_empty() {
+        run_start = i;
+      }
       let cc = bytes[i];
 
       if cc != LT_CHAR {
@@ -721,7 +741,7 @@ impl ConvertState {
 
       // Processing '<'
       if i + 1 >= chunk_length {
-        text_buffer.push(cc as char);
+        carry = true;
         break;
       }
 
@@ -751,12 +771,13 @@ impl ConvertState {
             if !text_buffer.is_empty() {
               self.process_text_buffer(&mut text_buffer);
               text_buffer.clear();
+              run_start = i;
             }
             let result = self.process_closing_tag(chunk, i);
             if result.complete {
               i = result.new_position;
             } else {
-              text_buffer.push_str(&chunk[result.remaining_start..]);
+              carry = true;
               break;
             }
             continue;
@@ -787,41 +808,44 @@ impl ConvertState {
             if !text_buffer.is_empty() {
               self.process_text_buffer(&mut text_buffer);
               text_buffer.clear();
+              run_start = i;
             }
             self.process_cdata_section(&after_open[..rel]);
             i += "<![CDATA[".len() + rel + 3;
             continue;
           }
           // Unterminated CDATA: re-parse from '<' in the next chunk.
-          text_buffer.push_str(remaining);
+          carry = true;
           break;
         }
         if remaining.len() < "<![CDATA[".len() && "<![CDATA[".starts_with(remaining) {
           // Chunk boundary fell inside the `<![CDATA[` opener.
-          text_buffer.push_str(remaining);
+          carry = true;
           break;
         }
         if !text_buffer.is_empty() {
           self.process_text_buffer(&mut text_buffer);
           text_buffer.clear();
+          run_start = i;
         }
         let result = process_comment_or_doctype(chunk, i);
         if result.complete {
           i = result.new_position;
         } else {
-          text_buffer.push_str(&chunk[result.remaining_start..]);
+          carry = true;
           break;
         }
       } else if next == SLASH_CHAR {
         if !text_buffer.is_empty() {
           self.process_text_buffer(&mut text_buffer);
           text_buffer.clear();
+          run_start = i;
         }
         let result = self.process_closing_tag(chunk, i);
         if result.complete {
           i = result.new_position;
         } else {
-          text_buffer.push_str(&chunk[result.remaining_start..]);
+          carry = true;
           break;
         }
       } else {
@@ -837,7 +861,7 @@ impl ConvertState {
           i2 += 1;
         }
         let Some(tag_name_end) = tag_name_end else {
-          text_buffer.push_str(&chunk[i..]);
+          carry = true;
           break;
         };
         let tag_name_raw = &chunk[tag_name_start..tag_name_end];
@@ -880,6 +904,7 @@ impl ConvertState {
         if !text_buffer.is_empty() {
           self.process_text_buffer(&mut text_buffer);
           text_buffer.clear();
+          run_start = i;
         }
 
         let result =
@@ -894,33 +919,41 @@ impl ConvertState {
           } else {
             self.is_first_text_in_element = true;
             if builtin_tag_id == Some(TAG_SCRIPT) {
-              let Some(close_index) = self.process_script_chunk(chunk, i, &mut text_buffer) else {
-                break;
-              };
-              i = close_index;
+              match self.process_script_chunk(chunk, i) {
+                ScriptChunk::Closed(close_index) => i = close_index,
+                ScriptChunk::Carry(from) => {
+                  // Carry the raw script tail (from the partial close tag, or
+                  // nothing when fully consumed) into the next chunk.
+                  run_start = from;
+                  carry = true;
+                  break;
+                }
+              }
             }
           }
         } else {
-          // Include full tag from '<' for re-parsing in next chunk
-          text_buffer.push_str(&chunk[i..]);
+          // Incomplete opening tag: re-parse from '<' in the next chunk.
+          carry = true;
           break;
         }
       }
     }
 
-    // If text_buffer is empty (common for non-streaming), save allocation for reuse
-    if text_buffer.is_empty() {
+    // Carry the chunk's unfinished tail (incomplete tag/entity, or text a later
+    // chunk may extend) RAW from `run_start`, never the decoded+escaped
+    // `text_buffer`; re-processing re-derives it so nothing is double-applied.
+    // Otherwise reuse the allocation (the common non-streaming case).
+    if carry || !text_buffer.is_empty() {
+      let leftover = chunk[run_start..].to_string();
+      text_buffer.clear();
       self.parse_text_buffer = text_buffer;
-      String::new()
-    } else {
-      if text_buffer
-        .as_bytes()
-        .first()
-        .is_some_and(|&c| is_whitespace(c))
-      {
+      if leftover.as_bytes().first().is_some_and(|&c| is_whitespace(c)) {
         self.last_char_was_whitespace = false;
       }
-      text_buffer
+      leftover
+    } else {
+      self.parse_text_buffer = text_buffer;
+      String::new()
     }
   }
 
@@ -1139,6 +1172,4 @@ pub(crate) struct OpeningTagResult {
 pub(crate) struct CloseTagResult {
   complete: bool,
   new_position: usize,
-  /// Start offset into html_chunk for remaining text (only meaningful when !complete)
-  remaining_start: usize,
 }

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -1056,14 +1056,25 @@ impl ConvertState {
 
   pub fn get_markdown_chunk(&mut self) -> String {
     let buf_len = self.buffer.len();
-    // A trailing whitespace-bearing text node may still be trimmed when a
-    // closing inline tag arrives in a later chunk. Hold that mutable suffix back.
-    let mut stable_end =
-      if self.last_text_node_contains_whitespace && self.depth_map[TAG_PRE as usize] == 0 {
-        self.buffer.trim_end_matches(' ').len()
-      } else {
-        buf_len
-      };
+    // Trailing spaces at the buffer end are never final outside <pre>: a later
+    // block close (or a dropped empty element followed by a block) trims them,
+    // and an inline close arriving next chunk can trim a text node's trailing
+    // space. Yielding them would let that later trim silently remove an
+    // already-sent byte and shift every byte after it. Always hold them back;
+    // they are re-yielded once real content follows, or dropped at finalize.
+    let mut stable_end = self.buffer.trim_end_matches(' ').len();
+    if stable_end < buf_len && self.depth_map[TAG_PRE as usize] != 0 {
+      // Inside <pre> trailing spaces are usually significant code, so yield
+      // them. The exception is a line-leading run (preceded by a newline): a
+      // list continuation indent is emitted right after the closing fence, and
+      // before the next sibling is known, while <pre>'s depth is still set.
+      // That indent is speculative (the next <li> rewrites it to its marker),
+      // so hold it back like any other trailing whitespace.
+      let line_leading = stable_end == 0 || self.buffer.as_bytes()[stable_end - 1] == b'\n';
+      if !line_leading {
+        stable_end = buf_len;
+      }
+    }
     let leading = if self.preserve_leading_whitespace || self.has_streamed_output {
       0
     } else {
@@ -1071,8 +1082,21 @@ impl ConvertState {
     };
     // An open inline marker may still be dropped if its element closes empty in a later chunk;
     // hold the buffer at the earliest such marker so already-yielded output is never rewritten.
+    // The spaces immediately before it belong to the preceding text node: if the marker is
+    // dropped (empty element) and a block boundary then trims that trailing space, a yielded
+    // space would be silently removed and shift every later byte. Hold those spaces back too.
     if let Some(&(_, p, _)) = self.open_markers.first() {
-      stable_end = stable_end.min(p);
+      stable_end = stable_end.min(self.buffer[..p].trim_end_matches(' ').len());
+    }
+    // An open `<a>`'s close can rewrite the buffer back to `link_bracket_pos`
+    // (emptyLinkText drop, selfLinkHeadings, redundantLinks, GFM autolink). Hold the
+    // yield boundary there so a link that turns out empty never leaks a stray `[`.
+    // As with inline markers, the spaces just before the `[` belong to the
+    // preceding text: an empty-link drop followed by a block close trims them,
+    // so hold them back too or a yielded space would be silently removed.
+    // Mirrors the same guard in `drain_streamed_prefix`.
+    if self.depth_map[TAG_A as usize] > 0 {
+      stable_end = stable_end.min(self.buffer[..self.link_bracket_pos].trim_end_matches(' ').len());
     }
     // `last_yielded_length` is an absolute buffer offset (see drain below).
     let mut start = self.last_yielded_length.max(leading);
@@ -1130,11 +1154,24 @@ impl ConvertState {
       retained_tail_start -= 1;
     }
     let mut drain_end = self.last_yielded_length.min(retained_tail_start);
+    // An empty link or inline marker closing in a later chunk truncates the
+    // buffer back to its reach-back point (`link_bracket_pos` / `output_start`).
+    // The next block then counts its leading newlines from the two bytes ending
+    // there (see `write_output`, which inspects only the last two), so keep
+    // those two bytes; otherwise a dropped element leaks an extra newline in
+    // streaming.
+    let keep_two_before = |buf: &str, at: usize| {
+      let mut i = at.saturating_sub(2);
+      while i > 0 && !buf.is_char_boundary(i) {
+        i -= 1;
+      }
+      i
+    };
     if self.depth_map[TAG_A as usize] > 0 {
-      drain_end = drain_end.min(self.link_bracket_pos);
+      drain_end = drain_end.min(keep_two_before(&self.buffer, self.link_bracket_pos));
     }
     if let Some(&(_, output_start, _)) = self.open_markers.first() {
-      drain_end = drain_end.min(output_start);
+      drain_end = drain_end.min(keep_two_before(&self.buffer, output_start));
     }
     if drain_end == 0 {
       return;

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -1168,7 +1168,6 @@ impl ConvertState {
       return CloseTagResult {
         complete: false,
         new_position: position,
-        remaining_start: position,
       };
     }
 
@@ -1210,7 +1209,6 @@ impl ConvertState {
       return CloseTagResult {
         complete: false,
         new_position: position,
-        remaining_start: position,
       };
     }
 
@@ -1269,7 +1267,6 @@ impl ConvertState {
     CloseTagResult {
       complete: true,
       new_position: i + 1,
-      remaining_start: 0,
     }
   }
 

--- a/crates/core/src/scan.rs
+++ b/crates/core/src/scan.rs
@@ -19,8 +19,6 @@ pub(crate) fn is_whitespace(c: u8) -> bool {
 pub(crate) struct CommentResult {
   pub(crate) complete: bool,
   pub(crate) new_position: usize,
-  /// Start offset into html_chunk for remaining text (only meaningful when !complete)
-  pub(crate) remaining_start: usize,
 }
 
 pub(crate) fn process_comment_or_doctype(html_chunk: &str, position: usize) -> CommentResult {
@@ -36,7 +34,6 @@ pub(crate) fn process_comment_or_doctype(html_chunk: &str, position: usize) -> C
         return CommentResult {
           complete: true,
           new_position: i,
-          remaining_start: 0,
         };
       }
       i += 1;
@@ -44,7 +41,6 @@ pub(crate) fn process_comment_or_doctype(html_chunk: &str, position: usize) -> C
     CommentResult {
       complete: false,
       new_position: position,
-      remaining_start: position,
     }
   } else {
     i += 2;
@@ -54,7 +50,6 @@ pub(crate) fn process_comment_or_doctype(html_chunk: &str, position: usize) -> C
         return CommentResult {
           complete: true,
           new_position: i,
-          remaining_start: 0,
         };
       }
       i += 1;
@@ -62,7 +57,6 @@ pub(crate) fn process_comment_or_doctype(html_chunk: &str, position: usize) -> C
     CommentResult {
       complete: false,
       new_position: i,
-      remaining_start: position,
     }
   }
 }

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -142,6 +142,31 @@ fn streaming_does_not_re_escape_carried_text() {
   }
 }
 
+// A code block ending a list item dropped the next item's list marker in
+// streaming (`2.` became a plain continuation indent).
+#[test]
+fn streaming_keeps_list_marker_after_code_block() {
+  for html in [
+    "<ol><li>one<pre><code>cmd</code></pre></li><li>two</li></ol>",
+    "<ul><li>one<pre><code>cmd</code></pre></li><li>two</li></ul>",
+    "<ol><li>one<pre><code>a</code></pre></li><li>two</li><li>three</li></ol>",
+  ] {
+    assert_stream_matches(html, HTMLToMarkdownOptions::default());
+  }
+}
+
+// A raw-passthrough element (<summary>) containing a foreign child (<svg>) lost
+// the `<` of its closing tag in streaming (`</summary>` → ` /summary>`).
+#[test]
+fn streaming_keeps_raw_close_tag_after_foreign_child() {
+  for html in [
+    "<summary>text <svg></svg></summary>",
+    "<details><summary>text <svg><polyline points=\"1 2\"></polyline></svg></summary><p>b</p></details>",
+  ] {
+    assert_stream_matches(html, HTMLToMarkdownOptions::default());
+  }
+}
+
 // Script data is dropped from output; a chunk boundary landing inside the
 // script (or across its `</script>` close tag) must still leave the surrounding
 // content identical to one-shot. Guards the script-data carry path, which now
@@ -194,6 +219,36 @@ fn streaming_multibyte_never_panics() {
   for &html in CASES {
     for max_bytes in [1usize, 2, 3, 4, 5, 7, 11] {
       let _ = stream_chars(html, max_bytes, HTMLToMarkdownOptions::default());
+    }
+  }
+}
+
+// An empty link or inline marker that closes in a later chunk is truncated
+// away; the drain must keep the two bytes of block spacing before its
+// reach-back point so the next block counts newlines correctly. Without it the
+// close leaked a stray `[` and, once that was held back, an extra blank line.
+#[test]
+fn streaming_dropped_empty_element_keeps_block_spacing() {
+  let cases = [
+    r##"<h3>Set priority</h3><a class="anchor-link" href="#x"></a><p>The value.</p>"##,
+    r#"<h2>Section</h2><a href="/x"><svg></svg></a><p>Body text.</p>"#,
+    "<p>First para.</p><em></em><p>Second para.</p>",
+    // A heading in a list item trailed by an empty anchor-link icon: the space
+    // before the dropped `[` leaked, then the following block trimmed it.
+    r##"<ul><li><h3>NetSparkle</h3><a class="anchor-link" href="#x"><span><svg></svg></span></a></li></ul><p>Copyright.</p>"##,
+  ];
+  let opts = HTMLToMarkdownOptions {
+    clean: Some(safe_clean()),
+    ..Default::default()
+  };
+  for html in cases {
+    let expected = html_to_markdown(html, opts.clone());
+    for chunk in 1..=32 {
+      assert_eq!(
+        stream_chunks(html, chunk, opts.clone()).trim(),
+        expected.trim(),
+        "mismatch: chunk={chunk} html={html:?}"
+      );
     }
   }
 }

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -155,6 +155,18 @@ fn streaming_keeps_list_marker_after_code_block() {
   }
 }
 
+#[test]
+fn streaming_keeps_closing_fence_after_cleaned_empty_link_in_pre() {
+  let opts = HTMLToMarkdownOptions {
+    clean: Some(safe_clean()),
+    ..Default::default()
+  };
+  assert_stream_matches(
+    r#"<pre><code>b c<em></em><a href="/x"><svg></svg></a></code></pre>"#,
+    opts,
+  );
+}
+
 // A raw-passthrough element (<summary>) containing a foreign child (<svg>) lost
 // the `<` of its closing tag in streaming (`</summary>` → ` /summary>`).
 #[test]

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -114,6 +114,50 @@ fn streamed_output_matches_one_shot() {
   }
 }
 
+// Streaming must equal one-shot for these parse-layer cases (drain-transparent).
+// Each asserts across chunk sizes so a boundary landing anywhere is covered.
+fn assert_stream_matches(html: &str, opts: HTMLToMarkdownOptions) {
+  let expected = html_to_markdown(html, opts.clone());
+  for chunk in 1..=html.len().max(1) {
+    assert_eq!(
+      stream_chunks(html, chunk, opts.clone()).trim(),
+      expected.trim(),
+      "mismatch: chunk={chunk} html={html:?}"
+    );
+  }
+}
+
+// A chunk boundary inside an escape context (code/pre/table/link) returned the
+// already-escaped text as the unparsed remainder, so it was re-escaped on the
+// next chunk and backslashes multiplied (`\\`` → `\\\\``…).
+#[test]
+fn streaming_does_not_re_escape_carried_text() {
+  for html in [
+    "<pre><code>const x = `hi ${y}`;</code></pre>",
+    "<p>use <code>a`b</code> here</p>",
+    "<table><tr><td>a`b</td><td>c\\d</td></tr></table>",
+    r#"<p>text with <a href="/x">a [bracket] link</a> end</p>"#,
+  ] {
+    assert_stream_matches(html, HTMLToMarkdownOptions::default());
+  }
+}
+
+// Script data is dropped from output; a chunk boundary landing inside the
+// script (or across its `</script>` close tag) must still leave the surrounding
+// content identical to one-shot. Guards the script-data carry path, which now
+// carries only the unconsumed tail instead of re-feeding consumed script bytes.
+#[test]
+fn streaming_drops_script_without_disturbing_neighbors() {
+  for html in [
+    "<p>before</p><script>var x = 1; if (a < b) { y(); }</script><p>after</p>",
+    "<script>a()</script><script>b()</script><p>ok</p>",
+    r#"<p>x</p><script>let s = "</scr" + "ipt>end";</script><p>y</p>"#,
+    "<p>one</p><script>\n  line1\n  line2\n</script><p>two</p>",
+  ] {
+    assert_stream_matches(html, HTMLToMarkdownOptions::default());
+  }
+}
+
 // Regression: the streaming buffer was sliced/drained on raw byte offsets that
 // could land mid-codepoint, panicking on non-ASCII input.
 #[test]


### PR DESCRIPTION
# Fix streaming output diverging from one-shot conversion

Several inputs produced different Markdown when converted incrementally
(many small `process_chunk` calls) than when converted in a single
`html_to_markdown` call. Each is a genuine bug where a chunk boundary
landing at a specific spot changed the output.

All fixes are **drain-transparent** — the streaming buffer's drain
(memory reclamation) still produces identical bytes whether it runs or
not, which the existing drain-equivalence test verifies. Each fix ships
with a regression test that asserts `streaming == one-shot` across every
chunk size.

## Commit 1 — don't re-escape text carried across a chunk boundary

When a chunk boundary fell inside an escape context (inline code, `<pre>`,
a table cell, or a link), `process_html` returned the already
decoded-and-escaped `text_buffer` as the "unparsed remainder". The next
chunk re-processed it and escaped it again, so backslashes multiplied:

```
input split mid-run:  <code>a`b</code>
expected:             `` a`b ``    (one-shot)
got (streamed):       a\`b -> a\\`b -> a\\\\`b ...
```

The fix tracks the raw start of the current run and carries the *raw*
chunk tail to the next chunk instead of the escaped buffer; re-processing
re-derives the same text so nothing is escaped twice. This also removes
the now-dead `remaining_start` fields on `CloseTagResult` and
`CommentResult`.

## Commit 2 — hold speculative trailing whitespace until a later chunk can't rewrite it

The streamed chunker could emit bytes that a later chunk then rewrote:

- A text node's trailing space was emitted, then trimmed by a following
  block close — silently removing an already-sent byte and shifting every
  byte after it. Symptoms: a raw-passthrough close tag losing its leading
  `<` (`</summary>` -> ` /summary>`) after an empty/foreign child, and
  collapsed block spacing after a heading trailed by an empty link inside
  a list item.
- A list continuation indent emitted right after a closing code fence was
  emitted before the next sibling was known, so the next item's marker was
  lost (`2.` became a plain continuation indent).
- A cleaned empty link at the end of `<pre>` left a speculative separator space in
  streamed output, moving the closing fence onto the code line.

`get_markdown_chunk` now never yields a trailing run of spaces outside
`<pre>` (with an exception for line-leading indents inside `<pre>`, which
are still speculative), and holds the spaces immediately before an open
inline marker or an open link's `[` — both reach-back points that a later
empty-close can truncate. `drain_streamed_prefix` keeps the two bytes of
block spacing before each reach-back point so the next block still counts
its leading newlines correctly.

## Testing

- `cargo test -p mdream` — all green.
- New regression tests: `streaming_does_not_re_escape_carried_text`,
  `streaming_keeps_list_marker_after_code_block`,
  `streaming_keeps_raw_close_tag_after_foreign_child`, and a list-item
  heading case added to `streaming_dropped_empty_element_keeps_block_spacing`.
- `streaming_keeps_closing_fence_after_cleaned_empty_link_in_pre` covers
  cleaned empty links at the end of `<pre>`.
- The drain-equivalence test (`drain_is_byte_transparent`) confirms every
  change is drain-transparent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming HTML-to-Markdown conversion for inputs split across chunk boundaries, including correct handling of unfinished tags and entity fragments.
  * Prevented incorrect re-escaping and preserved formatting/whitespace near `pre`, tables, inline markers, links, and code blocks.
  * Fixed raw-element passthrough behavior to preserve closing tags, and improved script boundary handling to avoid output loss or corruption.
* **Tests**
  * Added streaming regression tests that compare chunked output to one-shot conversion across a wide range of chunk sizes, covering tricky boundary cases and whitespace stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->