### PR TITLE
fix: separate sibling blockquotes with a blank line

### DIFF
--- a/crates/core/src/consts.rs
+++ b/crates/core/src/consts.rs
@@ -246,7 +246,7 @@ pub const MARKDOWN_HORIZONTAL_RULE: &str = "---";
 
 pub const NO_SPACING: [u8; 2] = [0, 0];
 pub const DEFAULT_BLOCK_SPACING: [u8; 2] = [2, 2];
-pub const BLOCKQUOTE_SPACING: [u8; 2] = [1, 1];
+pub const BLOCKQUOTE_SPACING: [u8; 2] = [2, 2];
 pub const LIST_ITEM_SPACING: [u8; 2] = [1, 0];
 pub const TABLE_ROW_SPACING: [u8; 2] = [0, 1];
 

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -864,6 +864,44 @@ fn blockquote_keeps_block_children_inside_the_quote() {
   }
 }
 
+#[test]
+fn sibling_blockquotes_separated_by_blank_line() {
+  for (name, html, expected) in [
+    (
+      "single-line siblings",
+      "<blockquote>a</blockquote><blockquote>b</blockquote>",
+      "> a\n\n> b",
+    ),
+    (
+      "paragraph siblings",
+      "<blockquote><p>a</p></blockquote><blockquote><p>b</p></blockquote>",
+      "> a\n\n> b",
+    ),
+    (
+      "nested quote then sibling",
+      "<blockquote><p>Outer</p><blockquote><p>Nested</p></blockquote></blockquote><blockquote><p>After</p></blockquote>",
+      "> Outer\n> > Nested\n\n> After",
+    ),
+    (
+      "siblings with newline whitespace",
+      "<blockquote>a</blockquote>\n<blockquote>b</blockquote>",
+      "> a\n\n> b",
+    ),
+    (
+      "bare-text quote then paragraph-child quote",
+      "<blockquote>A quote.</blockquote>\n<blockquote><p>b</p></blockquote>",
+      "> A quote.\n\n> b",
+    ),
+    (
+      "bare-text quote then heading-child quote",
+      "<blockquote>A quote.</blockquote>\n<blockquote><h2>H</h2></blockquote>",
+      "> A quote.\n\n> ## H",
+    ),
+  ] {
+    assert_eq!(convert(html), expected, "{name}");
+  }
+}
+
 // ── Lists ──
 
 #[test]

--- a/packages/js/src/const.ts
+++ b/packages/js/src/const.ts
@@ -249,6 +249,6 @@ export const MARKDOWN_HORIZONTAL_RULE = '---'
 // Newline configurations
 export const NO_SPACING: readonly [number, number] = [0, 0]
 export const DEFAULT_BLOCK_SPACING: readonly [number, number] = [2, 2]
-export const BLOCKQUOTE_SPACING: readonly [number, number] = [1, 1]
+export const BLOCKQUOTE_SPACING: readonly [number, number] = [2, 2]
 export const LIST_ITEM_SPACING: readonly [number, number] = [1, 0]
 export const TABLE_ROW_SPACING: readonly [number, number] = [0, 1]

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -1320,8 +1320,11 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
           const isBlockElement = !isInlineElement && !collapsesWhiteSpace && configuredNewLines > 0
           // Don't trim before elements that have collapsesInnerWhiteSpace on enter
           // Also don't trim before block elements that have their own spacing configuration
