### PR TITLE
fix(core): two streaming divergences (raw-HTML block close, trailing nbsp)

### DIFF
--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -1076,6 +1076,15 @@ impl ConvertState {
         stable_end = buf_len;
       }
     }
+    // In a raw-HTML block (`<dl>`/`<dt>`/`<dd>`, `<details>`/`<summary>`,
+    // `<address>`) the next block close is a literal tag glued onto its
+    // predecessor, trimming the block-spacing newline before it (`</dd>\n</dl>`
+    // → `</dd></dl>`). A yielded newline can't be un-sent, so hold trailing
+    // newlines here too; they stay in the buffer for newline counting and are
+    // re-yielded once content (or a non-gluing close) follows.
+    if self.in_raw_html_block() && self.depth_map[TAG_PRE as usize] == 0 {
+      stable_end = stable_end.min(self.buffer.trim_end_matches(['\n', ' ']).len());
+    }
     let leading = if self.preserve_leading_whitespace || self.has_streamed_output {
       0
     } else {

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -801,7 +801,7 @@ impl ConvertState {
   }
 
   #[inline]
-  fn in_raw_html_block(&self) -> bool {
+  pub(crate) fn in_raw_html_block(&self) -> bool {
     self.depth_map[TAG_DETAILS as usize] > 0
       || self.depth_map[TAG_SUMMARY as usize] > 0
       || self.depth_map[TAG_ADDRESS as usize] > 0

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -1597,7 +1597,11 @@ impl ConvertState {
           let start = buf_len.saturating_sub(cache_len);
           if cache_len <= buf_len && self.buffer.is_char_boundary(start) {
             let frag = &self.buffer[start..];
-            let trimmed_len = frag.trim_end().len();
+            // Trim only ASCII whitespace, not `str::trim_end`'s full Unicode
+            // set: a trailing U+00A0 (`&nbsp;`) is meaningful content, and once
+            // streaming has yielded it the truncation can't un-send its bytes,
+            // so the reach-back would drop the next text's leading char.
+            let trimmed_len = frag.trim_end_matches(|c: char| c.is_ascii_whitespace()).len();
             if trimmed_len < cache_len {
               self.buffer.truncate(start + trimmed_len);
               if !is_enter && is_inline {

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -362,6 +362,31 @@ fn streaming_memory_is_bounded_not_document_sized() {
   );
 }
 
+// A text node ending in `&nbsp;` (U+00A0) before a sibling inline was trimmed
+// at the element boundary by `str::trim_end` (nbsp is Unicode whitespace). In
+// streaming the nbsp was already yielded, so the truncation shifted the reach-
+// back and dropped the next element's leading char (`2013, 09:53` →
+// `2013,\u{a0}9:53`, losing the `0`). Trailing nbsp is now kept.
+#[test]
+fn streaming_keeps_trailing_nbsp_before_sibling() {
+  let cases: &[&str] = &[
+    r#"<p>answered on <span>03 Apr 2013,&nbsp;</span><span>09:53 AM</span></p>"#,
+    r#"<p><span>a b,&nbsp;</span><span>0</span></p>"#,
+  ];
+  let opts = HTMLToMarkdownOptions {
+    clean: Some(safe_clean()),
+    ..Default::default()
+  };
+  for html in cases {
+    let expected = html_to_markdown(html, opts.clone());
+    assert!(expected.contains('\u{a0}'), "nbsp should be preserved: {expected:?}");
+    for chunk in 1..=html.len().max(1) {
+      let got = stream_chunks(html, chunk, opts.clone());
+      assert_eq!(got.trim(), expected.trim(), "chunk={chunk} html={html:?}");
+    }
+  }
+}
+
 // A raw-HTML block (`<dl>`/`<dt>`/`<dd>`, `<details>`, `<address>`) closes with
 // a literal tag glued onto its predecessor, trimming the block-spacing newline
 // before it (`</dd>\n</dl>` → `</dd></dl>`). Once the buffer drains past that

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -361,3 +361,34 @@ fn streaming_memory_is_bounded_not_document_sized() {
     "peak {peak} should be a bounded window, not ~{total_out} output"
   );
 }
+
+// A raw-HTML block (`<dl>`/`<dt>`/`<dd>`, `<details>`, `<address>`) closes with
+// a literal tag glued onto its predecessor, trimming the block-spacing newline
+// before it (`</dd>\n</dl>` → `</dd></dl>`). Once the buffer drains past that
+// newline it was already yielded and can't be un-sent, so the trim shifted the
+// close tag and dropped the `<` of `</dl>`. Needs enough preceding content to
+// force a drain before the final close.
+#[test]
+fn streaming_keeps_raw_block_close_after_drain() {
+  let mut html = String::from("<article>");
+  for i in 0..400 {
+    html.push_str(&format!("<p>Filler paragraph number {i} with some words.</p>"));
+  }
+  html.push_str(
+    "<dl><dt>MPN:</dt><dd>D100-V36-PBO-1WZ</dd>\
+     <dt>Availability:</dt><dd>Ships in 2-3 days</dd></dl></article>",
+  );
+  let opts = HTMLToMarkdownOptions {
+    clean: Some(safe_clean()),
+    ..Default::default()
+  };
+  let expected = html_to_markdown(&html, opts.clone());
+  assert!(expected.contains("</dl>"));
+  for chunk in [1usize, 7, 16, 31, 32, 33, 64, 128, 256, 512] {
+    assert_eq!(
+      stream_chunks(&html, chunk, opts.clone()).trim(),
+      expected.trim(),
+      "mismatch: chunk={chunk}"
+    );
+  }
+}


### PR DESCRIPTION
Two independent streaming≠one-shot fixes. Both share the same root: streaming must not retro-trim bytes it has already yielded in an earlier chunk.

### 1. Raw-HTML block close loses its `<`
In a raw-HTML block (`<dl>`/`<dt>`/`<dd>`, `<details>`/`<summary>`, `<address>`) the next block close is a literal tag glued onto its predecessor, trimming the block-spacing newline before it (`</dd>\n</dl>` → `</dd></dl>`). If that newline was already yielded in an earlier chunk, the trim shifts the close tag and drops its `<`. Fix: hold trailing newlines back while inside such a block (outside `<pre>`), mirroring the existing trailing-space hold.

### 2. Trailing `&nbsp;` truncated at an element boundary
A text node ending in U+00A0 before a sibling inline was trimmed via `str::trim_end`, which treats nbsp as whitespace. Once yielded, the truncation can't be un-sent, so the reach-back dropped the next element's leading char (`2013, 09:53` → `2013,\u{a0}9:53`, losing the `0`). Fix: trim only ASCII whitespace there; a trailing nbsp is meaningful content.

### Tests
- Each fix has a regression test (in `crates/core/tests/streaming_drain.rs`) that fails pre-fix and passes post-fix, asserting streaming output matches one-shot at every chunk boundary.
- Full crate suite and the existing drain-transparency test pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved non-ASCII whitespace, such as non-breaking spaces, during streaming conversion.
  * Fixed streamed output near raw HTML block closing tags to prevent missing characters.
  * Improved consistency between streamed and one-shot conversion results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->