### PR TITLE
chore(ci): benchmark link-aligned Rust streaming

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -98,7 +98,7 @@ Vitest bench runs each benchmark for a minimum time window, collecting enough sa
 
 ### CI Regression Benchmarks (`perf-ci.mjs`)
 
-Every PR's Bundle Size comment includes a Performance section produced by `bench/perf-ci.mjs`. It benchmarks the built bench bundles (JS core, minimal preset, stream, Rust edge WASM), running base and PR back-to-back on the same runner so machine variance cancels. The suite converts the 1.8 MB Wikipedia fixture and streams synthetic long text, style, and excluded script bodies through the compiled Rust WASM API. The synthetic cases exercise chunk-boundary scaling that ordinary markup cannot expose. Signals per bench:
+Every PR's Bundle Size comment includes a Performance section produced by `bench/perf-ci.mjs`. It benchmarks the built bench bundles (JS core, minimal preset, stream, Rust edge WASM), running base and PR back-to-back on the same runner so machine variance cancels. The suite converts the 1.8 MB Wikipedia fixture, streams it with link-aligned chunk boundaries, and streams synthetic long text, style, and excluded script bodies through the compiled Rust WASM API. The streaming cases exercise real conversion and chunk-boundary scaling. Signals per bench:
 
 - **Main-thread CPU** (`process.threadCpuUsage()`): the gated timing authority. Excludes V8's background GC/JIT threads and descheduling, which makes it ~3x steadier than process-wide CPU on this allocation-heavy workload. A change is flagged past `max(5%, 2x combined RME)`.
 - **Wall time**: informational only; never drives the verdict.

--- a/bench/perf-ci.mjs
+++ b/bench/perf-ci.mjs
@@ -44,6 +44,7 @@ const bundle = name => import(pathToFileURL(resolve(distDir, name)).href)
 // the fixture always comes from the PR checkout so base and PR chew identical input
 const html = readFileSync(resolve(currentDir, 'bundle/wiki.html'), 'utf8')
 const htmlBytes = new TextEncoder().encode(html)
+const htmlAnchorChunks = splitAfterAnchors(html)
 const STREAM_CHUNK_SIZE = 16 * 1024
 const RUST_STREAM_CHUNK_SIZE = 8 * 1024
 const RUST_STREAM_BODY_SIZE = 2 * 1024 * 1024
@@ -59,6 +60,19 @@ function stats(samples) {
   const variance = samples.reduce((a, b) => a + (b - mean) ** 2, 0) / (samples.length - 1)
   const sem = Math.sqrt(variance) / Math.sqrt(samples.length)
   return { value: mean, rme: (sem * 1.96 / mean) * 100 } // 95% CI as a percentage of the mean
+}
+
+function splitAfterAnchors(source) {
+  const chunks = []
+  let start = 0
+  for (const match of source.matchAll(/<\/a\s*>/gi)) {
+    const end = match.index + match[0].length
+    chunks.push(source.slice(start, end))
+    start = end
+  }
+  if (start < source.length)
+    chunks.push(source.slice(start))
+  return chunks
 }
 
 // per batch, record both wall time and main-thread CPU time (user+system); the
@@ -155,6 +169,20 @@ async function rustBenches() {
     }
   }
 
+  function drainRustChunks(glue, chunks) {
+    const stream = new glue.MarkdownStream(undefined)
+    let outputLength = 0
+    try {
+      for (const chunk of chunks)
+        outputLength += stream.processChunk(chunk).length
+      outputLength += stream.finish().length
+      return outputLength
+    }
+    finally {
+      stream.free()
+    }
+  }
+
   const { glue, instance } = await loadRust('timing')
   const convertRust = () => glue.htmlToMarkdown(html, undefined)
   const wikiTimes = await timeBenches('rust-wiki', 'Rust edge (WASM) · wiki', convertRust, { warmup: 5, reps: 16, runs: 8 })
@@ -174,11 +202,22 @@ async function rustBenches() {
     () => drainRustStream(glue, styleRun),
     streamTimeOptions,
   )
+  const anchorStreamTimes = await timeBenches(
+    'rust-stream-wiki-anchors',
+    'Rust stream (WASM) · wiki at link boundaries',
+    () => drainRustChunks(glue, htmlAnchorChunks),
+    { warmup: 1, reps: 8, runs: 2 },
+  )
 
   // Use a fresh WASM instance so earlier fixtures cannot set the memory high-water mark.
   const { glue: scriptGlue, instance: scriptInstance } = await loadRust('script-memory')
   const scriptRun = `<script>${'a'.repeat(RUST_SCRIPT_BODY_SIZE)}</script>`
   drainRustStream(scriptGlue, scriptRun)
+
+  // Use the full fixture with a boundary after every link. This covers normal
+  // conversion while exposing retention hidden by fixed-size transport frames.
+  const { glue: streamWikiGlue, instance: streamWikiInstance } = await loadRust('stream-wiki-memory')
+  drainRustChunks(streamWikiGlue, htmlAnchorChunks)
 
   // linear memory only grows, and after the timed warm runs it has hit its plateau,
   // so this is a deterministic peak (exact byte-for-byte across runs), not a sample
@@ -186,8 +225,10 @@ async function rustBenches() {
     ...wikiTimes,
     ...textTimes,
     ...styleTimes,
+    ...anchorStreamTimes,
     { id: 'rust-wiki-mem', name: 'Rust edge (WASM) · wiki linear memory (peak)', kind: 'alloc', value: wikiMemory },
     { id: 'rust-stream-script-mem', name: 'Rust stream (WASM) · excluded 8 MiB script memory (peak)', kind: 'alloc', value: scriptInstance.memory.buffer.byteLength },
+    { id: 'rust-stream-wiki-anchors-mem', name: 'Rust stream (WASM) · wiki at link boundaries memory (peak)', kind: 'alloc', value: streamWikiInstance.memory.buffer.byteLength },
   ]
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

Related to #178

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Streams the 1.8 MB Wikipedia fixture through Rust WASM with chunks ending after each anchor. Reports CPU, wall time, and peak linear memory; PR #178 moves the memory result from 3.19 MiB to 1.13 MiB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the performance benchmark methodology, including realistic streaming conversions and varied input scenarios.

* **Tests**
  * Expanded regression coverage to measure streaming performance when content is split at link boundaries.
  * Added memory-usage tracking for the new streaming scenario alongside existing conversion benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->