### PR TITLE
fix: serialize decoded text for output context

### DIFF
--- a/crates/core/src/consts.rs
+++ b/crates/core/src/consts.rs
@@ -265,9 +265,6 @@ pub const TAB_CHAR: u8 = 9; // '\t'
 pub const NEWLINE_CHAR: u8 = 10; // '\n'
 pub const CARRIAGE_RETURN_CHAR: u8 = 13; // '\r'
 pub const BACKTICK_CHAR: u8 = 96; // '`'
-pub const PIPE_CHAR: u8 = 124; // '|'
-pub const OPEN_BRACKET_CHAR: u8 = 91; // '['
-pub const CLOSE_BRACKET_CHAR: u8 = 93; // ']'
 
 /// Longest built-in HTML tag name (`blockquote`, `figcaption`); also the size
 /// of the stack buffer used for the case-insensitive lookup.

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -23,11 +23,6 @@ pub(crate) struct TrackedExtraction {
   pub(crate) attributes: Vec<(String, String)>,
 }
 
-// Escape context bitmask flags
-const ESC_TABLE: u8 = 1;
-const ESC_LINK: u8 = 4;
-const ESC_BLOCKQUOTE: u8 = 8;
-
 #[inline(always)]
 fn is_inline_gfm_hazard(byte: u8) -> bool {
   const LOW: u64 = (1 << b'*') | (1 << b'<');
@@ -270,7 +265,6 @@ pub struct ConvertState {
   is_first_text_in_element: bool,
   in_non_nesting: bool,
   script_data_state: u8,
-  escape_ctx: u8,
   in_pre: bool,
   depth_limit_reached: bool,
   /// Filter: depth of the shallowest currently-open visually-hidden element, or
@@ -427,7 +421,6 @@ impl ConvertState {
       is_first_text_in_element: false,
       in_non_nesting: false,
       script_data_state: SCRIPT_DATA,
-      escape_ctx: 0,
       in_pre: false,
       depth_limit_reached: false,
       hidden_since_depth: None,
@@ -657,12 +650,11 @@ impl ConvertState {
 
       if cc != LT_CHAR {
         // FAST PATH: batch contiguous plain ASCII text (>32, <128, not & or <)
-        // Skip when: in escape context, non-nesting mode, or pre tag
+        // Skip when: non-nesting mode or pre tag
         if cc > 32
           && cc < 0x80
           && cc != AMPERSAND_CHAR
           && !is_inline_gfm_hazard(cc)
-          && self.escape_ctx == 0
           && !self.in_non_nesting
           && !self.in_pre
         {
@@ -733,28 +725,11 @@ impl ConvertState {
           self.last_char_was_whitespace = false;
           self.just_closed_tag = false;
 
-          if self.escape_ctx == 0 {
-            if cc < 0x80 {
-              text_buffer.push(cc as char);
-            } else {
-              if let Some(ch) = chunk[i..].chars().next() {
-                text_buffer.push(ch);
-                i += ch.len_utf8();
-              } else {
-                i += 1;
-              }
-
-              continue;
-            }
-          } else if cc == PIPE_CHAR && (self.escape_ctx & ESC_TABLE) != 0 {
-            text_buffer.push_str("\\|");
-          } else if cc == OPEN_BRACKET_CHAR && (self.escape_ctx & ESC_LINK) != 0 {
-            text_buffer.push_str("\\[");
-          } else if cc == CLOSE_BRACKET_CHAR && (self.escape_ctx & ESC_LINK) != 0 {
-            text_buffer.push_str("\\]");
-          } else if cc == GT_CHAR && (self.escape_ctx & ESC_BLOCKQUOTE) != 0 {
-            text_buffer.push_str("\\>");
-          } else if cc < 0x80 {
+          // Structural GFM escaping (|, [, ], > in table/link/blockquote
+          // context) is applied at output time in escape_gfm_text, which also
+          // covers characters produced by decoded entities that never pass
+          // through this parse loop.
+          if cc < 0x80 {
             text_buffer.push(cc as char);
           } else if let Some(ch) = chunk[i..].chars().next() {
             text_buffer.push(ch);

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -534,7 +534,7 @@ impl ConvertState {
       });
     }
 
-    if !enter_is_literal && tag_id == Some(TAG_CODE) {
+    if !enter_is_literal && tag_id == Some(TAG_CODE) && !self.in_raw_html_block() {
       if self.depth_map[TAG_PRE as usize] == 0 {
         if let Some(emitted) = output.as_deref() {
           self.code_spans.push(CodeSpanState {
@@ -573,7 +573,7 @@ impl ConvertState {
 
     if !enter_is_literal
       && let Some(id) = tag_id
-      && (id != TAG_CODE || self.depth_map[TAG_PRE as usize] == 0)
+      && (id != TAG_CODE || (self.depth_map[TAG_PRE as usize] == 0 && !self.in_raw_html_block()))
       && let Some(inline_marker_type) = Self::inline_marker_type(id)
       && let Some(emitted) = output.as_deref()
       && !emitted.is_empty()
@@ -685,12 +685,15 @@ impl ConvertState {
         output = self.get_exit_output(node);
       }
     }
-    let closing_code_span =
-      if !has_override && tag_id == Some(TAG_CODE) && self.depth_map[TAG_PRE as usize] == 0 {
-        self.code_spans.pop()
-      } else {
-        None
-      };
+    let closing_code_span = if !has_override
+      && tag_id == Some(TAG_CODE)
+      && self.depth_map[TAG_PRE as usize] == 0
+      && !self.in_raw_html_block()
+    {
+      self.code_spans.pop()
+    } else {
+      None
+    };
 
     let node_spacing = if let Some(ov) = override_config {
       ov.spacing.or(node.spacing)
@@ -890,7 +893,7 @@ impl ConvertState {
     // Empty pair: only the enter marker was written, so drop it instead of emitting a close.
     if !has_override
       && let Some(id) = tag_id
-      && (id != TAG_CODE || self.depth_map[TAG_PRE as usize] == 0)
+      && (id != TAG_CODE || (self.depth_map[TAG_PRE as usize] == 0 && !self.in_raw_html_block()))
       && let Some(inline_marker_type) = Self::inline_marker_type(id)
       && output.as_deref().is_some_and(|emitted| !emitted.is_empty())
       && let Some((open_type, output_start, content_start)) = self.open_markers.pop()
@@ -1142,12 +1145,34 @@ impl ConvertState {
       text
     };
 
+    let inside_raw_html_block = self.in_raw_html_block();
+    let raw_html_storage;
+    let text = if !self.plain_text && self.depth_map[TAG_PRE as usize] == 0 && inside_raw_html_block
+    {
+      raw_html_storage = self.escape_raw_html_text(text);
+      raw_html_storage.as_ref()
+    } else {
+      text
+    };
+
+    let has_contextual_escape = self.depth_map[TAG_TABLE as usize] > 0
+      || self.depth_map[TAG_A as usize] > 0
+      || self.depth_map[TAG_BLOCKQUOTE as usize] > 0;
+    let context_has_gfm_hazard = !inside_raw_html_block
+      && has_contextual_escape
+      && text.bytes().any(|byte| {
+        (byte == b'|' && self.depth_map[TAG_TABLE as usize] > 0)
+          || (byte == b']' && self.depth_map[TAG_A as usize] > 0)
+          || (byte == b'>' && self.depth_map[TAG_BLOCKQUOTE as usize] > 0)
+      });
     let escaped_storage;
     let text = if !self.plain_text
       && self.depth_map[TAG_PRE as usize] == 0
       && self.depth_map[TAG_CODE as usize] == 0
-      && !self.in_raw_html_block()
-      && (has_inline_gfm_hazard || self.starts_with_gfm_block_candidate(text))
+      && !inside_raw_html_block
+      && (has_inline_gfm_hazard
+        || context_has_gfm_hazard
+        || self.starts_with_gfm_block_candidate(text))
     {
       #[cfg(test)]
       {
@@ -1200,6 +1225,9 @@ impl ConvertState {
   /// markers are written elsewhere and never pass through this path.
   #[inline]
   fn escape_gfm_text<'a>(&self, text: &'a str) -> Cow<'a, str> {
+    let in_table = self.depth_map[TAG_TABLE as usize] > 0;
+    let in_link = self.depth_map[TAG_A as usize] > 0;
+    let in_blockquote = self.depth_map[TAG_BLOCKQUOTE as usize] > 0;
     let mut line_indent = self.markdown_line_indent();
     let mut ordered_digits = 0u8;
     let bytes = text.as_bytes();
@@ -1210,11 +1238,12 @@ impl ConvertState {
     while index < bytes.len() {
       let byte = bytes[index];
 
+      // A `\&` guarding a decoded entity reference is emitted by the entity
+      // decoder; preserve the pair verbatim so this pass never doubles the slash.
       if byte == b'\\'
-        && bytes.get(index + 1).is_some_and(|&next| {
-          self.is_parser_protected_escape(next)
-            || (next == b'&' && Self::is_entity_reference_after_ampersand(&bytes[index + 1..]))
-        })
+        && bytes
+          .get(index + 1)
+          .is_some_and(|&next| next == b'&' && Self::is_entity_reference_after_ampersand(&bytes[index + 1..]))
       {
         line_indent = None;
         ordered_digits = 0;
@@ -1222,7 +1251,19 @@ impl ConvertState {
         continue;
       }
 
+      if in_table && matches!(byte, b'\n' | b'\r') {
+        let out = output.get_or_insert_with(|| String::with_capacity(text.len() + 8));
+        out.push_str(&text[copied_until..index]);
+        out.push_str(if byte == b'\n' { "&#10;" } else { "&#13;" });
+        copied_until = index + 1;
+        index += 1;
+        continue;
+      }
+
       let mut should_escape = matches!(byte, b'\\' | b'*' | b'_' | b'~' | b'`' | b'[')
+        || (byte == b']' && in_link)
+        || (byte == b'|' && in_table)
+        || (byte == b'>' && in_blockquote)
         || (byte == b'<'
           && bytes
             .get(index + 1)
@@ -1318,13 +1359,6 @@ impl ConvertState {
   }
 
   #[inline]
-  fn is_parser_protected_escape(&self, next: u8) -> bool {
-    (next == b'|' && self.depth_map[TAG_TABLE as usize] > 0)
-      || ((next == b'[' || next == b']') && self.depth_map[TAG_A as usize] > 0)
-      || (next == b'>' && self.depth_map[TAG_BLOCKQUOTE as usize] > 0)
-  }
-
-  #[inline]
   fn is_entity_reference_after_ampersand(value: &[u8]) -> bool {
     let mut index = 1usize;
     if value.get(index) == Some(&b'#') {
@@ -1397,9 +1431,9 @@ impl ConvertState {
 
   /// Prepare `<pre>` content for raw-HTML emission inside a GFM table cell
   /// (issue #147): fold literal line breaks into `<br>` so the value stays on
-  /// one row, and HTML-escape `&`, `<`, `>` so decoded source (e.g. `<script>`)
-  /// is not evaluated as live HTML. Leading and trailing breaks are dropped; a
-  /// `\r\n` pair counts as one break.
+  /// one row, encode `|`, and HTML-escape `&`, `<`, `>` so decoded source (e.g.
+  /// `<script>`) is not evaluated as live HTML. Leading and trailing breaks are
+  /// dropped; a `\r\n` pair counts as one break.
   fn fold_pre_lines_to_br(value: &str) -> String {
     let bytes = value.as_bytes();
     let mut start = 0usize;
@@ -1428,11 +1462,51 @@ impl ConvertState {
         out.push_str("&lt;");
       } else if c == '>' {
         out.push_str("&gt;");
+      } else if c == '|' {
+        out.push_str("&#124;");
       } else {
         out.push(c);
       }
     }
     out
+  }
+
+  fn escape_raw_html_text<'a>(&self, value: &'a str) -> Cow<'a, str> {
+    let in_table = self.depth_map[TAG_TABLE as usize] > 0;
+    let in_link = self.depth_map[TAG_A as usize] > 0;
+    let mut output: Option<String> = None;
+    let mut copied_until = 0usize;
+
+    let bytes = value.as_bytes();
+    let mut index = 0usize;
+    while index < bytes.len() {
+      let byte = bytes[index];
+      let replacement = match byte {
+        b'&' => Some("&amp;"),
+        b'<' => Some("&lt;"),
+        b'>' => Some("&gt;"),
+        b'\n' => Some("&#10;"),
+        b'\r' => Some("&#13;"),
+        b'|' if in_table => Some("&#124;"),
+        b'[' if in_link => Some("&#91;"),
+        b']' if in_link => Some("&#93;"),
+        _ => None,
+      };
+      if let Some(replacement) = replacement {
+        let out = output.get_or_insert_with(|| String::with_capacity(value.len() + 8));
+        out.push_str(&value[copied_until..index]);
+        out.push_str(replacement);
+        copied_until = index + 1;
+      }
+      index += 1;
+    }
+
+    if let Some(mut output) = output {
+      output.push_str(&value[copied_until..]);
+      Cow::Owned(output)
+    } else {
+      Cow::Borrowed(value)
+    }
   }
 
   #[inline]
@@ -1663,6 +1737,8 @@ impl ConvertState {
             s.push('\n');
             Some(Cow::Owned(s))
           }
+        } else if self.in_raw_html_block() {
+          Some(Cow::Borrowed("<code>"))
         } else if self.depth_map[TAG_LI as usize] > 0 {
           // Inline code inside a list item: collapse the paragraph
           // boundary with a separator space when following text, but
@@ -1879,6 +1955,8 @@ impl ConvertState {
           } else {
             Some(Cow::Borrowed("\n```"))
           }
+        } else if self.in_raw_html_block() {
+          Some(Cow::Borrowed("</code>"))
         } else {
           Some(Cow::Borrowed(MARKDOWN_INLINE_CODE))
         }

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -628,12 +628,8 @@ impl ConvertState {
       if (id as usize) < MAX_TAG_ID {
         self.depth_map[id as usize] = self.depth_map[id as usize].saturating_add(1);
       }
-      match id {
-        TAG_TABLE if !self.plain_text => self.escape_ctx |= ESC_TABLE,
-        TAG_PRE => self.in_pre = true,
-        TAG_A if !self.plain_text => self.escape_ctx |= ESC_LINK,
-        TAG_BLOCKQUOTE if !self.plain_text => self.escape_ctx |= ESC_BLOCKQUOTE,
-        _ => {}
+      if id == TAG_PRE {
+        self.in_pre = true;
       }
     }
     self.depth += 1;
@@ -1087,7 +1083,7 @@ impl ConvertState {
           if (id as usize) < MAX_TAG_ID {
             self.depth_map[id as usize] = self.depth_map[id as usize].saturating_sub(1);
           }
-          self.update_escape_ctx_on_close(id);
+          self.update_in_pre_on_close(id);
           if id == TAG_LI
             && let Some(w) = self.list_indent_widths.pop()
           {
@@ -1117,7 +1113,7 @@ impl ConvertState {
       if (id as usize) < MAX_TAG_ID {
         self.depth_map[id as usize] = self.depth_map[id as usize].saturating_sub(1);
       }
-      self.update_escape_ctx_on_close(id);
+      self.update_in_pre_on_close(id);
       if id == TAG_LI
         && let Some(w) = self.list_indent_widths.pop()
       {
@@ -1332,15 +1328,9 @@ impl ConvertState {
   }
 
   #[inline]
-  pub(crate) fn update_escape_ctx_on_close(&mut self, id: u8) {
-    match id {
-      TAG_TABLE if self.depth_map[id as usize] == 0 => self.escape_ctx &= !ESC_TABLE,
-      TAG_PRE if self.depth_map[TAG_PRE as usize] == 0 => {
-        self.in_pre = false;
-      }
-      TAG_A if self.depth_map[id as usize] == 0 => self.escape_ctx &= !ESC_LINK,
-      TAG_BLOCKQUOTE if self.depth_map[id as usize] == 0 => self.escape_ctx &= !ESC_BLOCKQUOTE,
-      _ => {}
+  pub(crate) fn update_in_pre_on_close(&mut self, id: u8) {
+    if id == TAG_PRE && self.depth_map[TAG_PRE as usize] == 0 {
+      self.in_pre = false;
     }
   }
 }

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -253,6 +253,49 @@ fn gfm_text_escaping_does_not_repeat_context_escapes() {
   );
 }
 
+#[test]
+fn decoded_text_is_serialized_for_its_output_context() {
+  assert_eq!(
+    convert(r#"<a href="/safe">x&#93;(/evil) [y</a>"#),
+    r"[x\](/evil) \[y](/safe)"
+  );
+  assert_eq!(
+    convert("<table><tr><td>a&#124;b</td><td>c&#10;d</td></tr></table>"),
+    "| a\\|b | c&#10;d |\n| --- | --- |"
+  );
+
+  let details = convert("<details><summary>&lt;img src=x onerror=alert(1)&gt;</summary></details>");
+  assert!(
+    details.contains("<summary>&lt;img src=x onerror=alert(1)&gt;</summary>"),
+    "decoded text became active raw HTML: {details}"
+  );
+
+  let raw_code = convert(
+    "<details><summary><code>&lt;img src=x onerror=alert(1)&gt;</code></summary></details>",
+  );
+  assert!(
+    raw_code.contains("<code>&lt;img src=x onerror=alert(1)&gt;</code>"),
+    "decoded code became active raw HTML: {raw_code}"
+  );
+  assert!(
+    convert(r#"<details><a href="/x">a[b]</a></details>"#).contains("[a&#91;b&#93;](/x)"),
+    "parser-added escapes must not become visible raw-HTML text"
+  );
+  assert!(
+    convert(r#"<details><a href="/x">&#92;&#91;</a></details>"#).contains(r"[\&#91;](/x)"),
+    "decoded backslashes must remain visible raw-HTML text"
+  );
+  assert!(
+    convert("<details><table><tr><td><pre>a|b&#124;c</pre></td><td>x</td></tr></table></details>",)
+      .contains("| <pre>a&#124;b&#124;c</pre> | x |"),
+    "raw pre text must not split a GFM table row"
+  );
+  assert_eq!(
+    convert("<table><tr><td><pre>a|b&#124;c</pre></td><td>x</td></tr></table>"),
+    "| <pre>a&#124;b&#124;c</pre> | x |\n| --- | --- |"
+  );
+}
+
 // ── Links ──
 
 #[test]

--- a/packages/js/src/const.ts
+++ b/packages/js/src/const.ts
@@ -246,6 +246,16 @@ export const MARKDOWN_CODE_BLOCK = '```'
 export const MARKDOWN_INLINE_CODE = '`'
 export const MARKDOWN_HORIZONTAL_RULE = '---'
 
+// Raw-HTML blocks whose text/code is emitted verbatim rather than as Markdown.
+export function isInsideRawHtmlBlock(depthMap: Uint8Array): boolean {
+  return Boolean(depthMap[TAG_DETAILS]
+    || depthMap[TAG_SUMMARY]
+    || depthMap[TAG_ADDRESS]
+    || depthMap[TAG_DL]
+    || depthMap[TAG_DT]
+    || depthMap[TAG_DD])
+}
+
 // Newline configurations
 export const NO_SPACING: readonly [number, number] = [0, 0]
 export const DEFAULT_BLOCK_SPACING: readonly [number, number] = [2, 2]

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -3,6 +3,7 @@ import type { ElementNode, EngineOptions, GfmAction, Node, NodeEvent, PluginCont
 import {
   DEFAULT_BLOCK_SPACING,
   ELEMENT_NODE,
+  isInsideRawHtmlBlock,
   MARKDOWN_CODE_BLOCK,
   MARKDOWN_INLINE_CODE,
   MAX_TAG_ID,
@@ -10,19 +11,14 @@ import {
   NodeEventEnter,
   NodeEventExit,
   TAG_A,
-  TAG_ADDRESS,
   TAG_B,
   TAG_BLOCKQUOTE,
   TAG_BR,
   TAG_CITE,
   TAG_CODE,
-  TAG_DD,
   TAG_DEL,
-  TAG_DETAILS,
   TAG_DFN,
   TAG_DIV,
-  TAG_DL,
-  TAG_DT,
   TAG_EM,
   TAG_FIGCAPTION,
   TAG_H1,
@@ -41,7 +37,6 @@ import {
   TAG_SPAN,
   TAG_STRIKE,
   TAG_STRONG,
-  TAG_SUMMARY,
   TAG_TABLE,
   TAG_TD,
   TAG_TH,
@@ -243,9 +238,9 @@ function canWrapHere(depthMap: Uint8Array): boolean {
 /**
  * Prepare `<pre>` content for raw-HTML emission inside a GFM table cell
  * (issue #147): fold literal line breaks into `<br>` so the value stays on one
- * row, and HTML-escape `&`, `<`, `>` so decoded source (e.g. `<script>`) is not
- * evaluated as live HTML by downstream renderers. Leading and trailing breaks
- * are dropped; a `\r\n` pair counts as one break.
+ * row, encode `|`, and HTML-escape `&`, `<`, `>` so decoded source (e.g.
+ * `<script>`) is not evaluated as live HTML by downstream renderers. Leading
+ * and trailing breaks are dropped; a `\r\n` pair counts as one break.
  */
 function foldPreLinesToBr(value: string): string {
   let start = 0
@@ -282,6 +277,9 @@ function foldPreLinesToBr(value: string): string {
     else if (c === 62) {
       out += '&gt;'
     }
+    else if (c === 124) {
+      out += '&#124;'
+    }
     else {
       out += value[i]
     }
@@ -289,13 +287,41 @@ function foldPreLinesToBr(value: string): string {
   return out
 }
 
-function isInsideRawHtmlBlock(depthMap: Uint8Array): boolean {
-  return Boolean(depthMap[TAG_DETAILS]
-    || depthMap[TAG_SUMMARY]
-    || depthMap[TAG_ADDRESS]
-    || depthMap[TAG_DL]
-    || depthMap[TAG_DT]
-    || depthMap[TAG_DD])
+function escapeRawHtmlText(value: string, depthMap: Uint8Array): string {
+  const inTable = Boolean(depthMap[TAG_TABLE])
+  const inLink = Boolean(depthMap[TAG_A])
+  let escaped = ''
+  let copiedUntil = 0
+
+  let index = 0
+  while (index < value.length) {
+    const code = value.charCodeAt(index)
+    let replacement: string | undefined
+    if (code === 38)
+      replacement = '&amp;'
+    else if (code === 60)
+      replacement = '&lt;'
+    else if (code === 62)
+      replacement = '&gt;'
+    else if (code === 10)
+      replacement = '&#10;'
+    else if (code === 13)
+      replacement = '&#13;'
+    else if (inTable && code === 124)
+      replacement = '&#124;'
+    else if (inLink && code === 91)
+      replacement = '&#91;'
+    else if (inLink && code === 93)
+      replacement = '&#93;'
+
+    if (replacement) {
+      escaped += value.slice(copiedUntil, index) + replacement
+      copiedUntil = index + 1
+    }
+    index++
+  }
+
+  return copiedUntil === 0 ? value : escaped + value.slice(copiedUntil)
 }
 
 /**
@@ -349,12 +375,6 @@ function isThematicBreak(value: string, start: number, marker: number): boolean 
   return count >= 3
 }
 
-function isParserProtectedEscape(depthMap: Uint8Array, next: number): boolean {
-  return (next === 124 && Boolean(depthMap[TAG_TABLE])) // |
-    || ((next === 91 || next === 93) && Boolean(depthMap[TAG_A])) // []
-    || (next === 62 && Boolean(depthMap[TAG_BLOCKQUOTE])) // >
-}
-
 function isEntityReferenceAfterAmpersand(value: string, ampersand: number): boolean {
   let index = ampersand + 1
   if (value.charCodeAt(index) === 35) {
@@ -393,9 +413,14 @@ const GFM_TEXT_NATIVE_TRIGGER = /[\\*_~`[<\r\n]/
  * precise JavaScript scanner. A block marker can only begin within the first
  * four characters here; later lines are covered by the newline trigger.
  */
-function mayNeedGfmTextEscape(value: string, buffer: string[]): boolean {
+function mayNeedGfmTextEscape(value: string, buffer: string[], depthMap: Uint8Array): boolean {
   if (value.search(GFM_TEXT_NATIVE_TRIGGER) !== -1)
     return true
+  if ((depthMap[TAG_TABLE] && value.includes('|'))
+    || (depthMap[TAG_A] && value.includes(']'))
+    || (depthMap[TAG_BLOCKQUOTE] && value.includes('>'))) {
+    return true
+  }
 
   let lineIndent = markdownLineIndent(buffer)
   if (lineIndent < 0)
@@ -423,6 +448,9 @@ function mayNeedGfmTextEscape(value: string, buffer: string[]): boolean {
  * The common plain-text path returns the original string without allocation.
  */
 function escapeGfmText(value: string, buffer: string[], depthMap: Uint8Array): string {
+  const inTable = Boolean(depthMap[TAG_TABLE])
+  const inLink = Boolean(depthMap[TAG_A])
+  const inBlockquote = Boolean(depthMap[TAG_BLOCKQUOTE])
   let lineIndent = markdownLineIndent(buffer)
   let orderedDigits = 0
   let copiedUntil = 0
@@ -431,14 +459,20 @@ function escapeGfmText(value: string, buffer: string[], depthMap: Uint8Array): s
   for (let index = 0; index < value.length; index++) {
     const code = value.charCodeAt(index)
 
-    // These escapes were inserted by the parser for structural contexts.
-    // Preserve the pair verbatim so this text pass never doubles the slash.
+    // A `\&` guarding a decoded entity reference is emitted by the entity
+    // decoder; preserve the pair verbatim so this pass never doubles the slash.
     const next = index + 1 < value.length ? value.charCodeAt(index + 1) : 0
-    if (code === 92 && (isParserProtectedEscape(depthMap, next)
-      || (next === 38 && isEntityReferenceAfterAmpersand(value, index + 1)))) {
+    if (code === 92 && next === 38 && isEntityReferenceAfterAmpersand(value, index + 1)) {
       lineIndent = -1
       orderedDigits = 0
       index++
+      continue
+    }
+
+    if (inTable && (code === 10 || code === 13)) {
+      escaped += value.slice(copiedUntil, index)
+      escaped += code === 10 ? '&#10;' : '&#13;'
+      copiedUntil = index + 1
       continue
     }
 
@@ -448,6 +482,9 @@ function escapeGfmText(value: string, buffer: string[], depthMap: Uint8Array): s
       || code === 126 // ~
       || code === 96 // `
       || code === 91 // [
+      || (code === 93 && inLink) // ]
+      || (code === 124 && inTable) // |
+      || (code === 62 && inBlockquote) // >
       || (code === 60 && canStartGfmAngleConstruct(value.charCodeAt(index + 1))) // <
 
     if (!shouldEscape && lineIndent >= 0) {
@@ -997,11 +1034,18 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
         textNode.value = foldPreLinesToBr(textNode.value)
       }
 
+      const insideRawHtmlBlock = isInsideRawHtmlBlock(state.depthMap)
+      if (!state.plainText
+        && !state.depthMap[TAG_PRE]
+        && insideRawHtmlBlock) {
+        textNode.value = escapeRawHtmlText(textNode.value, state.depthMap)
+      }
+
       if (!state.plainText
         && !state.depthMap[TAG_PRE]
         && !state.depthMap[TAG_CODE]
-        && !isInsideRawHtmlBlock(state.depthMap)
-        && mayNeedGfmTextEscape(textNode.value, state.buffer)) {
+        && !insideRawHtmlBlock
+        && mayNeedGfmTextEscape(textNode.value, state.buffer, state.depthMap)) {
         textNode.value = escapeGfmText(textNode.value, state.buffer, state.depthMap)
       }
 
@@ -1193,7 +1237,10 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
     if (eventType === NodeEventExit && openMarkerCount) {
       // Empty pair: only the enter marker was written, so drop it instead of emitting a close.
       const markerType = handlerOutput === undefined ? 0 : INLINE_MARKER_TYPE[element.tagId!]!
-      if (markerType && (element.tagId !== TAG_CODE || !state.depthMap[TAG_PRE]) && !handler?.literalExit) {
+      if (markerType
+        && (element.tagId !== TAG_CODE
+          || (!state.depthMap[TAG_PRE] && !isInsideRawHtmlBlock(state.depthMap)))
+        && !handler?.literalExit) {
         const idx = dropEmptyMarker(buff, openMarkers[--openMarkerCount]!, markerType)
         if (idx >= 0) {
           state.lastContentCache = idx > 0 ? buff[idx - 1] : undefined
@@ -1372,10 +1419,15 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
     // fragment as the drop boundary.
     if (eventType === NodeEventEnter && handlerOutput !== undefined && isInlineElement && !handler?.literalEnter) {
       const markerType = INLINE_MARKER_TYPE[element.tagId!]!
-      if (markerType && (element.tagId !== TAG_CODE || !state.depthMap[TAG_PRE]) && buff[buff.length - 1] === handlerOutput)
+      if (markerType
+        && (element.tagId !== TAG_CODE
+          || (!state.depthMap[TAG_PRE] && !isInsideRawHtmlBlock(state.depthMap)))
+        && buff[buff.length - 1] === handlerOutput) {
         openMarkers[openMarkerCount++] = (buff.length - 1) << 3 | markerType
-      else if (openMarkerCount && hasNonWhitespace(handlerOutput))
+      }
+      else if (openMarkerCount && hasNonWhitespace(handlerOutput)) {
         openMarkerCount = 0
+      }
     }
     else if (openMarkerCount && (handler?.literalExit || (element.tagId !== -1 && !isInlineElement) || output?.some(hasNonWhitespace))) {
       // Literal overrides, plugin output, and block boundaries make all open

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -1,6 +1,7 @@
 import type { ElementNode, Node, NodeEvent, TagHandler, TextNode, TransformPlugin } from './types'
 import {
   ELEMENT_NODE,
+  isInsideRawHtmlBlock,
   MAX_TAG_ID,
   NodeEventEnter,
   NodeEventExit,
@@ -83,21 +84,14 @@ const TAB_CHAR = 9 // '\t'
 const NEWLINE_CHAR = 10 // '\n'
 const FORM_FEED_CHAR = 12 // '\f'
 const CARRIAGE_RETURN_CHAR = 13 // '\r'
-const PIPE_CHAR = 124 // '|'
 const OPEN_BRACKET_CHAR = 91 // '['
-const CLOSE_BRACKET_CHAR = 93 // ']'
 
 function shouldProtectDecodedEntityReferences(state: ParseState): boolean {
   const depthMap = state.depthMap
   return !state.plainText
     && !depthMap[TAG_PRE]
     && !depthMap[TAG_CODE]
-    && !depthMap[TAG_DETAILS]
-    && !depthMap[TAG_SUMMARY]
-    && !depthMap[TAG_ADDRESS]
-    && !depthMap[TAG_DL]
-    && !depthMap[TAG_DT]
-    && !depthMap[TAG_DD]
+    && !isInsideRawHtmlBlock(depthMap)
 }
 
 const SCRIPT_DATA = 0
@@ -823,23 +817,11 @@ function parseHtmlInternal(
         state.textBufferContainsNonWhitespace = true
         state.lastCharWasWhitespace = false
         state.justClosedTag = false
-
-        // Handle special characters that need escaping
-        if (!state.plainText && currentCharCode === PIPE_CHAR && state.depthMap[TAG_TABLE]) {
-          textBuffer += '\\|'
-        }
-        else if (!state.plainText && currentCharCode === OPEN_BRACKET_CHAR && state.depthMap[TAG_A]) {
-          textBuffer += '\\['
-        }
-        else if (!state.plainText && currentCharCode === CLOSE_BRACKET_CHAR && state.depthMap[TAG_A]) {
-          textBuffer += '\\]'
-        }
-        else if (!state.plainText && currentCharCode === GT_CHAR && state.depthMap[TAG_BLOCKQUOTE]) {
-          textBuffer += '\\>'
-        }
-        else {
-          textBuffer += htmlChunk[i]
-        }
+        // Structural GFM escaping (|, [, ], > in table/link/blockquote
+        // context) is applied at output time in escapeGfmText, which also
+        // covers characters produced by decoded entities that never pass
+        // through this parse loop.
+        textBuffer += htmlChunk[i]
       }
       i++
       continue

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -1,6 +1,7 @@
 import type { EngineOptions, HandlerContext, TagHandler, TagOverride } from './types'
 import {
   BLOCKQUOTE_SPACING,
+  isInsideRawHtmlBlock,
   LIST_ITEM_SPACING,
   MARKDOWN_CODE_BLOCK,
   MARKDOWN_EMPHASIS,
@@ -213,21 +214,11 @@ function isInsideTableCell(state: HandlerContext['state']): boolean {
   return depthMap[TAG_TD]! > 0 || depthMap[TAG_TH]! > 0
 }
 
-function isInsideRawHtmlBlock(state: HandlerContext['state']): boolean {
-  const depthMap = state.depthMap!
-  return Boolean(depthMap[TAG_DETAILS]
-    || depthMap[TAG_SUMMARY]
-    || depthMap[TAG_ADDRESS]
-    || depthMap[TAG_DL]
-    || depthMap[TAG_DT]
-    || depthMap[TAG_DD])
-}
-
 export function renderBreak(node: HandlerContext['node'], state: HandlerContext['state']): string {
   // A literal newline would terminate a table row/ATX heading or collapse
   // inside a raw HTML block, so preserve the inline HTML there.
   const depthMap = state.depthMap!
-  if (isInsideTableCell(state) || isInsideRawHtmlBlock(state)
+  if (isInsideTableCell(state) || isInsideRawHtmlBlock(depthMap)
     || depthMap[TAG_H1]
     || depthMap[TAG_H2]
     || depthMap[TAG_H3]
@@ -473,6 +464,9 @@ export const tagHandlers: Record<number, TagHandler> = {
           output: `${MARKDOWN_CODE_BLOCK}${language}\n`,
         }
       }
+      if (isInsideRawHtmlBlock(state.depthMap!)) {
+        return '<code>'
+      }
       // Inline code inside a list item: collapse the paragraph boundary with a
       // separator space when following text, but not when the buffer just
       // emitted a wrapper opener where a leading space would break the
@@ -511,6 +505,9 @@ export const tagHandlers: Record<number, TagHandler> = {
           }
         }
         return { _tag: 'CodeFenceExit', output: `\n${MARKDOWN_CODE_BLOCK}` }
+      }
+      if (isInsideRawHtmlBlock(state.depthMap!)) {
+        return '</code>'
       }
       return { _tag: 'CodeSpanExit' }
     },

--- a/packages/js/test/unit/gfm-text-escaping.test.ts
+++ b/packages/js/test/unit/gfm-text-escaping.test.ts
@@ -108,11 +108,42 @@ describe('gfm text escaping', () => {
       .toBe('| a\\|b |\n| --- |')
   })
 
+  it('serializes decoded text for its output context', () => {
+    expect(htmlToMarkdown('<a href="/safe">x&#93;(/evil) [y</a>'))
+      .toBe('[x\\](/evil) \\[y](/safe)')
+    expect(htmlToMarkdown('<table><tr><td>a&#124;b</td><td>c&#10;d</td></tr></table>'))
+      .toBe('| a\\|b | c&#10;d |\n| --- | --- |')
+
+    const details = htmlToMarkdown('<details><summary>&lt;img src=x onerror=alert(1)&gt;</summary></details>')
+    expect(details).toContain('<summary>&lt;img src=x onerror=alert(1)&gt;</summary>')
+    expect(htmlToMarkdown('<details><summary><code>&lt;img src=x onerror=alert(1)&gt;</code></summary></details>'))
+      .toContain('<code>&lt;img src=x onerror=alert(1)&gt;</code>')
+    expect(htmlToMarkdown('<details><a href="/x">a[b]</a></details>'))
+      .toContain('[a&#91;b&#93;](/x)')
+    expect(htmlToMarkdown('<details><a href="/x">&#92;&#91;</a></details>'))
+      .toContain('[\\&#91;](/x)')
+    expect(htmlToMarkdown('<details><table><tr><td><pre>a|b&#124;c</pre></td><td>x</td></tr></table></details>'))
+      .toContain('| <pre>a&#124;b&#124;c</pre> | x |')
+    expect(htmlToMarkdown('<table><tr><td><pre>a|b&#124;c</pre></td><td>x</td></tr></table>'))
+      .toBe('| <pre>a&#124;b&#124;c</pre> | x |\n| --- | --- |')
+  })
+
   it('matches one-shot output across stream boundaries', async () => {
-    const html = '<p>&#35; heading [label](url) and *bar* ~~baz~~ `qux` &amp;copy;</p><p>> quote</p><p>1. item</p><p>---</p>'
-    const expected = htmlToMarkdown(html)
-    for (let chunkSize = 1; chunkSize <= html.length; chunkSize++)
-      expect(await streamConvert(html, chunkSize), `chunk size ${chunkSize}`).toBe(expected)
+    for (const html of [
+      '<p>&#35; heading [label](url) and *bar* ~~baz~~ `qux` &amp;copy;</p><p>> quote</p><p>1. item</p><p>---</p>',
+      '<a href="/safe">x&#93;(/evil) [y</a>',
+      '<table><tr><td>a&#124;b</td><td>c&#10;d</td></tr></table>',
+      '<details><summary>&lt;img src=x onerror=alert(1)&gt;</summary></details>',
+      '<details><summary><code>&lt;img src=x onerror=alert(1)&gt;</code></summary></details>',
+      '<details><a href="/x">a[b]</a></details>',
+      '<details><a href="/x">&#92;&#91;</a></details>',
+      '<details><table><tr><td><pre>a|b&#124;c</pre></td><td>x</td></tr></table></details>',
+      '<table><tr><td><pre>a|b&#124;c</pre></td><td>x</td></tr></table>',
+    ]) {
+      const expected = htmlToMarkdown(html)
+      for (let chunkSize = 1; chunkSize <= html.length; chunkSize++)
+        expect(await streamConvert(html, chunkSize), `${html}: chunk size ${chunkSize}`).toBe(expected)
+    }
   })
 
   it('widens code delimiters across every stream boundary', async () => {

--- a/packages/mdream/test/unit/nodes/html-to-markdown-parity.test.ts
+++ b/packages/mdream/test/unit/nodes/html-to-markdown-parity.test.ts
@@ -24,6 +24,14 @@ const recentMergeCases: ParityCase[] = [
     html: '<img src="/image.png?utm_source=test&width=10">',
     options: { clean: { urls: true }, format: 'text', origin: 'https://example.com' },
   },
+  { html: '<a href="/safe">x&#93;(/evil) [y</a>' },
+  { html: '<table><tr><td>a&#124;b</td><td>c&#10;d</td></tr></table>' },
+  { html: '<details><summary>&lt;img src=x onerror=alert(1)&gt;</summary></details>' },
+  { html: '<details><summary><code>&lt;img src=x onerror=alert(1)&gt;</code></summary></details>' },
+  { html: '<details><a href="/x">a[b]</a></details>' },
+  { html: '<details><a href="/x">&#92;&#91;</a></details>' },
+  { html: '<details><table><tr><td><pre>a|b&#124;c</pre></td><td>x</td></tr></table></details>' },
+  { html: '<table><tr><td><pre>a|b&#124;c</pre></td><td>x</td></tr></table>' },
 ]
 
 async function streamConvert(engine: TestEngine, { html, options }: ParityCase, chunkSize: number): Promise<string> {


### PR DESCRIPTION
## Problem

Decoded HTML entities (e.g. `&#124;`, `&#93;`, `&lt;`) bypassed the parser's character escaping and reached their output context unescaped, where they acted as live GFM/HTML:

- `&#124;` in a table cell split the row into extra columns
- `&#93;` in link text closed the `[...]` early (enabling `](/evil)` injection)
- `&#62;` in a blockquote acted as a nested quote marker
- `&lt;img onerror=...&gt;` inside `<details>`/`<summary>` became live HTML

The parser escaped raw source characters per-character, but entity decoding happens *after* that pass, so decoded characters were never escaped.

## Fix

Serialize text for the context it is emitted into, at **output time** (the one layer that sees decoded entities):

- tables: escape `|`, encode newlines as `&#10;`/`&#13;`
- links: escape `]`
- blockquotes: escape `>`
- raw-HTML blocks (`<details>`, `<summary>`, `<dl>`…): HTML-escape `&`, `<`, `>`, newlines and context chars, and emit inline code as `<code></code>`

Structural escaping now lives solely in this output escaper. The parallel parser-side escaping and its `escape_ctx` bookkeeping (plus `is_parser_protected_escape`) became redundant and are removed, leaving a **single escaping path** in both the JS and Rust engines. Dropping the `escape_ctx == 0` guard also lets the fast ASCII-batch path run inside table/link/blockquote text.

## Verification

- JS + mdream suites: 1384 passed / 17 skipped, including cross-engine (JS vs Rust NAPI) parity for the new cases at every stream chunk size
- Rust `conversion` tests: 237 passed
- `pnpm typecheck`: clean across all packages
- `cargo clippy`: no new warnings vs. base


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved serialization/escaping of decoded HTML entities so decoded `]`, `\`, `|`, and newlines don’t corrupt Markdown links, tables, or blockquotes.
  - Hardened handling of decoded content inside `&lt;details&gt;/&lt;summary&gt;` and other raw-HTML contexts to prevent unintended active HTML.
  - Preserved correct output for `<code>` elements inside raw-HTML sections.
  - Improved consistency between streamed and one-shot conversions.

- **Tests**
  - Added and expanded regression and parity tests for entity-decoding behavior across links, tables, details/summary, code, and streaming boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->