### PR TITLE
fix(js): align streaming boundaries with Rust core

### DIFF
--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -375,6 +375,31 @@ function hasNonWhitespace(value: string): boolean {
   return false
 }
 
+function trimAsciiWhitespaceEnd(value: string): string {
+  let end = value.length
+  while (end > 0) {
+    const code = value.charCodeAt(end - 1)
+    if (code !== 32 && (code < 9 || code > 13))
+      break
+    end--
+  }
+  return end === value.length ? value : value.slice(0, end)
+}
+
+function fragmentPosition(buffer: string[], fragment: number): number {
+  let position = 0
+  for (let i = 0; i < fragment; i++)
+    position += buffer[i]!.length
+  return position
+}
+
+function trimSpacePosition(content: string, position: number): number {
+  let end = Math.max(0, position)
+  while (end > 0 && content.charCodeAt(end - 1) === 32)
+    end--
+  return end
+}
+
 /** Drop the top marker when every following fragment is whitespace. */
 function dropEmptyMarker(buffer: string[], packed: number, markerType: number): number {
   const idx = packed >> 3
@@ -460,6 +485,7 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
   // Open inline-marker enter positions, packed as (buffer fragment index << 3 | kind).
   const openMarkers: number[] = []
   let openMarkerCount = 0
+  let openLinkFragment = -1
 
   let lastYieldedLength = 0
   let hasYieldedContent = false
@@ -774,7 +800,7 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
 
           if (shouldTrim) {
             const originalLength = lastFragment.length
-            const trimmed = lastFragment.trimEnd()
+            const trimmed = trimAsciiWhitespaceEnd(lastFragment)
             const trimmedChars = originalLength - trimmed.length
 
             // Update the last content in buffer regions with trimmed content
@@ -808,6 +834,9 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
       }
     }
 
+    if (eventType === NodeEventEnter && element.tagId === TAG_A && handlerOutput === '[' && buff.at(-1) === '[')
+      openLinkFragment = buff.length - 1
+
     // Track open inline markers for empty pair detection. Inline code in a
     // list may own a leading separator (" `"), so retain the whole output
     // fragment as the drop boundary.
@@ -823,6 +852,9 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
       // markers permanent, allowing streaming to release buffered content.
       openMarkerCount = 0
     }
+
+    if (eventType === NodeEventExit && element.tagId === TAG_A)
+      openLinkFragment = -1
 
     updateListIndent(state, element, eventType)
   }
@@ -866,30 +898,36 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
     const currentContent = hasYieldedContent || (state.plainText && preserveLeadingWhitespace)
       ? content
       : content.trimStart()
-    const hasMutableTrailingSpace = state.lastTextNode?.containsWhitespace
-      && !state.depthMap[TAG_PRE]
-      && currentContent.endsWith(' ')
-
     let stableLength = currentContent.length
