### PR TITLE
perf(core): speed up attribute and text scanning

### DIFF
--- a/crates/core/src/consts.rs
+++ b/crates/core/src/consts.rs
@@ -237,6 +237,85 @@ pub static TAG_NAMES: [&str; MAX_TAG_ID] = {
 pub const ELEMENT_NODE: u8 = 1;
 pub const TEXT_NODE: u8 = 2;
 
+/// Attribute bitmask: which attribute names a tag's rendering actually reads.
+/// Each stored value costs an owned `String`, the dominant allocation during
+/// parsing, yet a built-in tag reads at most three.
+pub const ATTR_NONE: u16 = 0;
+pub const ATTR_HREF: u16 = 1 << 0;
+pub const ATTR_TITLE: u16 = 1 << 1;
+pub const ATTR_ARIA_LABEL: u16 = 1 << 2;
+pub const ATTR_SRC: u16 = 1 << 3;
+pub const ATTR_ALT: u16 = 1 << 4;
+pub const ATTR_CLASS: u16 = 1 << 5;
+pub const ATTR_ALIGN: u16 = 1 << 6;
+pub const ATTR_NAME: u16 = 1 << 7;
+pub const ATTR_PROPERTY: u16 = 1 << 8;
+pub const ATTR_CONTENT: u16 = 1 << 9;
+pub const ATTR_ALL: u16 = u16::MAX;
+
+/// Case-insensitive, length-first so the common miss costs one compare.
+#[inline]
+pub(crate) fn attr_bit(name: &[u8]) -> u16 {
+  match name.len() {
+    3 => {
+      if name.eq_ignore_ascii_case(b"alt") {
+        ATTR_ALT
+      } else if name.eq_ignore_ascii_case(b"src") {
+        ATTR_SRC
+      } else {
+        ATTR_NONE
+      }
+    }
+    4 => {
+      if name.eq_ignore_ascii_case(b"href") {
+        ATTR_HREF
+      } else if name.eq_ignore_ascii_case(b"name") {
+        ATTR_NAME
+      } else {
+        ATTR_NONE
+      }
+    }
+    5 => {
+      if name.eq_ignore_ascii_case(b"title") {
+        ATTR_TITLE
+      } else if name.eq_ignore_ascii_case(b"class") {
+        ATTR_CLASS
+      } else if name.eq_ignore_ascii_case(b"align") {
+        ATTR_ALIGN
+      } else {
+        ATTR_NONE
+      }
+    }
+    7 => {
+      if name.eq_ignore_ascii_case(b"content") {
+        ATTR_CONTENT
+      } else {
+        ATTR_NONE
+      }
+    }
+    8 => {
+      if name.eq_ignore_ascii_case(b"property") {
+        ATTR_PROPERTY
+      } else {
+        ATTR_NONE
+      }
+    }
+    10 => {
+      if name.eq_ignore_ascii_case(b"aria-label") {
+        ATTR_ARIA_LABEL
+      } else {
+        ATTR_NONE
+      }
+    }
+    _ => ATTR_NONE,
+  }
+}
+
+#[inline]
+pub(crate) fn attr_wanted(mask: u16, name: &[u8]) -> bool {
+  mask == ATTR_ALL || mask & attr_bit(name) != 0
+}
+
 pub const MARKDOWN_STRONG: &str = "**";
 pub const MARKDOWN_EMPHASIS: &str = "*";
 pub const MARKDOWN_STRIKETHROUGH: &str = "~~";

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -23,16 +23,44 @@ pub(crate) struct TrackedExtraction {
   pub(crate) attributes: Vec<(String, String)>,
 }
 
+/// ASCII split point of the hazard bitmap: one `u64` covers bytes 0..63, the
+/// other 64..127.
+const HAZARD_MASK_SPLIT: u8 = 64;
+
+/// Bytes readable as GFM inline markup if emitted unescaped. [`BATCHABLE_TEXT`]
+/// derives from these, so a hazard added here cannot be left batchable.
+const GFM_HAZARD_LOW: u64 = (1 << b'*') | (1 << b'<');
+const GFM_HAZARD_HIGH: u64 = (1 << (b'[' - HAZARD_MASK_SPLIT))
+  | (1 << (b'\\' - HAZARD_MASK_SPLIT))
+  | (1 << (b'_' - HAZARD_MASK_SPLIT))
+  | (1 << (b'`' - HAZARD_MASK_SPLIT))
+  | (1 << (b'~' - HAZARD_MASK_SPLIT));
+
+const BATCHABLE_TEXT: [bool; 256] = {
+  let mut t = [false; 256];
+  let mut c = 33usize;
+  while c < 0x80 {
+    let mask = if c < HAZARD_MASK_SPLIT as usize {
+      GFM_HAZARD_LOW
+    } else {
+      GFM_HAZARD_HIGH
+    };
+    t[c] = (mask >> (c & (HAZARD_MASK_SPLIT as usize - 1))) & 1 == 0;
+    c += 1;
+  }
+  t[AMPERSAND_CHAR as usize] = false;
+  t
+};
+
+/// Callers must range-guard: bytes >= 128 alias into `GFM_HAZARD_HIGH`.
 #[inline(always)]
 fn is_inline_gfm_hazard(byte: u8) -> bool {
-  const LOW: u64 = (1 << b'*') | (1 << b'<');
-  const HIGH: u64 = (1 << (b'[' - 64))
-    | (1 << (b'\\' - 64))
-    | (1 << (b'_' - 64))
-    | (1 << (b'`' - 64))
-    | (1 << (b'~' - 64));
-  let mask = if byte < 64 { LOW } else { HIGH };
-  (mask >> (byte & 63)) & 1 != 0
+  let mask = if byte < HAZARD_MASK_SPLIT {
+    GFM_HAZARD_LOW
+  } else {
+    GFM_HAZARD_HIGH
+  };
+  (mask >> (byte & (HAZARD_MASK_SPLIT - 1))) & 1 != 0
 }
 
 struct CodeSpanState {
@@ -267,10 +295,12 @@ pub struct ConvertState {
   script_data_state: u8,
   in_pre: bool,
   depth_limit_reached: bool,
-  /// Filter: depth of the shallowest currently-open visually-hidden element, or
-  /// None. Lets the parser skip a hidden subtree in O(1) without re-checking
-  /// styles per node, and keeps this state off the public `ElementNode`.
+  /// Shallowest open element that is hidden or matches an exclude selector.
+  /// Both drop their whole subtree, so one marker skips it in O(1).
   hidden_since_depth: Option<usize>,
+  /// Shallowest open element matching an include selector. Only consulted
+  /// when `filter_process_children` is set.
+  filter_included_since_depth: Option<usize>,
   /// Unified collapse depth counter (replaces separate counters in ParseState + MarkdownState)
   collapse_non_span_depth: u8,
   collapse_span_depth: u8,
@@ -424,6 +454,7 @@ impl ConvertState {
       in_pre: false,
       depth_limit_reached: false,
       hidden_since_depth: None,
+      filter_included_since_depth: None,
       collapse_non_span_depth: 0,
       collapse_span_depth: 0,
       first_block_parent_index: None,
@@ -649,31 +680,33 @@ impl ConvertState {
       let cc = bytes[i];
 
       if cc != LT_CHAR {
-        // FAST PATH: batch contiguous plain ASCII text (>32, <128, not & or <)
-        // Skip when: non-nesting mode or pre tag
-        if cc > 32
-          && cc < 0x80
-          && cc != AMPERSAND_CHAR
-          && !is_inline_gfm_hazard(cc)
-          && !self.in_non_nesting
-          && !self.in_pre
-        {
+        // Batch contiguous plain ASCII text, absorbing single inter-word
+        // spaces so prose is copied once per text node, not per word.
+        if BATCHABLE_TEXT[cc as usize] && !self.in_non_nesting && !self.in_pre {
           let start = i;
           i += 1;
-          while i < chunk_length {
-            let c = bytes[i];
-            if c <= 32
-              || c >= 0x80
-              || c == LT_CHAR
-              || c == AMPERSAND_CHAR
-              || is_inline_gfm_hazard(c)
-            {
-              break;
+          let mut had_space = false;
+          loop {
+            while i < chunk_length && BATCHABLE_TEXT[bytes[i] as usize] {
+              i += 1;
             }
-            i += 1;
+            // Doubled, trailing, and pre-tag spaces leave the run to the
+            // general path, which keeps its collapsing semantics.
+            if i + 1 < chunk_length
+              && bytes[i] == SPACE_CHAR
+              && BATCHABLE_TEXT[bytes[i + 1] as usize]
+            {
+              had_space = true;
+              i += 2;
+              continue;
+            }
+            break;
           }
           text_buffer.push_str(&chunk[start..i]);
           self.text_buffer_contains_non_whitespace = true;
+          if had_space {
+            self.text_buffer_contains_whitespace = true;
+          }
           self.last_char_was_whitespace = false;
           self.just_closed_tag = false;
           continue;

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -6,14 +6,18 @@ const DESTINATION_ESCAPES: [u8; 16] = [0, 0, 0, 0, 0, 0, 0, 80, 0, 0, 0, 16, 0, 
 const TITLE_ESCAPES: [u8; 16] = [0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0];
 const IMAGE_DESCRIPTION_ESCAPES: [u8; 16] = [0, 0, 0, 0, 64, 4, 0, 16, 0, 0, 0, 184, 1, 0, 0, 64];
 
+#[inline(always)]
+fn in_byte_set(byte: u8, set: &[u8; 16]) -> bool {
+  byte < 128 && set[(byte >> 3) as usize] & (1 << (byte & 7)) != 0
+}
+
 #[inline(never)]
 fn write_ascii_escaped(output: &mut String, value: &str, escapes: &[u8; 16]) {
   let bytes = value.as_bytes();
   let mut copied = 0usize;
   let mut index = 0usize;
   while index < bytes.len() {
-    let byte = bytes[index];
-    if byte < 128 && escapes[(byte >> 3) as usize] & (1 << (byte & 7)) != 0 {
+    if in_byte_set(bytes[index], escapes) {
       output.push_str(&value[copied..index]);
       output.push('\\');
       copied = index;
@@ -23,15 +27,14 @@ fn write_ascii_escaped(output: &mut String, value: &str, escapes: &[u8; 16]) {
   output.push_str(&value[copied..]);
 }
 
+/// Bytes forcing a destination into angle brackets: tab, LF, FF, CR, space,
+/// `(`, `)`, and every byte of [`DESTINATION_ESCAPES`] (must stay a superset).
+const DESTINATION_NEEDS_ANGLE: [u8; 16] = [0, 54, 0, 0, 1, 3, 0, 80, 0, 0, 0, 16, 0, 0, 0, 0];
+
 fn write_markdown_destination(output: &mut String, destination: &str) {
   let bytes = destination.as_bytes();
   let mut index = 0usize;
-  while index < bytes.len()
-    && !matches!(
-      bytes[index],
-      b'\t' | b'\n' | 0x0C | b'\r' | b' ' | b'(' | b')' | b'\\' | b'<' | b'>'
-    )
-  {
+  while index < bytes.len() && !in_byte_set(bytes[index], &DESTINATION_NEEDS_ANGLE) {
     index += 1;
   }
   if index == bytes.len() {
@@ -509,8 +512,7 @@ impl ConvertState {
       && self.depth_map[TAG_PRE as usize] == 0
       && output.as_deref().is_some_and(|value| value.ends_with('\n'))
     {
-      let trimmed_len = self.buffer.trim_end_matches(' ').len();
-      self.buffer.truncate(trimmed_len);
+      self.trim_trailing_spaces();
       if output.as_deref() == Some("\n") && self.buffer.ends_with("\n\n") {
         output = None;
       }
@@ -783,30 +785,30 @@ impl ConvertState {
       // redundantLinks: [url](url) → url
       if self.clean_flags & CLEAN_REDUNDANT_LINKS != 0
         && let Some(href) = node.attributes.get("href")
-      {
-        let resolved = resolve_url(
+        && let resolved = resolve_url(
           href,
           self.options.origin.as_deref(),
           self.options.clean_urls,
-        );
-        if link_text == resolved.as_ref() && text_len > 0 {
-          // Remove [ and keep text only — use truncate+copy without intermediate String
-          let new_len = bracket_pos + text_len;
-          // SAFETY: same invariants as self-link heading case. Preserves valid UTF-8.
-          #[allow(unsafe_code)]
-          unsafe {
-            let buf = self.buffer.as_mut_vec();
-            std::ptr::copy(
-              buf.as_ptr().add(text_start),
-              buf.as_mut_ptr().add(bracket_pos),
-              text_len,
-            );
-            buf.set_len(new_len);
-          }
-          self.last_content_cache_len = text_len;
-          self.last_node_is_inline = is_inline;
-          return;
+        )
+        && link_text == resolved.as_ref()
+        && text_len > 0
+      {
+        // Remove [ and keep text only — use truncate+copy without intermediate String
+        let new_len = bracket_pos + text_len;
+        // SAFETY: same invariants as self-link heading case. Preserves valid UTF-8.
+        #[allow(unsafe_code)]
+        unsafe {
+          let buf = self.buffer.as_mut_vec();
+          std::ptr::copy(
+            buf.as_ptr().add(text_start),
+            buf.as_mut_ptr().add(bracket_pos),
+            text_len,
+          );
+          buf.set_len(new_len);
         }
+        self.last_content_cache_len = text_len;
+        self.last_node_is_inline = is_inline;
+        return;
       }
     }
 
@@ -834,6 +836,7 @@ impl ConvertState {
           self.options.origin.as_deref(),
           self.options.clean_urls,
         );
+        let resolved = resolved.as_ref();
         let mut title = node.attributes.get("title").map_or("", String::as_str);
         if !title.is_empty() && self.last_content_cache_len > 0 {
           let buf_len = self.buffer.len();
@@ -851,16 +854,16 @@ impl ConvertState {
         // directly at the `[` byte (set in emit_enter_element), so this
         // is an O(1) check. `[` is single-byte UTF-8, so `bp + 1` is
         // always a char boundary once `buf_bytes[bp]` is confirmed `[`.
-        if title.is_empty() && is_autolink_uri(&resolved) {
+        if title.is_empty() && is_autolink_uri(resolved) {
           let bp = self.link_bracket_pos;
           let buf_bytes = self.buffer.as_bytes();
           if bp < buf_bytes.len()
             && buf_bytes[bp] == b'['
-            && &self.buffer[bp + 1..] == resolved.as_ref()
+            && &self.buffer[bp + 1..] == resolved
           {
             self.buffer.truncate(bp);
             self.buffer.push('<');
-            self.buffer.push_str(&resolved);
+            self.buffer.push_str(resolved);
             self.buffer.push('>');
             self.last_content_cache_len = self.buffer.len();
             self.last_node_is_inline = is_inline;
@@ -870,7 +873,7 @@ impl ConvertState {
         self.buffer.push(']');
         write_markdown_resource(
           &mut self.buffer,
-          &resolved,
+          resolved,
           (!title.is_empty()).then_some(title),
         );
         self.last_content_cache_len = self.buffer.len(); // will be recalculated
@@ -973,8 +976,6 @@ impl ConvertState {
     }
   }
 
-  /// Emit markdown for a text node (no TextNode allocation).
-  #[inline]
   /// Emit a bare <pre>'s opening code fence (issue #97). Mirrors the
   /// <code>-in-<pre> enter formatting: indented and newline-padded inside a
   /// list item, otherwise a plain ```lang opener. Marks the <pre> as owning
@@ -1007,6 +1008,8 @@ impl ConvertState {
     self.last_node_is_inline = false;
   }
 
+  /// Emit markdown for a text node (no TextNode allocation).
+  #[inline]
   pub(crate) fn emit_text(
     &mut self,
     text: &str,
@@ -1506,6 +1509,34 @@ impl ConvertState {
       Cow::Owned(output)
     } else {
       Cow::Borrowed(value)
+    }
+  }
+
+  /// Lowest offset a trailing-whitespace trim may cut back to. Open fences,
+  /// code spans, and blockquotes record offsets whose bytes are delimiter, not
+  /// spacing; cutting behind one corrupts the block and leaves `content_start`
+  /// past the buffer end, which panics on finalize.
+  #[inline]
+  fn trim_floor(&self) -> usize {
+    let mut floor = 0usize;
+    if let Some(fence) = &self.code_fence {
+      floor = floor.max(fence.content_start);
+    }
+    if let Some(span) = self.code_spans.last() {
+      floor = floor.max(span.content_start);
+    }
+    if let Some(frame) = self.blockquotes.last() {
+      floor = floor.max(frame.content_start);
+    }
+    floor
+  }
+
+  #[inline]
+  fn trim_trailing_spaces(&mut self) {
+    let floor = self.trim_floor();
+    if self.buffer.len() > floor {
+      let trimmed_len = floor + self.buffer[floor..].trim_end_matches(' ').len();
+      self.buffer.truncate(trimmed_len);
     }
   }
 
@@ -2233,8 +2264,7 @@ impl ConvertState {
       }
 
       if last_char == b' ' && !self.buffer.is_empty() {
-        let trimmed_len = self.buffer.trim_end_matches(' ').len();
-        self.buffer.truncate(trimmed_len);
+        self.trim_trailing_spaces();
         // This source whitespace was consumed by the block boundary; do not
         // let its state leak into a later inline event and trim that output.
         self.last_text_node_contains_whitespace = false;
@@ -2284,8 +2314,9 @@ impl ConvertState {
         if should_trim && self.last_content_cache_len > 0 {
           let cache_len = self.last_content_cache_len;
           let buf_len = self.buffer.len();
-          let start = buf_len.saturating_sub(cache_len);
-          if cache_len <= buf_len && self.buffer.is_char_boundary(start) {
+          // The cached run can include a fence opener (see `trim_floor`).
+          let start = buf_len.saturating_sub(cache_len).max(self.trim_floor());
+          if cache_len <= buf_len && start <= buf_len && self.buffer.is_char_boundary(start) {
             let frag = &self.buffer[start..];
             // Trim only ASCII whitespace, not `str::trim_end`'s full Unicode
             // set: a trailing U+00A0 (`&nbsp;`) is meaningful content, and once
@@ -2294,7 +2325,7 @@ impl ConvertState {
             let trimmed_len = frag
               .trim_end_matches(|c: char| c.is_ascii_whitespace())
               .len();
-            if trimmed_len < cache_len {
+            if start + trimmed_len < buf_len {
               self.buffer.truncate(start + trimmed_len);
               if !is_enter && is_inline {
                 self.pending_inline_whitespace = true;
@@ -2361,7 +2392,11 @@ impl ConvertState {
     if self.last_node_is_inline {
       return false;
     }
-    let first_byte = text.as_bytes()[0];
+    // Malformed attribute quoting can carry a start tag past its `>` and leave
+    // an empty text node behind, so there may be no first byte to inspect.
+    let Some(&first_byte) = text.as_bytes().first() else {
+      return false;
+    };
     if first_byte == b' ' {
       return false;
     }

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -107,105 +107,179 @@ fn needs_implied_end_recovery(tag_id: u8) -> bool {
   (tag_id as usize) < MAX_TAG_ID && NEEDS_IMPLIED_END_RECOVERY[tag_id as usize]
 }
 
+/// Build a tag lookup table. Sized 256 rather than `MAX_TAG_ID` so indexing by
+/// any `u8` is in bounds by construction: no bounds check, no panic path.
+const fn tag_set(ids: &[u8]) -> [bool; 256] {
+  let mut t = [false; 256];
+  let mut i = 0;
+  while i < ids.len() {
+    t[ids[i] as usize] = true;
+    i += 1;
+  }
+  t
+}
+
 /// "Button scope" terminators for closing a `<p>`: scanning up the open stack
 /// stops here so a `<p>` outside a table cell is never closed from inside one.
 /// `UL`/`OL`/`DL`/`LI` are added (a deviation from the bare spec list) to keep
 /// scans short; a `<p>` is always closed before any of these can become its
 /// ancestor, so they never hide a closable `<p>`.
-fn is_p_scope_boundary(tag_id: u8) -> bool {
-  matches!(
-    tag_id,
-    TAG_BUTTON
-      | TAG_TD
-      | TAG_TH
-      | TAG_CAPTION
-      | TAG_TABLE
-      | TAG_TEMPLATE
-      | TAG_HTML
-      | TAG_UL
-      | TAG_OL
-      | TAG_DL
-      | TAG_LI
-  )
-}
+const P_SCOPE_BOUNDARY: [bool; 256] = tag_set(&[
+  TAG_BUTTON,
+  TAG_TD,
+  TAG_TH,
+  TAG_CAPTION,
+  TAG_TABLE,
+  TAG_TEMPLATE,
+  TAG_HTML,
+  TAG_UL,
+  TAG_OL,
+  TAG_DL,
+  TAG_LI,
+]);
 
 /// "List item scope" terminators for closing a `<li>`: a new `<li>` closes the
 /// previous one only within the same list, never across a nested list or table.
-fn is_li_scope_boundary(tag_id: u8) -> bool {
-  matches!(
-    tag_id,
-    TAG_UL | TAG_OL | TAG_TABLE | TAG_TD | TAG_TH | TAG_CAPTION | TAG_TEMPLATE | TAG_HTML
-  )
-}
+const LI_SCOPE_BOUNDARY: [bool; 256] = tag_set(&[
+  TAG_UL,
+  TAG_OL,
+  TAG_TABLE,
+  TAG_TD,
+  TAG_TH,
+  TAG_CAPTION,
+  TAG_TEMPLATE,
+  TAG_HTML,
+]);
 
 /// Scope terminators for closing a `<dt>`/`<dd>`: each closes the other within
 /// the same `<dl>`, never crossing into a nested list or table.
-fn is_dl_scope_boundary(tag_id: u8) -> bool {
-  matches!(
-    tag_id,
-    TAG_DL
-      | TAG_UL
-      | TAG_OL
-      | TAG_LI
-      | TAG_TABLE
-      | TAG_TD
-      | TAG_TH
-      | TAG_CAPTION
-      | TAG_TEMPLATE
-      | TAG_HTML
-  )
-}
+const DL_SCOPE_BOUNDARY: [bool; 256] = tag_set(&[
+  TAG_DL,
+  TAG_UL,
+  TAG_OL,
+  TAG_LI,
+  TAG_TABLE,
+  TAG_TD,
+  TAG_TH,
+  TAG_CAPTION,
+  TAG_TEMPLATE,
+  TAG_HTML,
+]);
 
 /// "Table cell scope" terminators: a new `<td>`/`<th>` closes the current cell
 /// (and any inline content left open inside it), stopping at the row/section.
-fn is_cell_scope_boundary(tag_id: u8) -> bool {
-  matches!(
-    tag_id,
-    TAG_TR | TAG_THEAD | TAG_TBODY | TAG_TFOOT | TAG_TABLE | TAG_CAPTION | TAG_TEMPLATE | TAG_HTML
-  )
-}
+const CELL_SCOPE_BOUNDARY: [bool; 256] = tag_set(&[
+  TAG_TR,
+  TAG_THEAD,
+  TAG_TBODY,
+  TAG_TFOOT,
+  TAG_TABLE,
+  TAG_CAPTION,
+  TAG_TEMPLATE,
+  TAG_HTML,
+]);
 
 /// Block-level terminators for closing an `<a>`: a nested `<a>` closes the open
 /// one (HTML forbids nested anchors — the adoption agency closes the outer),
 /// but only within the same block so a stray open `<a>` in another block is left
 /// alone. Closing intervening inline formatting matches the spec's reconstruction.
-fn is_a_scope_boundary(tag_id: u8) -> bool {
-  matches!(
-    tag_id,
-    TAG_P
-      | TAG_DIV
-      | TAG_LI
-      | TAG_UL
-      | TAG_OL
-      | TAG_DL
-      | TAG_DD
-      | TAG_DT
-      | TAG_TABLE
-      | TAG_TD
-      | TAG_TH
-      | TAG_TR
-      | TAG_CAPTION
-      | TAG_BLOCKQUOTE
-      | TAG_SECTION
-      | TAG_ARTICLE
-      | TAG_HEADER
-      | TAG_FOOTER
-      | TAG_NAV
-      | TAG_ASIDE
-      | TAG_MAIN
-      | TAG_FORM
-      | TAG_FIELDSET
-      | TAG_FIGURE
-      | TAG_BUTTON
-      | TAG_H1
-      | TAG_H2
-      | TAG_H3
-      | TAG_H4
-      | TAG_H5
-      | TAG_H6
-      | TAG_TEMPLATE
-      | TAG_HTML
-  )
+const A_SCOPE_BOUNDARY: [bool; 256] = tag_set(&[
+  TAG_P,
+  TAG_DIV,
+  TAG_LI,
+  TAG_UL,
+  TAG_OL,
+  TAG_DL,
+  TAG_DD,
+  TAG_DT,
+  TAG_TABLE,
+  TAG_TD,
+  TAG_TH,
+  TAG_TR,
+  TAG_CAPTION,
+  TAG_BLOCKQUOTE,
+  TAG_SECTION,
+  TAG_ARTICLE,
+  TAG_HEADER,
+  TAG_FOOTER,
+  TAG_NAV,
+  TAG_ASIDE,
+  TAG_MAIN,
+  TAG_FORM,
+  TAG_FIELDSET,
+  TAG_FIGURE,
+  TAG_BUTTON,
+  TAG_H1,
+  TAG_H2,
+  TAG_H3,
+  TAG_H4,
+  TAG_H5,
+  TAG_H6,
+  TAG_TEMPLATE,
+  TAG_HTML,
+]);
+
+/// Close targets use the same table form so the scan loop makes no indirect call.
+const TARGET_A: [bool; 256] = tag_set(&[TAG_A]);
+const TARGET_P: [bool; 256] = tag_set(&[TAG_P]);
+const TARGET_LI: [bool; 256] = tag_set(&[TAG_LI]);
+const TARGET_CELL: [bool; 256] = tag_set(&[TAG_TD, TAG_TH]);
+const TARGET_DT_DD: [bool; 256] = tag_set(&[TAG_DT, TAG_DD]);
+
+const ROW_CLOSEABLE: [bool; 256] = tag_set(&[TAG_TD, TAG_TH, TAG_TR]);
+
+const SECTION_CLOSEABLE: [bool; 256] = tag_set(&[
+  TAG_TD,
+  TAG_TH,
+  TAG_TR,
+  TAG_THEAD,
+  TAG_TBODY,
+  TAG_TFOOT,
+  TAG_CAPTION,
+]);
+
+/// Allows one optional space, so `display:none` and `display: none` both match.
+#[inline]
+fn style_value_at(bytes: &[u8], index: usize, prop: &[u8]) -> Option<usize> {
+  let end = index + prop.len();
+  if end > bytes.len() || &bytes[index..end] != prop {
+    return None;
+  }
+  Some(end + usize::from(bytes.get(end) == Some(&SPACE_CHAR)))
+}
+
+/// Single pass over the declarations, dispatching on the property's first byte.
+fn style_hides(style: &str) -> bool {
+  let bytes = style.as_bytes();
+  let mut index = 0usize;
+  while index < bytes.len() {
+    match bytes[index] {
+      b'd' => {
+        if let Some(value) = style_value_at(bytes, index, b"display:")
+          && bytes[value..].starts_with(b"none")
+        {
+          return true;
+        }
+      }
+      b'v' => {
+        if let Some(value) = style_value_at(bytes, index, b"visibility:")
+          && bytes[value..].starts_with(b"hidden")
+        {
+          return true;
+        }
+      }
+      b'p' => {
+        if let Some(value) = style_value_at(bytes, index, b"position:")
+          && (bytes[value..].starts_with(b"absolute") || bytes[value..].starts_with(b"fixed"))
+        {
+          return true;
+        }
+      }
+      _ => {}
+    }
+    index += 1;
+  }
+  false
 }
 
 /// Whether an element is visually hidden, so the filter should drop it and its
@@ -218,14 +292,7 @@ fn is_a_scope_boundary(tag_id: u8) -> bool {
 /// properties (rare in inline styles) are not handled.
 fn is_hidden(node: &ElementNode) -> bool {
   if let Some(style) = node.attributes.get("style")
-    && (style.contains("display:none")
-      || style.contains("display: none")
-      || style.contains("visibility:hidden")
-      || style.contains("visibility: hidden")
-      || style.contains("position:absolute")
-      || style.contains("position: absolute")
-      || style.contains("position:fixed")
-      || style.contains("position: fixed"))
+    && style_hides(style)
   {
     return true;
   }
@@ -399,17 +466,17 @@ impl ConvertState {
   /// `<dt>`/`<dd>`: the intervening unmatched nodes (inline formatting, unknown
   /// elements) are closed along the way, mirroring the spec's "generate implied
   /// end tags" step.
-  fn close_implied_to(&mut self, target: fn(u8) -> bool, boundary: fn(u8) -> bool) {
+  fn close_implied_to(&mut self, target: &[bool; 256], boundary: &[bool; 256]) {
     let mut close_count = 0usize;
     let mut found = false;
     for node in self.stack.iter().rev() {
       match node.tag_id {
-        Some(id) if target(id) => {
+        Some(id) if target[id as usize] => {
           close_count += 1;
           found = true;
           break;
         }
-        Some(id) if boundary(id) => break,
+        Some(id) if boundary[id as usize] => break,
         _ => close_count += 1,
       }
     }
@@ -424,10 +491,10 @@ impl ConvertState {
   /// they match `closeable`, stopping at the first node that does not (e.g. the
   /// enclosing `<table>`). Implements implied end tags for `<tr>` (closes an open
   /// cell + row) and `<thead>`/`<tbody>`/`<tfoot>` (closes cell + row + section).
-  fn close_table_context(&mut self, closeable: fn(u8) -> bool) {
+  fn close_table_context(&mut self, closeable: &[bool; 256]) {
     while let Some(top) = self.stack.last() {
       match top.tag_id {
-        Some(id) if closeable(id) => self.close_node(),
+        Some(id) if closeable[id as usize] => self.close_node(),
         _ => break,
       }
     }
@@ -468,14 +535,19 @@ impl ConvertState {
     position: usize,
   ) -> OpeningTagResult {
     let tag_handler = tag_id.and_then(get_tag_handler);
-    let needs_attrs = tag_handler.is_some_and(|h| h.needs_attributes)
-      || self.has_tailwind
+    // Plugins can read any attribute, so they force full capture. `frontmatter`
+    // is absent deliberately: TAG_META's own mask already covers what it reads.
+    let attr_mask = if self.has_tailwind
       || self.has_filter
       || self.has_extraction
       || self.has_tag_overrides
-      || self.has_frontmatter;
+    {
+      ATTR_ALL
+    } else {
+      tag_handler.map_or(ATTR_NONE, |h| h.wanted_attrs)
+    };
     let (complete, new_position, attributes, self_closing) =
-      process_tag_attributes(html_chunk, position, tag_handler, !needs_attrs);
+      process_tag_attributes(html_chunk, position, tag_handler, attr_mask);
 
     if !complete {
       return OpeningTagResult {
@@ -550,7 +622,7 @@ impl ConvertState {
         // A nested <a> closes the open one (anchors cannot nest), so the
         // markdown is two adjacent links rather than invalid nested `[..]`.
         TAG_A if self.depth_map[TAG_A as usize] > 0 => {
-          self.close_implied_to(|t| t == TAG_A, is_a_scope_boundary);
+          self.close_implied_to(&TARGET_A, &A_SCOPE_BOUNDARY);
         }
         TAG_TD | TAG_TH | TAG_TR | TAG_THEAD | TAG_TBODY | TAG_TFOOT
           if self.depth_map[TAG_TABLE as usize] > 0 =>
@@ -559,18 +631,13 @@ impl ConvertState {
             TAG_TD | TAG_TH
               if self.depth_map[TAG_TD as usize] > 0 || self.depth_map[TAG_TH as usize] > 0 =>
             {
-              self.close_implied_to(|t| t == TAG_TD || t == TAG_TH, is_cell_scope_boundary);
+              self.close_implied_to(&TARGET_CELL, &CELL_SCOPE_BOUNDARY);
             }
             TAG_TR if self.depth_map[TAG_TR as usize] > 0 => {
-              self.close_table_context(|t| matches!(t, TAG_TD | TAG_TH | TAG_TR));
+              self.close_table_context(&ROW_CLOSEABLE);
             }
             TAG_THEAD | TAG_TBODY | TAG_TFOOT => {
-              self.close_table_context(|t| {
-                matches!(
-                  t,
-                  TAG_TD | TAG_TH | TAG_TR | TAG_THEAD | TAG_TBODY | TAG_TFOOT | TAG_CAPTION
-                )
-              });
+              self.close_table_context(&SECTION_CLOSEABLE);
             }
             _ => {}
           }
@@ -580,7 +647,7 @@ impl ConvertState {
         _ => {
           if self.depth_map[TAG_P as usize] > 0 {
             debug_assert!(closes_p(id));
-            self.close_implied_to(|t| t == TAG_P, is_p_scope_boundary);
+            self.close_implied_to(&TARGET_P, &P_SCOPE_BOUNDARY);
           }
           match id {
             // A heading start closes an open heading (they cannot nest); only
@@ -597,12 +664,12 @@ impl ConvertState {
               self.close_node();
             }
             TAG_LI if self.depth_map[TAG_LI as usize] > 0 => {
-              self.close_implied_to(|t| t == TAG_LI, is_li_scope_boundary);
+              self.close_implied_to(&TARGET_LI, &LI_SCOPE_BOUNDARY);
             }
             TAG_DT | TAG_DD
               if self.depth_map[TAG_DT as usize] > 0 || self.depth_map[TAG_DD as usize] > 0 =>
             {
-              self.close_implied_to(|t| t == TAG_DT || t == TAG_DD, is_dl_scope_boundary);
+              self.close_implied_to(&TARGET_DT_DD, &DL_SCOPE_BOUNDARY);
             }
             _ => {}
           }
@@ -739,60 +806,36 @@ impl ConvertState {
       }
 
       if self.has_filter {
-        // Hidden elements (and their subtrees) are dropped — browsers never
-        // render them. `hidden_since_depth` records the shallowest open hidden
-        // element, so once inside a hidden subtree we skip O(1) without calling
-        // is_hidden() again. Cleared in close_node at the matching depth.
+        // Hidden and exclude-matched elements both drop their whole subtree, so
+        // one marker covers both: a descendant costs an Option check instead of
+        // rescanning every ancestor against every selector.
         if self.hidden_since_depth.is_some() {
           skip_node = true;
           filter_excluded = true;
-        } else if is_hidden(&tag) {
+        } else if is_hidden(&tag)
+          || self
+            .filter_exclude_parsed
+            .iter()
+            .any(|(_, parsed)| matches_selector(&tag, parsed))
+        {
           skip_node = true;
           filter_excluded = true;
           self.hidden_since_depth = Some(self.depth);
         }
-        if !skip_node {
-          for (_, parsed) in &self.filter_exclude_parsed {
-            if matches_selector(&tag, parsed) {
-              skip_node = true;
-              filter_excluded = true;
-              break;
-            }
-          }
-        }
-        if !skip_node {
-          for parent in &self.stack {
-            for (_, parsed) in &self.filter_exclude_parsed {
-              if matches_selector(parent, parsed) {
-                skip_node = true;
-                filter_excluded = true;
-                break;
-              }
-            }
-            if skip_node {
-              break;
-            }
-          }
-        }
         if !skip_node && !self.filter_include_parsed.is_empty() {
-          let mut match_found = false;
-          for (_, parsed) in &self.filter_include_parsed {
-            if matches_selector(&tag, parsed) {
-              match_found = true;
-              break;
-            }
-          }
-          if !match_found && self.filter_process_children {
-            for parent in &self.stack {
-              for (_, parsed) in &self.filter_include_parsed {
-                if matches_selector(parent, parsed) {
-                  match_found = true;
-                  break;
-                }
-              }
-              if match_found {
-                break;
-              }
+          // Inclusion is inherited the same way, but only when
+          // `process_children` keeps the matched element's subtree.
+          let mut match_found =
+            self.filter_process_children && self.filter_included_since_depth.is_some();
+          if !match_found
+            && self
+              .filter_include_parsed
+              .iter()
+              .any(|(_, parsed)| matches_selector(&tag, parsed))
+          {
+            match_found = true;
+            if self.filter_included_since_depth.is_none() {
+              self.filter_included_since_depth = Some(self.depth);
             }
           }
           if !match_found {
@@ -1007,9 +1050,12 @@ impl ConvertState {
     // Guard already checked above, but avoid panic on edge cases
     let Some(node) = self.stack.pop() else { return };
 
-    // Leaving the element that opened the current hidden subtree (filter).
+    // Each marker holds the shallowest open match, so only its own close clears it.
     if self.hidden_since_depth == Some(node.depth) {
       self.hidden_since_depth = None;
+    }
+    if self.filter_included_since_depth == Some(node.depth) {
+      self.filter_included_since_depth = None;
     }
 
     if self.first_block_parent_index == Some(popping_index) {

--- a/crates/core/src/scan.rs
+++ b/crates/core/src/scan.rs
@@ -69,35 +69,76 @@ pub(crate) fn process_tag_attributes(
   tag_handler: Option<&crate::types::TagHandler>,
   attr_mask: u16,
 ) -> (bool, usize, Attributes, bool) {
-  let mut i = position;
+  let self_closing = tag_handler.is_some_and(|h| h.is_self_closing);
+  if attr_mask == ATTR_NONE {
+    scan_tag::<false>(html_chunk, position, self_closing, ATTR_NONE)
+  } else {
+    scan_tag::<true>(html_chunk, position, self_closing, attr_mask)
+  }
+}
+
+/// Walk a start tag to its `>`, extracting attributes on the way when
+/// `EXTRACT`. Finding `>` needs the same quote tracking the extraction does, so
+/// both come from one pass; the flag is a const so the `ATTR_NONE`
+/// instantiation compiles the extraction out, which is what most tags want.
+fn scan_tag<const EXTRACT: bool>(
+  html_chunk: &str,
+  position: usize,
+  self_closing: bool,
+  attr_mask: u16,
+) -> (bool, usize, Attributes, bool) {
   let bytes = html_chunk.as_bytes();
   let chunk_length = bytes.len();
-
-  let self_closing = tag_handler.is_some_and(|h| h.is_self_closing);
+  let mut scan = AttrScan::new(attr_mask);
   let mut inside_quote = false;
   let mut quote_char: u8 = 0;
-  let attr_start_pos = i;
+  let mut i = position;
 
   while i < chunk_length {
     let c = bytes[i];
 
+    // A quote opened outside a value hides `>` until it closes.
     if inside_quote {
       if c == quote_char {
         inside_quote = false;
       }
+      if EXTRACT {
+        scan.step(html_chunk, c, i);
+      }
       i += 1;
       continue;
-    } else if c == QUOTE_CHAR || c == APOS_CHAR {
-      inside_quote = true;
-      quote_char = c;
-    } else if c == SLASH_CHAR && i + 1 < chunk_length && bytes[i + 1] == GT_CHAR {
-      let attrs = parse_attributes(html_chunk[attr_start_pos..i].trim(), attr_mask);
-      return (true, i + 2, attrs, true);
-    } else if c == GT_CHAR {
-      let attrs = parse_attributes(html_chunk[attr_start_pos..i].trim(), attr_mask);
-      return (true, i + 1, attrs, self_closing);
     }
 
+    if c == SLASH_CHAR && i + 1 < chunk_length && bytes[i + 1] == GT_CHAR {
+      return (true, i + 2, scan.finish(html_chunk, i), true);
+    }
+    if c == GT_CHAR {
+      return (true, i + 1, scan.finish(html_chunk, i), self_closing);
+    }
+
+    // Run to the closing quote without re-entering the state dispatch.
+    if EXTRACT && scan.opens_quoted_value(c) {
+      let value_start = i + 1;
+      let mut end = value_start;
+      while end < chunk_length && bytes[end] != c {
+        end += 1;
+      }
+      if end == chunk_length {
+        // Unterminated: the tag cannot close in this chunk.
+        return (false, chunk_length, Attributes::new(), false);
+      }
+      scan.take_value(html_chunk, value_start, end);
+      i = end + 1;
+      continue;
+    }
+
+    if c == QUOTE_CHAR || c == APOS_CHAR {
+      inside_quote = true;
+      quote_char = c;
+    }
+    if EXTRACT {
+      scan.step(html_chunk, c, i);
+    }
     i += 1;
   }
 
@@ -118,139 +159,134 @@ fn push_attr(result: &mut Attributes, mask: u16, raw: &str, value: Option<&str>)
   }
 }
 
-#[allow(clippy::collapsible_match)]
-pub(crate) fn parse_attributes(attr_str: &str, mask: u16) -> Attributes {
-  if attr_str.is_empty() || mask == ATTR_NONE {
-    return Attributes::new();
-  }
-  // A filtered mask keeps at most three names, so skip the eager reservation.
-  let mut result = if mask == ATTR_ALL {
-    Attributes::with_capacity(4)
-  } else {
-    Attributes::new()
-  };
+/// Attribute extraction fed one byte at a time by the tag scan. Offsets index
+/// the chunk itself, so nothing is allocated until a wanted attribute is whole.
+struct AttrScan {
+  mask: u16,
+  result: Attributes,
+  state: State,
+  name_start: usize,
+  name_end: usize,
+  value_start: usize,
+}
 
-  let bytes = attr_str.as_bytes();
-  let len = bytes.len();
-  let mut i = 0;
+/// Where the scan sits within one `name="value"` triple.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum State {
+  Gap,
+  Name,
+  AfterName,
+  BeforeValue,
+  UnquotedValue,
+}
 
-  const WHITESPACE: u8 = 0;
-  const NAME: u8 = 1;
-  const AFTER_NAME: u8 = 2;
-  const BEFORE_VALUE: u8 = 3;
-  const QUOTED_VALUE: u8 = 4;
-  const UNQUOTED_VALUE: u8 = 5;
-
-  let mut state = WHITESPACE;
-  let mut name_start = 0;
-  let mut name_end;
-  let mut value_start = 0;
-  let mut quote_char = 0;
-  let mut name_start_saved = 0;
-  let mut name_end_saved = 0;
-
-  while i < len {
-    let char_code = bytes[i];
-
-    // `is_whitespace` is computed per arm, not per byte: the quoted-value arm,
-    // where most attribute bytes live, never needs it.
-    match state {
-      WHITESPACE => {
-        if !is_whitespace(char_code) {
-          state = NAME;
-          name_start = i;
-        }
-      }
-      NAME => {
-        if char_code == EQUALS_CHAR || is_whitespace(char_code) {
-          name_end = i;
-          name_start_saved = name_start;
-          name_end_saved = name_end;
-          state = if char_code == EQUALS_CHAR {
-            BEFORE_VALUE
-          } else {
-            AFTER_NAME
-          };
-        }
-      }
-      AFTER_NAME => {
-        if char_code == EQUALS_CHAR {
-          state = BEFORE_VALUE;
-        } else if !is_whitespace(char_code) {
-          push_attr(
-            &mut result,
-            mask,
-            &attr_str[name_start_saved..name_end_saved],
-            None,
-          );
-          state = NAME;
-          name_start = i;
-        }
-      }
-      BEFORE_VALUE => {
-        if !is_whitespace(char_code) {
-          if char_code == QUOTE_CHAR || char_code == APOS_CHAR {
-            state = QUOTED_VALUE;
-            quote_char = char_code;
-            value_start = i + 1;
-          } else {
-            state = UNQUOTED_VALUE;
-            value_start = i;
-          }
-        }
-      }
-      QUOTED_VALUE => {
-        // Run to the closing quote without re-entering the state dispatch.
-        while i < len && bytes[i] != quote_char {
-          i += 1;
-        }
-        if i == len {
-          // Unterminated quote: the attribute is dropped.
-          break;
-        }
-        push_attr(
-          &mut result,
-          mask,
-          &attr_str[name_start_saved..name_end_saved],
-          Some(&attr_str[value_start..i]),
-        );
-        state = WHITESPACE;
-      }
-      UNQUOTED_VALUE => {
-        if is_whitespace(char_code) {
-          push_attr(
-            &mut result,
-            mask,
-            &attr_str[name_start_saved..name_end_saved],
-            Some(&attr_str[value_start..i]),
-          );
-          state = WHITESPACE;
-        }
-      }
-      _ => {}
+impl AttrScan {
+  #[inline]
+  fn new(mask: u16) -> Self {
+    Self {
+      mask,
+      // A filtered mask keeps at most three names, so skip the eager reservation.
+      result: if mask == ATTR_ALL {
+        Attributes::with_capacity(4)
+      } else {
+        Attributes::new()
+      },
+      state: State::Gap,
+      name_start: 0,
+      name_end: 0,
+      value_start: 0,
     }
-    i += 1;
   }
 
-  if state == NAME {
-    push_attr(&mut result, mask, &attr_str[name_start..], None);
-  } else if state == UNQUOTED_VALUE {
+  #[inline]
+  fn opens_quoted_value(&self, c: u8) -> bool {
+    self.state == State::BeforeValue && (c == QUOTE_CHAR || c == APOS_CHAR)
+  }
+
+  #[inline]
+  fn take_value(&mut self, chunk: &str, value_start: usize, value_end: usize) {
     push_attr(
-      &mut result,
-      mask,
-      &attr_str[name_start_saved..name_end_saved],
-      Some(&attr_str[value_start..]),
+      &mut self.result,
+      self.mask,
+      &chunk[self.name_start..self.name_end],
+      Some(&chunk[value_start..value_end]),
     );
-  } else if state == AFTER_NAME || state == BEFORE_VALUE {
+    self.state = State::Gap;
+  }
+
+  #[inline]
+  fn take_bare_name(&mut self, chunk: &str, name_end: usize) {
     push_attr(
-      &mut result,
-      mask,
-      &attr_str[name_start_saved..name_end_saved],
+      &mut self.result,
+      self.mask,
+      &chunk[self.name_start..name_end],
       None,
     );
   }
 
-  result
+  /// `is_whitespace` is computed per arm, not per byte: the value arms, where
+  /// most attribute bytes live, never need it.
+  #[inline]
+  fn step(&mut self, chunk: &str, c: u8, index: usize) {
+    match self.state {
+      State::Gap => {
+        if !is_whitespace(c) {
+          self.state = State::Name;
+          self.name_start = index;
+        }
+      }
+      State::Name => {
+        if c == EQUALS_CHAR || is_whitespace(c) {
+          self.name_end = index;
+          self.state = if c == EQUALS_CHAR {
+            State::BeforeValue
+          } else {
+            State::AfterName
+          };
+        }
+      }
+      State::AfterName => {
+        if c == EQUALS_CHAR {
+          self.state = State::BeforeValue;
+        } else if !is_whitespace(c) {
+          self.take_bare_name(chunk, self.name_end);
+          self.state = State::Name;
+          self.name_start = index;
+        }
+      }
+      State::BeforeValue => {
+        if !is_whitespace(c) {
+          self.state = State::UnquotedValue;
+          self.value_start = index;
+        }
+      }
+      State::UnquotedValue => {
+        if is_whitespace(c) {
+          self.take_value(chunk, self.value_start, index);
+        }
+      }
+    }
+  }
+
+  /// Take the attribute still open when the tag ended at `end`.
+  #[inline]
+  fn finish(mut self, chunk: &str, end: usize) -> Attributes {
+    match self.state {
+      State::Name => self.take_bare_name(chunk, end),
+      State::AfterName | State::BeforeValue => self.take_bare_name(chunk, self.name_end),
+      State::UnquotedValue => self.take_value(chunk, self.value_start, end),
+      State::Gap => {}
+    }
+    self.result
+  }
+}
+
+/// Attributes of a bare region, for tests that write their input as it reads
+/// inside `<…>`.
+#[cfg(test)]
+pub(crate) fn parse_attributes(attr_str: &str, mask: u16) -> Attributes {
+  let (_, _, attrs, _) = process_tag_attributes(&format!("{attr_str}>"), 0, None, mask);
+  attrs
 }
 
 #[cfg(test)]
@@ -358,5 +394,48 @@ mod tests {
     assert!(!self_closing);
     assert_eq!(&html[new_pos..], "rest");
     assert_eq!(attrs.get("href").map(String::as_str), Some("x"));
+  }
+
+  #[test]
+  fn an_unterminated_quoted_value_leaves_the_tag_incomplete() {
+    // The closing quote may still arrive in the next chunk, so nothing is
+    // reported until it does.
+    let html = "a href=\"x";
+    let (complete, _, attrs, _) = process_tag_attributes(html, 1, None, ATTR_ALL);
+    assert!(!complete);
+    assert!(attrs.is_empty());
+  }
+
+  #[test]
+  fn a_quoted_value_hides_a_tag_terminator() {
+    let html = "a href=\"x>y\">rest";
+    let (complete, new_pos, attrs, _) = process_tag_attributes(html, 1, None, ATTR_ALL);
+    assert!(complete);
+    assert_eq!(attrs.get("href").map(String::as_str), Some("x>y"));
+    assert_eq!(&html[new_pos..], "rest");
+  }
+
+  #[test]
+  fn both_scan_instantiations_agree_on_the_tag_end() {
+    // `ATTR_NONE` compiles the extraction out, so the two instantiations have
+    // to keep finding the same `>`.
+    for html in [
+      "a href=\"x>y\">rest",
+      "a href=x/>rest",
+      "a href=a\"b>rest",
+      "a>rest",
+    ] {
+      let (complete, extracted_pos, _, extracted_self_closing) =
+        process_tag_attributes(html, 1, None, ATTR_ALL);
+      let (bare_complete, bare_pos, bare_attrs, bare_self_closing) =
+        process_tag_attributes(html, 1, None, ATTR_NONE);
+      assert_eq!(complete, bare_complete, "html={html:?}");
+      assert_eq!(extracted_pos, bare_pos, "html={html:?}");
+      assert_eq!(
+        extracted_self_closing, bare_self_closing,
+        "html={html:?}"
+      );
+      assert!(bare_attrs.is_empty(), "html={html:?}");
+    }
   }
 }

--- a/crates/core/src/scan.rs
+++ b/crates/core/src/scan.rs
@@ -61,11 +61,13 @@ pub(crate) fn process_comment_or_doctype(html_chunk: &str, position: usize) -> C
   }
 }
 
+/// Scan a start tag's attribute region to its `>`, storing only the attributes
+/// `attr_mask` selects.
 pub(crate) fn process_tag_attributes(
   html_chunk: &str,
   position: usize,
   tag_handler: Option<&crate::types::TagHandler>,
-  skip_attrs: bool,
+  attr_mask: u16,
 ) -> (bool, usize, Attributes, bool) {
   let mut i = position;
   let bytes = html_chunk.as_bytes();
@@ -89,18 +91,10 @@ pub(crate) fn process_tag_attributes(
       inside_quote = true;
       quote_char = c;
     } else if c == SLASH_CHAR && i + 1 < chunk_length && bytes[i + 1] == GT_CHAR {
-      let attrs = if skip_attrs {
-        Attributes::new()
-      } else {
-        parse_attributes(html_chunk[attr_start_pos..i].trim())
-      };
+      let attrs = parse_attributes(html_chunk[attr_start_pos..i].trim(), attr_mask);
       return (true, i + 2, attrs, true);
     } else if c == GT_CHAR {
-      let attrs = if skip_attrs {
-        Attributes::new()
-      } else {
-        parse_attributes(html_chunk[attr_start_pos..i].trim())
-      };
+      let attrs = parse_attributes(html_chunk[attr_start_pos..i].trim(), attr_mask);
       return (true, i + 1, attrs, self_closing);
     }
 
@@ -110,12 +104,31 @@ pub(crate) fn process_tag_attributes(
   (false, i, Attributes::new(), false)
 }
 
+/// Mask rejection happens before any lowercasing or entity decoding, so
+/// unwanted attributes cost no allocations.
+#[inline]
+fn push_attr(result: &mut Attributes, mask: u16, raw: &str, value: Option<&str>) {
+  if !attr_wanted(mask, raw.as_bytes()) {
+    return;
+  }
+  let name = raw.to_ascii_lowercase();
+  match value {
+    Some(value) => result.insert(name, decode_html_attribute_entities(value).into_owned()),
+    None => result.insert(name, String::new()),
+  }
+}
+
 #[allow(clippy::collapsible_match)]
-pub(crate) fn parse_attributes(attr_str: &str) -> Attributes {
-  if attr_str.is_empty() {
+pub(crate) fn parse_attributes(attr_str: &str, mask: u16) -> Attributes {
+  if attr_str.is_empty() || mask == ATTR_NONE {
     return Attributes::new();
   }
-  let mut result = Attributes::with_capacity(4);
+  // A filtered mask keeps at most three names, so skip the eager reservation.
+  let mut result = if mask == ATTR_ALL {
+    Attributes::with_capacity(4)
+  } else {
+    Attributes::new()
+  };
 
   let bytes = attr_str.as_bytes();
   let len = bytes.len();
@@ -138,17 +151,18 @@ pub(crate) fn parse_attributes(attr_str: &str) -> Attributes {
 
   while i < len {
     let char_code = bytes[i];
-    let is_space = is_whitespace(char_code);
 
+    // `is_whitespace` is computed per arm, not per byte: the quoted-value arm,
+    // where most attribute bytes live, never needs it.
     match state {
       WHITESPACE => {
-        if !is_space {
+        if !is_whitespace(char_code) {
           state = NAME;
           name_start = i;
         }
       }
       NAME => {
-        if char_code == EQUALS_CHAR || is_space {
+        if char_code == EQUALS_CHAR || is_whitespace(char_code) {
           name_end = i;
           name_start_saved = name_start;
           name_end_saved = name_end;
@@ -162,18 +176,19 @@ pub(crate) fn parse_attributes(attr_str: &str) -> Attributes {
       AFTER_NAME => {
         if char_code == EQUALS_CHAR {
           state = BEFORE_VALUE;
-        } else if !is_space {
-          let raw = &attr_str[name_start_saved..name_end_saved];
-          // Single-pass lowercase: the result is owned either way,
-          // so the uppercase pre-scan would only add a redundant pass.
-          let name = raw.to_ascii_lowercase();
-          result.insert(name, String::new());
+        } else if !is_whitespace(char_code) {
+          push_attr(
+            &mut result,
+            mask,
+            &attr_str[name_start_saved..name_end_saved],
+            None,
+          );
           state = NAME;
           name_start = i;
         }
       }
       BEFORE_VALUE => {
-        if !is_space {
+        if !is_whitespace(char_code) {
           if char_code == QUOTE_CHAR || char_code == APOS_CHAR {
             state = QUOTED_VALUE;
             quote_char = char_code;
@@ -185,27 +200,29 @@ pub(crate) fn parse_attributes(attr_str: &str) -> Attributes {
         }
       }
       QUOTED_VALUE => {
-        if char_code == quote_char {
-          let raw = &attr_str[name_start_saved..name_end_saved];
-          // Single-pass lowercase: the result is owned either way,
-          // so the uppercase pre-scan would only add a redundant pass.
-          let name = raw.to_ascii_lowercase();
-          result.insert(
-            name,
-            decode_html_attribute_entities(&attr_str[value_start..i]).into_owned(),
-          );
-          state = WHITESPACE;
+        // Run to the closing quote without re-entering the state dispatch.
+        while i < len && bytes[i] != quote_char {
+          i += 1;
         }
+        if i == len {
+          // Unterminated quote: the attribute is dropped.
+          break;
+        }
+        push_attr(
+          &mut result,
+          mask,
+          &attr_str[name_start_saved..name_end_saved],
+          Some(&attr_str[value_start..i]),
+        );
+        state = WHITESPACE;
       }
       UNQUOTED_VALUE => {
-        if is_space {
-          let raw = &attr_str[name_start_saved..name_end_saved];
-          // Single-pass lowercase: the result is owned either way,
-          // so the uppercase pre-scan would only add a redundant pass.
-          let name = raw.to_ascii_lowercase();
-          result.insert(
-            name,
-            decode_html_attribute_entities(&attr_str[value_start..i]).into_owned(),
+        if is_whitespace(char_code) {
+          push_attr(
+            &mut result,
+            mask,
+            &attr_str[name_start_saved..name_end_saved],
+            Some(&attr_str[value_start..i]),
           );
           state = WHITESPACE;
         }
@@ -216,20 +233,21 @@ pub(crate) fn parse_attributes(attr_str: &str) -> Attributes {
   }
 
   if state == NAME {
-    let raw = &attr_str[name_start..];
-    let lc = raw.to_ascii_lowercase();
-    result.insert(lc, String::new());
+    push_attr(&mut result, mask, &attr_str[name_start..], None);
   } else if state == UNQUOTED_VALUE {
-    let raw = &attr_str[name_start_saved..name_end_saved];
-    let name = raw.to_ascii_lowercase();
-    result.insert(
-      name,
-      decode_html_attribute_entities(&attr_str[value_start..]).into_owned(),
+    push_attr(
+      &mut result,
+      mask,
+      &attr_str[name_start_saved..name_end_saved],
+      Some(&attr_str[value_start..]),
     );
   } else if state == AFTER_NAME || state == BEFORE_VALUE {
-    let raw = &attr_str[name_start_saved..name_end_saved];
-    let name = raw.to_ascii_lowercase();
-    result.insert(name, String::new());
+    push_attr(
+      &mut result,
+      mask,
+      &attr_str[name_start_saved..name_end_saved],
+      None,
+    );
   }
 
   result
@@ -251,29 +269,29 @@ mod tests {
 
   #[test]
   fn parses_quoted_and_unquoted_attributes() {
-    let a = parse_attributes("href=\"/x\" id=main");
+    let a = parse_attributes("href=\"/x\" id=main", ATTR_ALL);
     assert_eq!(a.get("href").map(String::as_str), Some("/x"));
     assert_eq!(a.get("id").map(String::as_str), Some("main"));
   }
 
   #[test]
   fn parses_valueless_and_empty_attributes() {
-    let a = parse_attributes("disabled checked");
+    let a = parse_attributes("disabled checked", ATTR_ALL);
     assert!(a.contains_key("disabled"));
     assert!(a.contains_key("checked"));
-    let empty = parse_attributes("");
+    let empty = parse_attributes("", ATTR_ALL);
     assert!(empty.is_empty());
   }
 
   #[test]
   fn attribute_names_lowercased_values_decoded() {
-    let a = parse_attributes("DATA-X='a &amp; b'");
+    let a = parse_attributes("DATA-X='a &amp; b'", ATTR_ALL);
     assert_eq!(a.get("data-x").map(String::as_str), Some("a & b"));
   }
 
   #[test]
   fn attribute_entities_follow_ambiguous_ampersand_rules() {
-    let a = parse_attributes("title='&copycat &copy=1 &copy! &copy;cat'");
+    let a = parse_attributes("title='&copycat &copy=1 &copy! &copy;cat'", ATTR_ALL);
     assert_eq!(
       a.get("title").map(String::as_str),
       Some("&copycat &copy=1 ©! ©cat")
@@ -288,16 +306,54 @@ mod tests {
   #[test]
   fn valueless_equals_attribute_kept_as_empty() {
     // `<a href=>` — attribute ends in `name=`, must survive as empty value
-    let a = parse_attributes("href=");
+    let a = parse_attributes("href=", ATTR_ALL);
     assert!(a.contains_key("href"));
     assert_eq!(a.get("href").map(String::as_str), Some(""));
+  }
+
+  #[test]
+  fn a_filtered_mask_stores_only_the_wanted_names() {
+    // <a>'s mask: href/title/aria-label. Everything else is scanned past.
+    let mask = ATTR_HREF | ATTR_TITLE | ATTR_ARIA_LABEL;
+    let a = parse_attributes(
+      "class=btn href=\"/x\" rel=nofollow data-id='7' TITLE=\"t\" target=_blank",
+      mask,
+    );
+    assert_eq!(a.get("href").map(String::as_str), Some("/x"));
+    assert_eq!(a.get("title").map(String::as_str), Some("t"));
+    assert!(!a.contains_key("class"));
+    assert!(!a.contains_key("rel"));
+    assert!(!a.contains_key("data-id"));
+    assert!(!a.contains_key("target"));
+  }
+
+  #[test]
+  fn a_filtered_mask_keeps_trailing_and_valueless_forms() {
+    // Tail states (bare name, `name=`, unquoted final value) honour the mask.
+    assert!(parse_attributes("hidden href", ATTR_HREF).contains_key("href"));
+    assert!(parse_attributes("hidden href=", ATTR_HREF).contains_key("href"));
+    assert_eq!(
+      parse_attributes("class=c src=/i.png", ATTR_SRC)
+        .get("src")
+        .map(String::as_str),
+      Some("/i.png")
+    );
+    assert!(!parse_attributes("class=c src=/i.png", ATTR_SRC).contains_key("class"));
+  }
+
+  #[test]
+  fn attr_mask_none_stores_nothing_and_all_stores_everything() {
+    assert!(parse_attributes("href=/x class=c", ATTR_NONE).is_empty());
+    let all = parse_attributes("href=/x class=c", ATTR_ALL);
+    assert!(all.contains_key("href") && all.contains_key("class"));
   }
 
   #[test]
   fn process_tag_attributes_finds_close() {
     // "<a href=\"x\">" — scan from after the tag name
     let html = "a href=\"x\">rest";
-    let (complete, new_pos, attrs, self_closing) = process_tag_attributes(html, 1, None, false);
+    let (complete, new_pos, attrs, self_closing) =
+      process_tag_attributes(html, 1, None, ATTR_ALL);
     assert!(complete);
     assert!(!self_closing);
     assert_eq!(&html[new_pos..], "rest");

--- a/crates/core/src/tags.rs
+++ b/crates/core/src/tags.rs
@@ -8,7 +8,7 @@ const NONE: TagHandler = TagHandler {
   is_inline: false,
   spacing: None,
   excludes_text_nodes: false,
-  needs_attributes: false,
+  wanted_attrs: ATTR_NONE,
 };
 
 const BLOCK: TagHandler = NONE;
@@ -77,7 +77,7 @@ static TAG_HANDLERS: [Option<TagHandler>; MAX_TAG_ID] = {
     collapses_inner_white_space: true,
     is_self_closing: true,
     spacing: Some(NO_SPACING),
-    needs_attributes: true,
+    wanted_attrs: ATTR_NAME | ATTR_PROPERTY | ATTR_CONTENT,
     ..NONE
   });
   t[TAG_BR as usize] = Some(TagHandler {
@@ -139,7 +139,7 @@ static TAG_HANDLERS: [Option<TagHandler>; MAX_TAG_ID] = {
     collapses_inner_white_space: true,
     spacing: Some(NO_SPACING),
     is_inline: true,
-    needs_attributes: true,
+    wanted_attrs: ATTR_CLASS,
     ..NONE
   });
 
@@ -156,7 +156,7 @@ static TAG_HANDLERS: [Option<TagHandler>; MAX_TAG_ID] = {
     collapses_inner_white_space: true,
     spacing: Some(NO_SPACING),
     is_inline: true,
-    needs_attributes: true,
+    wanted_attrs: ATTR_HREF | ATTR_TITLE | ATTR_ARIA_LABEL,
     ..NONE
   });
   t[TAG_IMG as usize] = Some(TagHandler {
@@ -164,7 +164,7 @@ static TAG_HANDLERS: [Option<TagHandler>; MAX_TAG_ID] = {
     is_self_closing: true,
     spacing: Some(NO_SPACING),
     is_inline: true,
-    needs_attributes: true,
+    wanted_attrs: ATTR_SRC | ATTR_ALT | ATTR_TITLE,
     ..NONE
   });
 
@@ -182,7 +182,7 @@ static TAG_HANDLERS: [Option<TagHandler>; MAX_TAG_ID] = {
   });
   t[TAG_TH as usize] = Some(TagHandler {
     collapses_inner_white_space: true,
-    needs_attributes: true,
+    wanted_attrs: ATTR_ALIGN,
     spacing: Some(NO_SPACING),
     ..NONE
   });
@@ -211,10 +211,10 @@ static TAG_HANDLERS: [Option<TagHandler>; MAX_TAG_ID] = {
   t[TAG_HEADER as usize] = Some(BLOCK);
   t[TAG_MAIN as usize] = Some(BLOCK);
   t[TAG_FIGURE as usize] = Some(BLOCK);
-  // needs_attributes so a bare <pre class="language-x"> can resolve its fence
+  // `class` is kept so a bare <pre class="language-x"> can resolve its fence
   // language for the deferred code block (issue #97).
   t[TAG_PRE as usize] = Some(TagHandler {
-    needs_attributes: true,
+    wanted_attrs: ATTR_CLASS,
     ..NONE
   });
 

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -114,8 +114,9 @@ pub struct TagHandler {
   pub is_inline: bool,
   pub spacing: Option<[u8; 2]>,
   pub excludes_text_nodes: bool,
-  /// Whether the tag handler reads attributes (href, src, class, etc.)
-  pub needs_attributes: bool,
+  /// `ATTR_*` bitmask of the attribute names this tag's rendering reads.
+  /// Anything outside it is skipped instead of lowercased, decoded, and stored.
+  pub wanted_attrs: u16,
 }
 
 // Internal config types (distinct from NAPI types in lib.rs)

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -1780,6 +1780,199 @@ fn filter_exclude_by_compound_selector() {
   assert!(!md.contains("Remove"));
 }
 
+// ── Attribute masking (TagHandler::wanted_attrs) ──
+
+/// A renderer only sees attributes its tag's `wanted_attrs` mask keeps, so
+/// reading a new one without widening the mask fails here.
+#[test]
+fn every_rendered_attribute_survives_the_wanted_attrs_mask() {
+  let opts = HTMLToMarkdownOptions::default;
+
+  // TAG_A: href, title
+  let md = html_to_markdown(r#"<a href="/x" title="T">link</a>"#, opts());
+  assert_eq!(md, "[link](/x \"T\")", "a href/title: {md:?}");
+
+  // TAG_A: aria-label feeds empty-link text synthesis
+  let md = html_to_markdown(
+    r#"<a href="/x" aria-label="Label"><span></span></a>"#,
+    opts(),
+  );
+  assert!(md.contains("Label"), "a aria-label: {md:?}");
+
+  // TAG_IMG: src, alt, title
+  let md = html_to_markdown(r#"<img src="/i.png" alt="A" title="T">"#, opts());
+  assert_eq!(md, "![A](/i.png \"T\")", "img src/alt/title: {md:?}");
+
+  // TAG_CODE inside TAG_PRE: class → fence language
+  let md = html_to_markdown(
+    r#"<pre><code class="language-rust">let x = 1;</code></pre>"#,
+    opts(),
+  );
+  assert!(md.starts_with("```rust\n"), "code class: {md:?}");
+
+  // TAG_PRE: its own class → deferred fence language (issue #97)
+  let md = html_to_markdown(r#"<pre class="language-js">let x = 1;</pre>"#, opts());
+  assert!(md.starts_with("```js\n"), "pre class: {md:?}");
+
+  // TAG_TH: align → column alignment
+  let md = html_to_markdown(
+    r#"<table><tr><th align="center">H</th></tr><tr><td>c</td></tr></table>"#,
+    opts(),
+  );
+  assert!(md.contains(":---:"), "th align: {md:?}");
+
+  // TAG_META: name/property/content, read only by the frontmatter plugin
+  let md = html_to_markdown(
+    r#"<html><head><title>T</title><meta name="description" content="D"><meta property="og:title" content="O"></head><body><p>x</p></body></html>"#,
+    HTMLToMarkdownOptions {
+      plugins: Some(PluginConfig::frontmatter()),
+      ..Default::default()
+    },
+  );
+  assert!(md.contains("description: D"), "meta name: {md:?}");
+  assert!(md.contains("og:title"), "meta property: {md:?}");
+}
+
+// ── Trailing-whitespace trims must not reach behind an open block frame ──
+
+#[test]
+fn blockquote_content_start_survives_a_trailing_space_trim() {
+  // Regression: a trim reaching behind the blockquote's `content_start` splices
+  // the quote prefix mid-token (`<d> etails>` instead of `> <details>`).
+  let md = html_to_markdown(
+    "> e<blockquote><details>x</details></blockquote>",
+    HTMLToMarkdownOptions::default(),
+  );
+  assert_eq!(md, "\\> e\n\n> <details>x</details>", "got: {md:?}");
+}
+
+#[test]
+fn pre_fence_opener_survives_a_trailing_space_trim() {
+  // Regression: the same reach-back against a code fence eats the opener's
+  // trailing newline, leaving `content_start` past the buffer end and
+  // finalizing panicking.
+  let md = html_to_markdown("# h<pre><td></pre>", HTMLToMarkdownOptions::default());
+  assert_eq!(md, "\\# h\n\n```\n\n```", "got: {md:?}");
+
+  let md = html_to_markdown(
+    "# h<pre><code><td></code></pre>",
+    HTMLToMarkdownOptions::default(),
+  );
+  assert_eq!(md, "\\# h\n\n```\n```", "got: {md:?}");
+
+  // Every block-marker escape (`#`, `-`, `>`) can precede the fence.
+  for html in [
+    "- x<pre><td></pre>",
+    "> q<pre><td></pre>",
+    "#  hash<pre><span></pre>",
+  ] {
+    let md = html_to_markdown(html, HTMLToMarkdownOptions::default());
+    assert!(md.contains("```"), "{html} produced {md:?}");
+  }
+}
+
+#[test]
+fn spacing_check_tolerates_an_empty_text_node() {
+  // A `<td>` inside `<pre>` opens an implied table, and closing the row emits
+  // an empty text node while the last written byte is still content, so
+  // `should_add_spacing_before_text` has no first byte to index.
+  for (html, expected) in [
+    ("<pre><td>\n<th>6</th>\n<l>", "```\n | 6\n```"),
+    // Same shape without the `<pre>`, so no fence is opened.
+    ("<td>\n<th>6</th>\n<l>", "6"),
+    ("<pre><td>\n<th>x</th>\n<span>", "```\n | x\n```"),
+    ("<pre><td></td><th></th>\n<l>", "```\n |\n```"),
+  ] {
+    let md = html_to_markdown(html, HTMLToMarkdownOptions::default());
+    assert_eq!(md, expected, "{html:?} produced {md:?}");
+  }
+}
+
+#[test]
+fn filter_exclude_is_inherited_and_released_at_the_matching_close() {
+  // Exclusion reaches a deep subtree, and the matching close must clear the
+  // marker so later siblings survive.
+  let md = html_to_markdown(
+    r#"<p>Before</p><div class="ad"><section><ul><li><span>Deep</span></li></ul></section></div><p>After</p><div class="ad">Second</div><p>Last</p>"#,
+    HTMLToMarkdownOptions {
+      plugins: Some(PluginConfig {
+        filter: Some(FilterConfig {
+          exclude: Some(vec![".ad".to_string()]),
+          ..Default::default()
+        }),
+        ..Default::default()
+      }),
+      ..Default::default()
+    },
+  );
+  assert!(md.contains("Before"), "got: {md:?}");
+  assert!(md.contains("After"), "got: {md:?}");
+  assert!(md.contains("Last"), "got: {md:?}");
+  assert!(!md.contains("Deep"), "got: {md:?}");
+  assert!(!md.contains("Second"), "got: {md:?}");
+}
+
+#[test]
+fn filter_exclude_nested_match_does_not_release_the_outer_subtree() {
+  // An inner match closing must not clear the outer element's exclusion.
+  let md = html_to_markdown(
+    r#"<div class="ad"><div class="ad">Inner</div><p>StillInside</p></div><p>Outside</p>"#,
+    HTMLToMarkdownOptions {
+      plugins: Some(PluginConfig {
+        filter: Some(FilterConfig {
+          exclude: Some(vec![".ad".to_string()]),
+          ..Default::default()
+        }),
+        ..Default::default()
+      }),
+      ..Default::default()
+    },
+  );
+  assert!(md.contains("Outside"), "got: {md:?}");
+  assert!(!md.contains("Inner"), "got: {md:?}");
+  assert!(!md.contains("StillInside"), "got: {md:?}");
+}
+
+#[test]
+fn filter_include_is_inherited_by_descendants() {
+  let md = html_to_markdown(
+    r#"<div class="content"><section><p>Deep</p></section></div><div class="sidebar"><p>Nope</p></div>"#,
+    HTMLToMarkdownOptions {
+      plugins: Some(PluginConfig {
+        filter: Some(FilterConfig {
+          include: Some(vec![".content".to_string()]),
+          ..Default::default()
+        }),
+        ..Default::default()
+      }),
+      ..Default::default()
+    },
+  );
+  assert!(md.contains("Deep"), "got: {md:?}");
+  assert!(!md.contains("Nope"), "got: {md:?}");
+}
+
+#[test]
+fn filter_include_without_process_children_drops_unmatched_descendants() {
+  // process_children: false means an included ancestor does not carry inclusion
+  // down; only elements matching a selector themselves are kept.
+  let md = html_to_markdown(
+    r#"<div class="content"><p>Child</p></div>"#,
+    HTMLToMarkdownOptions {
+      plugins: Some(PluginConfig {
+        filter: Some(FilterConfig {
+          include: Some(vec![".content".to_string()]),
+          process_children: Some(false),
+          ..Default::default()
+        }),
+        ..Default::default()
+      }),
+      ..Default::default()
+    },
+  );
+  assert!(!md.contains("Child"), "got: {md:?}");
+}
+
 #[test]
 fn filter_exclude_empty_link_title_in_footer() {
   // Regression: <a title="Twitter"> inside excluded <footer> leaked "Twitter" into output

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -655,3 +655,25 @@ fn streaming_keeps_block_newline_count_across_drain() {
     );
   }
 }
+
+// A chunk boundary inside a batched ASCII run must not change whitespace
+// collapsing, at any split point.
+#[test]
+fn streaming_text_whitespace_batching_matches_every_split() {
+  for html in [
+    "<p>one two three four</p>",
+    "<p>a  b</p>",
+    "<p>a   b   c</p>",
+    "<p> leading and trailing </p>",
+    "<p>a <b>bold word</b> c</p>",
+    "<p>one two<span> three four</span>five six</p>",
+    "<p>a\tb c\nd  e</p>",
+    "<p>plain a &amp; b more words</p>",
+    "<p>hazard a *b* c words</p>",
+    "<p>word café word ok</p>",
+    "<pre>keep  double   spaces</pre>",
+    "<p>trailing space before tag <em>x</em></p>",
+  ] {
+    assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
+  }
+}

--- a/packages/mdream/package.json
+++ b/packages/mdream/package.json
@@ -70,7 +70,7 @@
     "test:wiki-small:file": "cat test/fixtures/wikipedia-small.html | node ./bin/mdream.mjs --origin https://en.wikipedia.org | tee test/wiki-markdown.md",
     "build": "obuild",
     "build:native": "cd ../../crates/node && napi build --platform --release",
-    "build:edge": "cd ../../crates/edge && wasm-pack build --target web --out-dir ../../packages/mdream/wasm --out-name mdream_edge && wasm-opt -Oz --enable-bulk-memory --enable-nontrapping-float-to-int --strip-producers ../../packages/mdream/wasm/mdream_edge_bg.wasm -o ../../packages/mdream/wasm/mdream_edge_bg.wasm && wasm-pack build --target bundler --out-dir ../../packages/mdream/wasm-bundler --out-name mdream_edge && wasm-opt -Oz --enable-bulk-memory --enable-nontrapping-float-to-int --strip-producers ../../packages/mdream/wasm-bundler/mdream_edge_bg.wasm -o ../../packages/mdream/wasm-bundler/mdream_edge_bg.wasm",
+    "build:edge": "cd ../../crates/edge && CARGO_PROFILE_RELEASE_OPT_LEVEL=s wasm-pack build --target web --out-dir ../../packages/mdream/wasm --out-name mdream_edge && wasm-opt -O3 --converge --low-memory-unused --enable-bulk-memory --enable-nontrapping-float-to-int --strip-producers ../../packages/mdream/wasm/mdream_edge_bg.wasm -o ../../packages/mdream/wasm/mdream_edge_bg.wasm && CARGO_PROFILE_RELEASE_OPT_LEVEL=s wasm-pack build --target bundler --out-dir ../../packages/mdream/wasm-bundler --out-name mdream_edge && wasm-opt -O3 --converge --low-memory-unused --enable-bulk-memory --enable-nontrapping-float-to-int --strip-producers ../../packages/mdream/wasm-bundler/mdream_edge_bg.wasm -o ../../packages/mdream/wasm-bundler/mdream_edge_bg.wasm",
     "typecheck": "tsc --noEmit",
     "dev:prepare": "obuild --stub",
     "test": "vitest test",

--- a/scripts/build-wasm-edge.mjs
+++ b/scripts/build-wasm-edge.mjs
@@ -3,9 +3,14 @@
  * Every consumer (CI tests, release, bundle-size bench) must build through
  * this script so the shipped artifact matches the measured one.
  *
- * Pipeline: wasm-pack (release, opt-level=s) -> wasm-opt -Oz
+ * Pipeline: wasm-pack (release, opt-level=s)
+ *        -> wasm-opt -O3 --converge --low-memory-unused
  * opt-level=s measured 20% smaller than the default opt-level=3 at a 3-7%
  * throughput cost; opt-level=z was 29% slower on large documents.
+ *
+ * On the wasm-opt side the win comes from --converge. Benchmark this flag set
+ * on arm64, which the perf gate uses: it is worth 4.3% there and only ~1.4% on
+ * x86_64, so a local x86 run reads as noise.
  */
 import { execFileSync } from 'node:child_process'
 import { statSync } from 'node:fs'
@@ -34,10 +39,12 @@ execFileSync('wasm-pack', ['build', '--target', target, '--out-dir', outDir, '--
   env: { ...process.env, CARGO_PROFILE_RELEASE_OPT_LEVEL: 's' },
 })
 
+const OPT_FLAGS = ['-O3', '--converge', '--low-memory-unused']
+
 const wasmFile = resolve(outDir, `${outName}_bg.wasm`)
 const rawSize = statSync(wasmFile).size
 execFileSync('wasm-opt', [
-  '-Oz',
+  ...OPT_FLAGS,
   '--enable-bulk-memory',
   '--enable-nontrapping-float-to-int',
   '--strip-producers',
@@ -47,4 +54,4 @@ execFileSync('wasm-opt', [
 ], { stdio: 'inherit' })
 
 const optSize = statSync(wasmFile).size
-console.log(`${wasmFile}: ${rawSize} -> ${optSize} bytes (wasm-opt -Oz)`)
+console.log(`${wasmFile}: ${rawSize} -> ${optSize} bytes (wasm-opt ${OPT_FLAGS.join(' ')})`)


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore

### 📚 Description

**Attribute scanning** — `TagHandler::needs_attributes: bool` becomes `wanted_attrs: u16`, an `ATTR_*` bitmask naming the attributes a tag's rendering actually reads. Everything outside the mask is now scanned past instead of lowercased, entity-decoded and stored; plugins that read arbitrary names still select `ATTR_ALL`. Quoted values run to their closing quote in a tight loop rather than re-entering the six-way state dispatch per byte, and `is_whitespace` is computed only in the states that consume it. Finding the tag's `>` needs the same quote tracking the attribute scan does, so the two share one walk instead of traversing the region twice: `scan_tag<const EXTRACT: bool>` carries both, and the `ATTR_NONE` instantiation compiles the extraction out so tags that read no attributes still pay only for the terminator search.

**Text and element scanning** — the innermost text-batching predicate and the link-destination scan become lookup tables instead of comparison chains. The fast path absorbs single inter-word spaces, so prose is copied once per text node rather than once per word. The `fn(u8) -> bool` scope predicates become `&'static [bool; 256]` tables, so walking the open-element stack no longer emits an indirect call per frame. Filter inclusion/exclusion is tracked by depth instead of rescanning every ancestor against every selector. The hiding `style` declarations are matched in one pass rather than eight `str::contains` scans. A misplaced `#[inline]` moves back onto `emit_text` — it had drifted between that function's doc comment and `flush_pre_fence`'s, so the cold `format!`-containing function carried the hint and the hot one had none.

Two latent panics turned up while working on this and are fixed here.

**Fixes**

- `should_add_spacing_before_text` indexed byte 0 of the text unconditionally, so an empty text node panicked. Malformed attribute quoting can carry a start tag past its `>` and leave one behind, e.g. `<pre><td>\n<th>6</th>\n<l>`.
- A trailing-space trim could cut behind an open fence, code span, or blockquote frame, leaving the frame's recorded `content_start` past the end of the buffer and panicking on finalize. The same reach-back also corrupted blockquote output, splicing the quote prefix mid-token (`<d> etails>` instead of `> <details>`).

Both are reachable on `main`; regression tests included.

**Build**

- `wasm-opt` runs as `-O3 --converge --low-memory-unused`. Converging is what pays rather than the level, and it takes gzip to 73,614 B from 73,989.
- `build:edge` now passes `CARGO_PROFILE_RELEASE_OPT_LEVEL=s`. It was the one consumer that skipped it, so a local edge build did not match the artifact CI measures and release ships.

the filter plugin path gains far more than the headline — since the old ancestor rescan was O(depth × selectors) per element. Nothing in `bench/perf-ci.mjs` exercises that path, so neither the gain nor a future regression shows up in CI. Might be worth a filter-enabled bench.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selective HTML attribute handling for more efficient and targeted Markdown conversion.
  * Improved filtering behavior for included and excluded content, including nested elements.
* **Bug Fixes**
  * Improved whitespace trimming, spacing, link rendering, and handling of incomplete or quoted attributes.
  * Preserved consistent output across streaming and one-shot conversions.
* **Performance**
  * Optimized HTML parsing, text batching, and WebAssembly builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->