-          const shouldTrim = (element.tagId === TAG_BR && output?.[0]?.endsWith('\n') && !parentInPre)
-            || ((!isInlineElement || eventType === NodeEventExit) && !isBlockElement && !(collapsesWhiteSpace && eventType === NodeEventEnter) && !(hasSpacing && eventType === NodeEventEnter))
+          // At a quote's content start the last fragment is the sibling separator,
+          // not trailing whitespace; trimming it would glue adjacent quotes.
+          const shouldTrim = !quoteAtStart
+            && ((element.tagId === TAG_BR && output?.[0]?.endsWith('\n') && !parentInPre)
+              || ((!isInlineElement || eventType === NodeEventExit) && !isBlockElement && !(collapsesWhiteSpace && eventType === NodeEventEnter) && !(hasSpacing && eventType === NodeEventEnter)))
 
           if (shouldTrim) {
             const originalLength = lastFragment.length

--- a/packages/mdream/test/unit/nodes/blockquote.test.ts
+++ b/packages/mdream/test/unit/nodes/blockquote.test.ts
@@ -109,6 +109,42 @@ describe.each(engines)('blockquotes $name', (engineConfig) => {
     expect(htmlToMarkdown(html, { engine })).toBe(expected)
   })
 
+  it.each([
+    [
+      'single-line siblings',
+      '<blockquote>a</blockquote><blockquote>b</blockquote>',
+      '> a\n\n> b',
+    ],
+    [
+      'paragraph siblings',
+      '<blockquote><p>a</p></blockquote><blockquote><p>b</p></blockquote>',
+      '> a\n\n> b',
+    ],
+    [
+      'nested quote followed by sibling',
+      '<blockquote><p>Outer</p><blockquote><p>Nested</p></blockquote></blockquote><blockquote><p>After</p></blockquote>',
+      '> Outer\n> > Nested\n\n> After',
+    ],
+    [
+      'siblings with newline whitespace',
+      '<blockquote>a</blockquote>\n<blockquote>b</blockquote>',
+      '> a\n\n> b',
+    ],
+    [
+      'bare-text quote then paragraph-child quote',
+      '<blockquote>A quote.</blockquote>\n<blockquote><p>b</p></blockquote>',
+      '> A quote.\n\n> b',
+    ],
+    [
+      'bare-text quote then heading-child quote',
+      '<blockquote>A quote.</blockquote>\n<blockquote><h2>H</h2></blockquote>',
+      '> A quote.\n\n> ## H',
+    ],
+  ])('separates %s with a blank line', async (_name, html, expected) => {
+    const engine = await resolveEngine(engineConfig.engine)
+    expect(htmlToMarkdown(html, { engine })).toBe(expected)
+  })
+
   it('keeps representative quote structure across every stream split', async () => {
     const engine = await resolveEngine(engineConfig.engine)
     const html = '<ul><li><blockquote><ul><li>x</li><li>y</li></ul></blockquote></li></ul>'


### PR DESCRIPTION
Adjacent `>` lines continue a single blockquote in CommonMark. mdream emitted
only a single newline between sibling `<blockquote>` elements, so consecutive
quotes merged into one quote and their paragraphs got soft-joined. Affected
both engines (Rust core and `@mdream/js`).

The JS engine had a second, related bug: when a quote's first child was a block
element without explicit handler spacing (`<p>`, `<div>`, headings), the leading
separator before that quote was trimmed, gluing the preceding sibling quote
directly onto it (e.g. `> A quote.> b`).

Given:

```html
<blockquote>A single-line quote.</blockquote>
<blockquote><p>A quote with a paragraph.</p></blockquote>
```

mdream produced:

> A single-line quote.
> A quote with a paragraph.

which round-trips to a single blockquote with the two
lines fused into one paragraph — not the two distinct quotes the HTML had.
Affected both engines (Rust core and @mdream/js).

## Fix

- `BLOCKQUOTE_SPACING` was `[1, 1]` while every other block uses `[2, 2]`.
  Bumped to `[2, 2]` in the Rust core and the JS engine so siblings get a true
  blank-line separator. Nested quotes are unaffected — the existing
  nested-collapse logic normalizes parent→child gaps to a single newline.
- JS engine: skip the trailing-whitespace trim at a quote's content start, where
  the last fragment is the structural sibling separator rather than content.

Verified via round-trip through `marked`: the 5-sibling fixture now reconstructs
to exactly 7 `<blockquote>` elements (was 3), identical output from both engines.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured adjacent blockquotes don’t merge and are separated by a blank line in rendered Markdown.
  * Updated blockquote spacing consistently across supported implementations.

* **Tests**
  * Added regression/unit coverage for sibling blockquotes, including paragraph and heading children, nested quote cases, and varied whitespace inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->