### PR TITLE
feat: fall back to image sources in text output

### DIFF
--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -1443,12 +1443,26 @@ impl ConvertState {
         }
       }
       TAG_IMG => {
-        let alt = node.attributes.get("alt").map_or("", String::as_str);
-        if alt.is_empty() {
-          None
-        } else {
-          Some(Cow::Owned(alt.to_string()))
+        if let Some(alt) = node.attributes.get("alt") {
+          return if alt.is_empty() {
+            None
+          } else {
+            Some(Cow::Owned(alt.clone()))
+          };
         }
+
+        if let Some(title) = node
+          .attributes
+          .get("title")
+          .filter(|title| !title.is_empty())
+        {
+          return Some(Cow::Owned(title.clone()));
+        }
+
+        let src = node.attributes.get("src").filter(|src| !src.is_empty())?;
+        Some(Cow::Owned(
+          resolve_url(src, self.options.origin.as_deref(), self.options.clean_urls).into_owned(),
+        ))
       }
       TAG_Q => Some(Cow::Borrowed("\"")),
       _ => None,

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -22,6 +22,16 @@ fn convert_text(html: &str) -> String {
   html_to_text(html, HTMLToMarkdownOptions::default())
 }
 
+fn convert_text_with_origin(html: &str, origin: &str) -> String {
+  html_to_text(
+    html,
+    HTMLToMarkdownOptions {
+      origin: Some(origin.to_string()),
+      ..Default::default()
+    },
+  )
+}
+
 // ── Plain text output ──
 
 #[test]
@@ -42,6 +52,28 @@ fn plain_text_output_preserves_readable_separators() {
     ),
     "Line\nBreak\n\nName\tRole\nAda\tAdmin\n\nDiagram"
   );
+}
+
+#[test]
+fn plain_text_images_fall_back_to_title_then_src() {
+  assert_eq!(
+    convert_text(r#"<img src="image.png" alt="Alt" title="Title">"#),
+    "Alt"
+  );
+  assert_eq!(
+    convert_text(r#"<img src="image.png" title="Title">"#),
+    "Title"
+  );
+  assert_eq!(convert_text(r#"<img src="image.png">"#), "image.png");
+  assert_eq!(
+    convert_text_with_origin(r#"<img src="/image.png">"#, "https://example.com"),
+    "https://example.com/image.png"
+  );
+  assert_eq!(
+    convert_text(r#"<img src="image.png" alt="" title="Title">"#),
+    ""
+  );
+  assert_eq!(convert_text("<img>"), "");
 }
 
 #[test]

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -40,6 +40,7 @@ import {
 } from './const'
 import { finalizeParse, parseHtmlStream } from './parse'
 import { processPluginsForEvent } from './plugin-processor'
+import { resolveUrl } from './tags'
 import { continuationPrefix } from './utils'
 
 export interface MarkdownState {
@@ -463,8 +464,12 @@ function getPlainTextOutput(node: ElementNode, eventType: number, state: Markdow
     }
     if (tagId === TAG_TD || tagId === TAG_TH)
       return (depthMap[TAG_TABLE] || 0) > 1 || node.index === 0 ? '' : '\t'
-    if (tagId === TAG_IMG)
-      return node.attributes?.alt || undefined
+    if (tagId === TAG_IMG) {
+      const alt = node.attributes?.alt
+      if (alt !== undefined)
+        return alt || undefined
+      return node.attributes?.title || resolveUrl(node.attributes?.src || '', state.options?.origin) || undefined
+    }
     if (tagId === TAG_Q)
       return '"'
     return undefined

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -121,7 +121,7 @@ import {
 import { continuationPrefix } from './utils'
 
 // Helper function to resolve URLs
-function resolveUrl(url: string, origin?: string): string {
+export function resolveUrl(url: string, origin?: string): string {
   if (!url)
     return url
 

--- a/packages/mdream/test/unit/plain-text.test.ts
+++ b/packages/mdream/test/unit/plain-text.test.ts
@@ -25,6 +25,23 @@ describe.each(engines)('plain text output $name', (engineConfig) => {
     expect(text).toBe('Line\nBreak\n\nName\tRole\nAda\tAdmin\n\nDiagram')
   })
 
+  it('falls back from image alt text to title and src', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+
+    expect(htmlToMarkdown('<img src="image.png" alt="Alt" title="Title">', { engine, format: 'text' }))
+      .toBe('Alt')
+    expect(htmlToMarkdown('<img src="image.png" title="Title">', { engine, format: 'text' }))
+      .toBe('Title')
+    expect(htmlToMarkdown('<img src="image.png">', { engine, format: 'text' }))
+      .toBe('image.png')
+    expect(htmlToMarkdown('<img src="/image.png">', { engine, format: 'text', origin: 'https://example.com' }))
+      .toBe('https://example.com/image.png')
+    expect(htmlToMarkdown('<img src="image.png" alt="" title="Title">', { engine, format: 'text' }))
+      .toBe('')
+    expect(htmlToMarkdown('<img>', { engine, format: 'text' }))
+      .toBe('')
+  })
+
   it('matches streaming output', async () => {
     const engine = await resolveEngine(engineConfig.engine)
     const html = '<h2>Title</h2><p>A <code>code</code> sample with <a href="/docs">docs</a>.</p>'


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #154

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Text output omitted `<img>` elements without `alt`. Rust and JavaScript now emit `title` when present, otherwise the resolved `src`; explicit `alt=""` remains silent. Tests cover both engines, origin resolution, and missing attributes.