-    if (hasMutableTrailingSpace) {
-      while (stableLength > 0 && currentContent[stableLength - 1] === ' ')
-        stableLength--
+    while (stableLength > 0 && currentContent.charCodeAt(stableLength - 1) === 32)
+      stableLength--
+
+    if (stableLength < currentContent.length && state.depthMap[TAG_PRE]) {
+      const lineLeading = stableLength === 0 || currentContent.charCodeAt(stableLength - 1) === 10
+      if (!lineLeading && !state.lastTextNode?.containsWhitespace)
+        stableLength = currentContent.length
     }
+    const hasMutableTrailingSpace = stableLength < currentContent.length
+
+    const leadingTrimmed = content.length - currentContent.length
 
     // An open inline marker may still be dropped if its element closes empty in a later chunk;
     // hold the buffer at the earliest such marker so already-yielded output is never rewritten.
     const markerHeld = openMarkerCount > 0
     if (markerHeld) {
       const openFragment = openMarkers[0]! >> 3
-      let markerPos = 0
-      for (let i = 0; i < openFragment; i++)
-        markerPos += state.buffer[i]!.length
-      // markerPos was recorded pre-trim; shift it into currentContent space.
-      markerPos -= content.length - currentContent.length
-      if (markerPos < lastYieldedLength)
-        markerPos = lastYieldedLength
+      const markerPos = Math.max(lastYieldedLength, trimSpacePosition(currentContent, fragmentPosition(state.buffer, openFragment) - leadingTrimmed))
       if (markerPos < stableLength)
         stableLength = markerPos
+    }
+
+    // An open link can rewrite its opening bracket and all link text when it
+    // closes as a GFM autolink. Hold that region until the close is final.
+    const linkHeld = openLinkFragment >= 0
+    if (linkHeld) {
+      const linkPos = Math.max(lastYieldedLength, trimSpacePosition(currentContent, fragmentPosition(state.buffer, openLinkFragment) - leadingTrimmed))
+      if (linkPos < stableLength)
+        stableLength = linkPos
     }
 
     const newContent = currentContent.slice(lastYieldedLength, stableLength)
@@ -902,7 +940,7 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
     // from joining and slicing the entire cumulative output. Plugin, wrapping,
     // and open-link paths retain the full buffer because they can inspect or
     // rewrite earlier content.
-    if (!markerHeld && !hasMutableTrailingSpace) {
+    if (!markerHeld && !linkHeld && !hasMutableTrailingSpace) {
       if (!resolvedPlugins.length && !options.wrapWidth && !state.depthMap[TAG_A]) {
         const tailStart = Math.max(0, stableLength - 2)
         const emittedTail = currentContent.slice(tailStart, stableLength)

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -769,9 +769,6 @@ function parseHtmlInternal(
   }
 
   while (i < chunkLength && !state.depthLimitReached) {
-    if (textBuffer.length === 0)
-      runStart = i
-
     const currentCharCode = htmlChunk.charCodeAt(i)
 
     // If not starting a tag, add to text buffer and continue
@@ -792,6 +789,8 @@ function parseHtmlInternal(
 
         // Skip if last character was whitespace and we're not in a pre tag
         if (!inPreTag && state.lastCharWasWhitespace) {
+          if (textBuffer.length === 0)
+            runStart = i + 1
           i++
           continue
         }
@@ -868,6 +867,7 @@ function parseHtmlInternal(
           }
           processCdataSection(htmlChunk.substring(i + 9, end), state, handleEvent)
           i = end + 3
+          runStart = i
           continue
         }
         if (chunkLength - i < 9 && '<![CDATA['.startsWith(htmlChunk.substring(i))) {
@@ -887,6 +887,7 @@ function parseHtmlInternal(
       const result = processCommentOrDoctype(htmlChunk, i)
       if (result.complete) {
         i = result.newPosition
+        runStart = i
       }
       else {
         textBuffer += result.remainingText
@@ -922,6 +923,7 @@ function parseHtmlInternal(
       const result = processClosingTag(htmlChunk, i, state, handleEvent)
       if (result.complete) {
         i = result.newPosition
+        runStart = i
       }
       else {
         textBuffer += result.remainingText
@@ -979,6 +981,7 @@ function parseHtmlInternal(
 
       if (result.skip) {
         i = result.newPosition
+        runStart = i
       }
       else if (result.complete) {
         i = result.newPosition
@@ -1000,6 +1003,8 @@ function parseHtmlInternal(
             i = scanResult
           }
         }
+        if (textBuffer.length === 0)
+          runStart = i
       }
       else {
         textBuffer += result.remainingText

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -745,6 +745,10 @@ function parseHtmlInternal(
     return ''
 
   let textBuffer = '' // Buffer to accumulate text content
+  // Raw start of the run held in textBuffer. Streaming must carry the source
+  // bytes from here, since textBuffer may already contain decoded or escaped
+  // Markdown that would be transformed again on the next chunk.
+  let runStart = 0
 
   // Initialize state
   state.depthMap ??= new Uint8Array(MAX_TAG_ID)
@@ -765,6 +769,9 @@ function parseHtmlInternal(
   }
 
   while (i < chunkLength && !state.depthLimitReached) {
+    if (textBuffer.length === 0)
+      runStart = i
+
     const currentCharCode = htmlChunk.charCodeAt(i)
 
     // If not starting a tag, add to text buffer and continue
@@ -857,6 +864,7 @@ function parseHtmlInternal(
           if (textBuffer.length > 0) {
             processTextBuffer(textBuffer, state, handleEvent)
             textBuffer = ''
+            runStart = i
           }
           processCdataSection(htmlChunk.substring(i + 9, end), state, handleEvent)
           i = end + 3
@@ -873,6 +881,7 @@ function parseHtmlInternal(
       if (textBuffer.length > 0) {
         processTextBuffer(textBuffer, state, handleEvent)
         textBuffer = ''
+        runStart = i
       }
 
       const result = processCommentOrDoctype(htmlChunk, i)
@@ -907,6 +916,7 @@ function parseHtmlInternal(
       if (textBuffer.length > 0) {
         processTextBuffer(textBuffer, state, handleEvent)
         textBuffer = ''
+        runStart = i
       }
 
       const result = processClosingTag(htmlChunk, i, state, handleEvent)
@@ -962,6 +972,7 @@ function parseHtmlInternal(
       if (textBuffer.length > 0) {
         processTextBuffer(textBuffer, state, handleEvent)
         textBuffer = ''
+        runStart = i
       }
 
       const result = processOpeningTag(tagName, tagId, htmlChunk, i2, state, handleEvent)
@@ -976,9 +987,13 @@ function parseHtmlInternal(
           if (tagId === TAG_SCRIPT && tagName === 'script') {
             const scanResult = scanScriptChunk(htmlChunk, i, state)
             if (scanResult < 0) {
-              textBuffer = scanResult <= SCRIPT_SEQUENCE_INCOMPLETE
-                ? htmlChunk.substring(-scanResult - 2)
-                : ''
+              if (scanResult <= SCRIPT_SEQUENCE_INCOMPLETE) {
+                runStart = -scanResult - 2
+                textBuffer = htmlChunk.substring(runStart)
+              }
+              else {
+                textBuffer = ''
+              }
               break
             }
             textBuffer = takeScriptText(state)
@@ -993,13 +1008,15 @@ function parseHtmlInternal(
     }
   }
 
-  // Trailing text is returned and re-scanned with the next stream chunk. A
-  // leading whitespace character in that buffer was accepted from a
+  // Trailing text is returned raw and re-scanned with the next stream chunk.
+  // Returning textBuffer would reprocess decoded and escaped Markdown. A
+  // leading whitespace character in the raw remainder was accepted from a
   // non-whitespace state, so restore that state before the re-scan.
-  if (textBuffer.length > 0 && isWhitespace(textBuffer.charCodeAt(0)))
+  const remainingHtml = textBuffer.length > 0 ? htmlChunk.substring(runStart) : ''
+  if (remainingHtml.length > 0 && isWhitespace(remainingHtml.charCodeAt(0)))
     state.lastCharWasWhitespace = false
 
-  return textBuffer
+  return remainingHtml
 }
 
 /**

--- a/packages/js/test/unit/streaming-parity.test.ts
+++ b/packages/js/test/unit/streaming-parity.test.ts
@@ -1,0 +1,88 @@
+import type { MdreamOptions } from '../../src/types'
+import { describe, expect, it } from 'vitest'
+import { htmlToMarkdown, streamHtmlToMarkdown } from '../../src/index'
+
+async function streamConvert(html: string, chunkSize: number, options: Partial<MdreamOptions> = {}): Promise<string> {
+  const stream = new ReadableStream<string>({
+    start(controller) {
+      for (let index = 0; index < html.length; index += chunkSize)
+        controller.enqueue(html.slice(index, index + chunkSize))
+      controller.close()
+    },
+  })
+  let output = ''
+  for await (const chunk of streamHtmlToMarkdown(stream, options))
+    output += chunk
+  return output
+}
+
+async function expectStreamingParity(html: string, options: Partial<MdreamOptions> = {}): Promise<void> {
+  const expected = htmlToMarkdown(html, options)
+  const wholeStream = await streamConvert(html, html.length || 1, options)
+  expect(wholeStream.trimEnd(), 'whole stream differs from one shot').toBe(expected)
+
+  for (let chunkSize = 1; chunkSize <= html.length; chunkSize++) {
+    expect(await streamConvert(html, chunkSize, options), `chunk size ${chunkSize}`)
+      .toBe(wholeStream)
+  }
+}
+
+describe('streaming parity with the Rust core', () => {
+  it.each([
+    '<pre><code>const x = `hi $' + '{y}`;</code></pre>',
+    '<p>use <code>a`b</code> here</p>',
+    '<table><tr><td>a`b</td><td>c\\d</td></tr></table>',
+    '<p>text with <a href="/x">a [bracket] link</a> end</p>',
+  ])('does not reprocess escaped text for %s', async (html) => {
+    await expectStreamingParity(html)
+  })
+
+  it.each([
+    '<ol><li>one<pre><code>cmd</code></pre></li><li>two</li></ol>',
+    '<ul><li>one<pre><code>cmd</code></pre></li><li>two</li></ul>',
+    '<ol><li>one<pre><code>a</code></pre></li><li>two</li><li>three</li></ol>',
+  ])('keeps list markers after fenced code for %s', async (html) => {
+    await expectStreamingParity(html)
+  })
+
+  it.each([
+    '<summary>text <svg></svg></summary>',
+    '<details><summary>text <svg><polyline points="1 2"></polyline></svg></summary><p>b</p></details>',
+  ])('keeps raw closing tags after foreign children for %s', async (html) => {
+    await expectStreamingParity(html)
+  })
+
+  it.each([
+    '<h3>Set priority</h3><a class="anchor-link" href="#x"></a><p>The value.</p>',
+    '<h2>Section</h2><a href="/x"><svg></svg></a><p>Body text.</p>',
+    '<p>First para.</p><em></em><p>Second para.</p>',
+    '<ul><li><h3>NetSparkle</h3><a class="anchor-link" href="#x"><span><svg></svg></span></a></li></ul><p>Copyright.</p>',
+  ])('keeps block spacing around empty inline elements for %s', async (html) => {
+    await expectStreamingParity(html)
+  })
+
+  it('does not emit link syntax before an autolink rewrite is final', async () => {
+    await expectStreamingParity('<a href="https://example.com">https://example.com</a>')
+  })
+
+  it.each([
+    '<dl><dt>MPN:</dt><dd>D100</dd><dt>Availability:</dt><dd>Ships</dd></dl>',
+    '<details><summary>Title</summary><p>Body</p></details>',
+    '<address><p>One</p><p>Two</p></address>',
+  ])('keeps raw HTML block closes stable for %s', async (html) => {
+    await expectStreamingParity(html)
+  })
+
+  it.each([
+    '<p>before</p><script>var x = 1; if (a < b) { y(); }</script><p>after</p>',
+    '<script>a()</script><script>b()</script><p>ok</p>',
+    '<p>x</p><script>let s = "</scr" + "ipt>end";</script><p>y</p>',
+    '<p>one</p><script>\n  line1\n  line2\n</script><p>two</p>',
+  ])('drops script data without disturbing its neighbors for %s', async (html) => {
+    await expectStreamingParity(html)
+  })
+
+  it('keeps a meaningful non breaking space before an inline sibling', async () => {
+    await expectStreamingParity('<p>answered on <span>03 Apr 2013,&nbsp;</span><span>09:53 AM</span></p>')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Related to #157

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

#157 fixed Rust streaming when chunks split escaped text or output was rewritten after emission. This ports raw carry and stable output guards to `@mdream/js`, including autolinks, fenced list indentation, raw tag closes, and trailing non-breaking spaces.

Regression tests compare every chunk size byte for byte with a whole stream, then verify the content against one-shot conversion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming HTML-to-Markdown output stability, especially around links, autolinks, whitespace handling, and inline element boundaries.
  * Preserved correct parsing boundaries across chunks for scripts and raw HTML, reducing unexpected chunk-to-chunk differences.

* **Tests**
  * Added streaming vs. one-shot parity tests that feed input in many chunk sizes and verify identical concatenated output across multiple HTML scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->