### PR TITLE
fix: keep a literal < with its surrounding spacing intact

### DIFF
--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -901,7 +901,11 @@ impl ConvertState {
         i2 = tag_name_end;
 
         if tag_name_raw.is_empty() {
+          // `<` followed by whitespace or `>` is not a tag: treat as literal text
           text_buffer.push(bytes[i] as char);
+          self.text_buffer_contains_non_whitespace = true;
+          self.last_char_was_whitespace = false;
+          self.just_closed_tag = false;
           i += 1;
           continue;
         }

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -967,6 +967,10 @@ function parseHtmlInternal(
       }
 
       if (!tagName) {
+        // `<` followed by whitespace or `>` is not a tag: treat as literal text
+        state.textBufferContainsNonWhitespace = true
+        state.lastCharWasWhitespace = false
+        state.justClosedTag = false
         textBuffer += htmlChunk[i++]
         continue
       }

--- a/packages/mdream/test/unit/nodes/html-to-markdown-parity.test.ts
+++ b/packages/mdream/test/unit/nodes/html-to-markdown-parity.test.ts
@@ -101,4 +101,11 @@ describe.each(engines)('html-to-markdown parity $name', (engineConfig) => {
     expect(htmlToMarkdown(`<p>- List Item</p>`, { engine })).toBe('\- List Item')
     expect(htmlToMarkdown(`<p>Just a - dash<p>`, { engine })).toBe('Just a - dash')
   })
+  it('raw <: keeps a literal < with its surrounding spacing intact.', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    expect(htmlToMarkdown(`<p>a < b</p>`, { engine })).toBe('a < b')
+    expect(htmlToMarkdown(`<p>4 < 5</p>`, { engine })).toBe('4 < 5')
+    expect(htmlToMarkdown(`<p>x < y < z</p>`, { engine })).toBe('x < y < z')
+    expect(htmlToMarkdown(`<p>a <> b</p>`, { engine })).toBe('a <> b')
+  })
 })


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A literal `<` followed by whitespace loses the space after it:

| HTML | before | after |
| --- | --- | --- |
| `<p>a < b</p>` | `a <b` | `a < b` |
| `<p>4 < 5</p>` | `4 <5` | `4 < 5` |
| `<p>x < y < z</p>` | `x <y <z` | `x < y < z` |
| `<p>a <> b</p>` | `a <b` | `a <> b` |

When `<` is followed by whitespace or `>`, the tag-name scan yields an empty name and the parser emits `<` as literal text. That fallback skipped the whitespace-tracking reset every other literal-character path performs, so `last_char_was_whitespace` stayed `true` and the following space collapsed against the one before the `<`.

### Changes 

Resets the whitespace-tracking state in the empty-tag fallback, matching the sibling literal-`<` path a few lines up. Mirrored in `crates/core/src/convert/mod.rs` (native + wasm) and `packages/js/src/parse.ts`, with a cross-engine regression test. The tag-name cases (`<p>x <y z</p>`) are left as-is — a browser also reads `<y z…>` as a start tag, so that is genuine HTML ambiguity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of literal `<` characters when they do not begin valid HTML tags.
  * Preserved surrounding whitespace and inline formatting in affected HTML-to-Markdown conversions.
  * Improved support for expressions containing `<>` so they are not incorrectly interpreted or escaped.

* **Tests**
  * Added coverage for raw `<` characters and spacing across multiple conversion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->