### PR TITLE
fix: drop fallback content of iframe, noframes, noembed and noscript

### DIFF
--- a/crates/core/src/consts.rs
+++ b/crates/core/src/consts.rs
@@ -112,8 +112,9 @@ pub const TAG_DATALIST: u8 = 108;
 pub const TAG_OPTGROUP: u8 = 109;
 pub const TAG_S: u8 = 110;
 pub const TAG_STRIKE: u8 = 111;
+pub const TAG_NOEMBED: u8 = 112;
 
-pub const MAX_TAG_ID: usize = 112;
+pub const MAX_TAG_ID: usize = 113;
 
 /// Reverse lookup: tag ID → static tag name string.
 /// Avoids allocating a String for known tags.
@@ -231,6 +232,7 @@ pub static TAG_NAMES: [&str; MAX_TAG_ID] = {
   names[TAG_CAPTION as usize] = "caption";
   names[TAG_DATALIST as usize] = "datalist";
   names[TAG_OPTGROUP as usize] = "optgroup";
+  names[TAG_NOEMBED as usize] = "noembed";
   names
 };
 
@@ -406,6 +408,7 @@ fn get_tag_id_bytes(bytes: &[u8]) -> Option<u8> {
     b"optgroup" => TAG_OPTGROUP,
     b"article" => TAG_ARTICLE,
     b"address" => TAG_ADDRESS,
+    b"noembed" => TAG_NOEMBED,
     b"strong" => TAG_STRONG,
     b"source" => TAG_SOURCE,
     b"select" => TAG_SELECT,

--- a/crates/core/src/tags.rs
+++ b/crates/core/src/tags.rs
@@ -45,6 +45,16 @@ const NON_NESTING_NO_SPACING: TagHandler = TagHandler {
   ..NONE
 };
 
+// Fallback content a browser with the feature enabled does not render. Both
+// flags are needed: `is_non_nesting` alone emits the raw text,
+// `excludes_text_nodes` alone still parses descendant markup into elements.
+const INERT_RAWTEXT: TagHandler = TagHandler {
+  is_non_nesting: true,
+  excludes_text_nodes: true,
+  spacing: Some(NO_SPACING),
+  ..NONE
+};
+
 // Compile-time tag handler table. No runtime init, no LazyLock, no indirection.
 static TAG_HANDLERS: [Option<TagHandler>; MAX_TAG_ID] = {
   let mut t: [Option<TagHandler>; MAX_TAG_ID] = [None; MAX_TAG_ID];
@@ -302,17 +312,15 @@ static TAG_HANDLERS: [Option<TagHandler>; MAX_TAG_ID] = {
   });
 
   // Non-nesting elements
+  // `textarea`, `xmp`, and `plaintext` are rendered, so their raw text is kept.
   t[TAG_TEXTAREA as usize] = Some(NON_NESTING_NO_SPACING);
-  t[TAG_IFRAME as usize] = Some(NON_NESTING_NO_SPACING);
-  t[TAG_NOFRAMES as usize] = Some(NON_NESTING_NO_SPACING);
   t[TAG_XMP as usize] = Some(NON_NESTING_NO_SPACING);
   t[TAG_PLAINTEXT as usize] = Some(NON_NESTING_NO_SPACING);
 
-  t[TAG_NOSCRIPT as usize] = Some(TagHandler {
-    excludes_text_nodes: true,
-    spacing: Some(NO_SPACING),
-    ..NONE
-  });
+  t[TAG_IFRAME as usize] = Some(INERT_RAWTEXT);
+  t[TAG_NOFRAMES as usize] = Some(INERT_RAWTEXT);
+  t[TAG_NOEMBED as usize] = Some(INERT_RAWTEXT);
+  t[TAG_NOSCRIPT as usize] = Some(INERT_RAWTEXT);
   // <datalist> holds <option> autocomplete data browsers never render; treat
   // the whole body as inert and drop it, mirroring <template>.
   t[TAG_DATALIST as usize] = Some(TagHandler {

--- a/crates/core/tests/templates.rs
+++ b/crates/core/tests/templates.rs
@@ -152,6 +152,34 @@ mod edge_cases {
     assert!(!md.contains("analytics"));
   }
 
+  /// The case above uses an empty `<iframe>` as the body, which leaks nothing
+  /// either way; a body carrying text is what separates dropping it from
+  /// copying it out.
+  #[test]
+  fn fallback_content_is_not_rendered() {
+    for tag in ["iframe", "noframes", "noembed", "noscript"] {
+      let html = format!("<p>before</p><{tag}><p>hidden</p></{tag}><p>after</p>");
+      assert_eq!(
+        convert(&html).trim(),
+        "before\n\nafter",
+        "<{tag}> fallback content should not reach the output"
+      );
+    }
+  }
+
+  /// `textarea`, `xmp`, and `plaintext` are also raw text, but are rendered.
+  #[test]
+  fn rendered_rawtext_keeps_its_body() {
+    for tag in ["textarea", "xmp", "plaintext"] {
+      let html = format!("<p>before</p><{tag}>kept text</{tag}>");
+      let md = convert(&html);
+      assert!(
+        md.contains("kept text"),
+        "<{tag}> body should be kept, got {md:?}"
+      );
+    }
+  }
+
   #[test]
   fn script_content_not_rendered() {
     let html = "<p>Text</p><script>var x = 1;</script><p>More</p>";

--- a/packages/js/src/const.ts
+++ b/packages/js/src/const.ts
@@ -111,9 +111,10 @@ export const TAG_DATALIST = 108 // Inert: <option> children are autocomplete dat
 export const TAG_OPTGROUP = 109
 export const TAG_S = 110
 export const TAG_STRIKE = 111
+export const TAG_NOEMBED = 112
 
 // Maximum tag ID for creating the typed array (update to match the highest tag ID)
-export const MAX_TAG_ID = 112
+export const MAX_TAG_ID = 113
 
 // Node type constants
 export const ELEMENT_NODE = 1
@@ -212,6 +213,7 @@ export const TagIdMap = {
   small: TAG_SMALL,
   noscript: TAG_NOSCRIPT,
   noframes: TAG_NOFRAMES,
+  noembed: TAG_NOEMBED,
   xmp: TAG_XMP,
   plaintext: TAG_PLAINTEXT,
   aside: TAG_ASIDE,

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -72,6 +72,7 @@ import {
   TAG_META,
   TAG_METER,
   TAG_NAV,
+  TAG_NOEMBED,
   TAG_NOFRAMES,
   TAG_NOSCRIPT,
   TAG_OL,
@@ -313,6 +314,15 @@ const Strikethrough: TagHandler = {
 }
 
 // Tag handlers with metadata
+// Fallback content a browser with the feature enabled does not render. Both
+// flags are needed: isNonNesting alone emits the raw text, excludesTextNodes
+// alone still parses descendant markup into elements.
+const INERT_RAWTEXT: TagHandler = {
+  isNonNesting: true,
+  excludesTextNodes: true,
+  spacing: NO_SPACING,
+}
+
 export const tagHandlers: Record<number, TagHandler> = {
   // Numeric tag constants
   [TAG_HEAD]: {
@@ -847,10 +857,7 @@ export const tagHandlers: Record<number, TagHandler> = {
   [TAG_CANVAS]: {
     spacing: NO_SPACING,
   },
-  [TAG_IFRAME]: {
-    isNonNesting: true,
-    spacing: NO_SPACING,
-  },
+  [TAG_IFRAME]: { ...INERT_RAWTEXT },
   [TAG_MAP]: {
     spacing: NO_SPACING,
   },
@@ -904,10 +911,8 @@ export const tagHandlers: Record<number, TagHandler> = {
     spacing: NO_SPACING,
     isInline: true,
   },
-  [TAG_NOSCRIPT]: {
-    excludesTextNodes: true,
-    spacing: NO_SPACING,
-  },
+  [TAG_NOSCRIPT]: { ...INERT_RAWTEXT },
+  [TAG_NOEMBED]: { ...INERT_RAWTEXT },
   [TAG_DATALIST]: {
     // <datalist> holds <option> autocomplete data that browsers never render.
     // Treat the whole body as inert and drop it, mirroring <template>.
@@ -915,10 +920,7 @@ export const tagHandlers: Record<number, TagHandler> = {
     excludesTextNodes: true,
     spacing: NO_SPACING,
   },
-  [TAG_NOFRAMES]: {
-    isNonNesting: true,
-    spacing: NO_SPACING,
-  },
+  [TAG_NOFRAMES]: { ...INERT_RAWTEXT },
   [TAG_XMP]: {
     isNonNesting: true,
     spacing: NO_SPACING,

--- a/packages/mdream/test/unit/nodes/not-supported.test.ts
+++ b/packages/mdream/test/unit/nodes/not-supported.test.ts
@@ -43,4 +43,17 @@ describe.each(engines)('not supported $name', (engineConfig) => {
     })
     expect(markdown).toBe('[Nuxt Concepts](/docs/guide/concepts) Read more in Nuxt Concepts.')
   })
+  // Fallback content for a feature the reader supports: read as raw text, and a
+  // browser with the feature enabled renders none of it.
+  it.each(['iframe', 'noframes', 'noembed', 'noscript'])('drops %s fallback content', async (tag) => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const html = `<p>before</p><${tag}><p>hidden</p></${tag}><p>after</p>`
+    expect(htmlToMarkdown(html, { engine })).toBe('before\n\nafter')
+  })
+
+  // The counterpart: these are raw text too, but are rendered.
+  it.each(['textarea', 'xmp', 'plaintext'])('keeps %s body', async (tag) => {
+    const engine = await resolveEngine(engineConfig.engine)
+    expect(htmlToMarkdown(`<${tag}>kept text</${tag}>`, { engine })).toContain('kept text')
+  })
 })


### PR DESCRIPTION
`iframe`, `noframes`, `noembed` and `noscript` hold fallback content for a feature the reader is assumed to support. A browser with the feature enabled renders none of it, and per the HTML spec's generic raw text element parsing the body is read as raw text, so markup inside it is text rather than markup.

Two flags in the tag table encode that, and each of these elements had only one of them, so all four leaked:

| element | `is_non_nesting` | `excludes_text_nodes` | `<x><p>LEAK</p></x>` produced |
| --- | --- | --- | --- |
| `iframe`, `noframes` | yes | **no** | `<p>LEAK</p>` — raw text copied out verbatim |
| `noscript` | **no** | yes | `LEAK` — inner markup parsed into real elements |
| `noembed` | no tag ID at all | — | `LEAK` — unknown element, children parsed normally |
| `script`, `style` | yes | yes | dropped, correct |

So `<p>a</p><iframe><p>LEAK</p></iframe><p>b</p>` returned `"a\n\n<p>LEAK</p>\n\nb"`, and `<iframe><img src=x onerror=alert(1)></iframe>` emitted that tag verbatim into the Markdown.

The fix is confined to the tag table: the four now share one `INERT_RAWTEXT` handler setting both flags, which is what `script` and `style` already do. `textarea`, `xmp` and `plaintext` are also raw text but browsers *do* render them, so they keep their body.

**Both engines had the identical defect, so both are fixed.** I first sent this for the Rust crate only, and `fixture-parity` correctly rejected it — `media elements produce identical output` failed on `<iframe src="/frame.html">no iframes</iframe>`, Rust `''` vs JS `'no iframes'`. That check is doing its job; the JS change (`packages/js/src/const.ts`, `packages/js/src/tags.ts`) mirrors the Rust one line for line.

### Why the existing test missed it

`noscript_content_not_rendered` uses an empty `<iframe src="analytics">` as the fallback body. That leaks nothing either way, so it passes both before and after. The added tests use a body that carries text, which is what separates dropping the body from copying it into the output, and they assert the opposite direction too so `textarea`/`xmp`/`plaintext` cannot regress into being dropped.

Verified by rebuilding `@mdream/js` with the fix reverted — all four fail:

```
drops iframe fallback content    expected 'before\n\n\<p>hidden\</p>\n\nafter' to be 'before\n\nafter'
drops noscript fallback content  expected 'before\n\nhidden\n\nafter'          to be 'before\n\nafter'
```

### Notes

- `noembed` needed a tag ID; IDs were used through 111, so it takes 112 and `MAX_TAG_ID` becomes 113 in both engines. The only sizing consequence is `depth_map: [u16; MAX_TAG_ID]`, which grows by 2 bytes.
- Rust: 477 passing on `main`, 479 with the two added here. Node: 1431 passing, 0 failures, including `fixture-parity`. `pnpm run lint` clean. `cargo clippy --all-targets` gives an identical warning set before and after, and the three touched Rust files are `rustfmt` clean — the pre-existing formatting differences in `output.rs`/`parse.rs` are untouched.
- `pnpm run typecheck` fails locally on `Cannot find module '../wasm/mdream_edge.js'`, which also fails without my changes; it needs the WASM build step I skipped.
