### PR TITLE
chore(ci): unblock bundle-size analysis for PRs that change the lockfile

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -51,9 +51,9 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           pr_sha=$(git rev-parse HEAD)
-          trap 'git checkout --detach "$pr_sha"' EXIT
+          trap 'git checkout --force --detach "$pr_sha"' EXIT
 
-          git checkout --detach "$BASE_SHA"
+          git checkout --force --detach "$BASE_SHA"
           rm -rf /tmp/base-dist
           mkdir -p /tmp/base-dist
 
@@ -70,7 +70,7 @@ jobs:
             echo "The base commit predates the bundle-size harness; bundles will be reported as new."
           fi
 
-          git checkout --detach "$pr_sha"
+          git checkout --force --detach "$pr_sha"
           trap - EXIT
 
       - name: Build pull request bundles

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,12 @@
+# pnpm's self-management rewrites pnpm-lock.yaml as a side effect of unrelated
+# commands, including the read-only `pnpm store path` that actions/setup-node
+# runs to locate its cache. It prepends a second YAML document recording
+# '@pnpm/exe' and pnpm as packageManagerDependencies, which leaves the working
+# tree dirty in every CI job before any install has run. CI already gets its
+# pinned version from pnpm/action-setup reading the packageManager field, so
+# nothing here needs pnpm to manage it.
+managePackageManagerVersions: false
+
 shellEmulator: true
 
 trustPolicy: no-downgrade


### PR DESCRIPTION
`analyze-bundle-size` fails for any pull request that changes `pnpm-lock.yaml`. `Build base branch bundles` aborts on its first command:

```
error: Your local changes to the following files would be overwritten by checkout:
	pnpm-lock.yaml
Aborting
```

That happens 63 ms into the step, before anything in it has run, so the lockfile is already modified by then rather than being modified by the step. It is only fatal when the PR also changes the file — otherwise git carries the modification across and prints `M pnpm-lock.yaml`, which every run of this workflow has been doing. Every lockfile change since the base-checkout step landed in 77fa67a has been a direct push to `main`, so no PR had exercised this until now.

### Cause

Probing after each setup action, the tree is clean through `actions/checkout` and `pnpm/action-setup`, then diverges during `actions/setup-node`. The only pnpm command `setup-node` runs is `pnpm store path --silent`, to locate the store for its cache, and the lockfile's mtime falls between that command starting and returning. Both runs used to confirm this had a pnpm cache miss, so nothing was restored over the file.

pnpm's self-management prepends a second YAML document to `pnpm-lock.yaml`, recording `@pnpm/exe` and `pnpm` as `packageManagerDependencies` — 199 inserted lines, no deletions, 713769 → 719754 bytes, new inode:

```yaml
---
lockfileVersion: '9.0'
importers:
  .:
    configDependencies: {}
    packageManagerDependencies:
      '@pnpm/exe': { specifier: 11.15.1, version: 11.15.1 }
      pnpm:        { specifier: 11.15.1, version: 11.15.1 }
packages:
  '@pnpm/exe@11.15.1': ...
---
lockfileVersion: '9.0'      # the original document, intact
```

Worth noting separately: because `setup-node` has already rewritten the file, every workflow that runs `pnpm install` is installing against a lockfile that differs from the one committed.

### Fix

Two independent changes, both needed:

1. **`managePackageManagerVersions: false`** stops the rewrite. CI already gets its pinned pnpm from `pnpm/action-setup` reading the `packageManager` field, so nothing depends on pnpm managing its own version. The setting is not resolution-affecting, so it is absent from the lockfile's `settings:` block and does not invalidate `--frozen-lockfile`.

2. **`git checkout --force`** on the base and restore checkouts. The configuration change alone is not sufficient and cannot fix its own base: the step checks out the base commit and runs `pnpm install` against *that* commit's configuration, so until the setting is on `main`, self-management is still enabled there. More generally the base commit is arbitrary history, so the step should not depend on what that commit's tooling does to tracked files. `--force` resets tracked files only, so the untracked `node_modules` and `bench/bundle/dist` survive, and the base bundles are already copied to `/tmp/base-dist` before the restore.

### Verification

Verified on a fork PR that changes `pnpm-lock.yaml`, since this repo has no such PR to test against:

| Change | Result |
|---|---|
| baseline | [fails at the base checkout](https://github.com/edevil/mdream/actions/runs/30252503952) |
| configuration only | [base checkout and both base builds succeed, restore aborts on `pnpm-lock.yaml`](https://github.com/edevil/mdream/actions/runs/30253405439) |
| both | [all 19 steps green, report generated](https://github.com/edevil/mdream/actions/runs/30253640967) |

With both applied, all six probes report the lockfile byte-identical to HEAD for the whole job. The workflow change here is identical to the one verified there; only the temporary probe steps are omitted.

Happy to split this into two PRs, or to drop either half, if you would rather take them separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI bundle-size checks to more reliably reset the working state during pull request validation.
  * Prevented package manager commands from unexpectedly rewriting the lockfile in CI.
  * These updates make automated runs more consistent without changing application functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->