### PR TITLE
fix: keep the first of a duplicated attribute, not the last

### DIFF
--- a/crates/core/src/scan.rs
+++ b/crates/core/src/scan.rs
@@ -310,6 +310,21 @@ mod tests {
     assert_eq!(a.get("id").map(String::as_str), Some("main"));
   }
 
+  /// A repeated name is a duplicate-attribute parse error and the later one is
+  /// dropped from the token, so the first wins. Names are lowercased first, so
+  /// `HREF` collides with `href`.
+  #[test]
+  fn duplicate_attribute_keeps_the_first() {
+    let a = parse_attributes("href=/first href=/second", ATTR_ALL);
+    assert_eq!(a.get("href").map(String::as_str), Some("/first"));
+
+    let b = parse_attributes("href=/first HREF=/second", ATTR_ALL);
+    assert_eq!(b.get("href").map(String::as_str), Some("/first"));
+
+    let c = parse_attributes("href=\"/1\" href='/2' href=/3", ATTR_ALL);
+    assert_eq!(c.get("href").map(String::as_str), Some("/1"));
+  }
+
   #[test]
   fn parses_valueless_and_empty_attributes() {
     let a = parse_attributes("disabled checked", ATTR_ALL);

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -33,15 +33,14 @@ impl Attributes {
     self.inner.iter().any(|(k, _)| k == key)
   }
 
+  /// The first occurrence of a name wins: the HTML parser treats a repeated
+  /// attribute name as a duplicate-attribute parse error and drops the later
+  /// one, so `<a href=/first href=/second>` links to `/first`.
   #[inline]
   pub fn insert(&mut self, key: String, value: String) {
-    for (k, v) in &mut self.inner {
-      if *k == key {
-        *v = value;
-        return;
-      }
+    if !self.contains_key(&key) {
+      self.inner.push((key, value));
     }
-    self.inner.push((key, value));
   }
 
   #[inline]

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -253,6 +253,20 @@ fn gfm_text_escaping_does_not_repeat_context_escapes() {
   );
 }
 
+/// A browser navigates to the first `href`, so reporting the last one would
+/// point somewhere the reader never goes.
+#[test]
+fn duplicate_attribute_keeps_the_first() {
+  assert_eq!(
+    convert("<a href=/first href=/second>link</a>"),
+    "[link](/first)"
+  );
+  assert_eq!(
+    convert("<img src=/first.png src=/second.png alt=x>"),
+    "![x](/first.png)"
+  );
+}
+
 #[test]
 fn decoded_text_is_serialized_for_its_output_context() {
   assert_eq!(


### PR DESCRIPTION
`Attributes::insert` overwrote an existing name, so a repeated attribute resolved to the last occurrence:

```
<a href=/first href=/second>link</a>        ->  [link](/second)
<img src=/first.png src=/second.png alt=x>  ->  ![x](/second.png)
<a href=/1 href=/2 href=/3>link</a>         ->  [link](/3)
```

Per the spec, a repeated attribute name is a duplicate-attribute parse error and the later attribute is removed from the token, so a browser navigates to `/first`. Reporting the last one points somewhere the reader never goes — which matters for anything reading mdream's output to determine the links a page actually resolves to, since the divergence hides the target rather than exposing it.

Names are lowercased before insertion, so `<a href=/first HREF=/second>` collides too and was also resolving to `/second`.

### Fix

Both callers of `insert` are the parse path in `push_attr`, and `Attributes` models HTML attributes rather than a general map, so the rule belongs in `insert` itself rather than at the call site. The linear scan already located the collision; it now drops the new value instead of assigning it, so there is no extra work — one comparison loop either way.

### Tests

`duplicate_attribute_keeps_the_first` at both layers: attribute parsing (including the mixed-case collision and a quoted/unquoted mix) and conversion output. Both fail on `main`:

```
scan::tests::duplicate_attribute_keeps_the_first   left: Some("/second")     right: Some("/first")
conversion::duplicate_attribute_keeps_the_first    left: "[link](/second)"   right: "[link](/first)"
```

Suite: 477 passing on `main`, 479 with the two added here, no failures. `cargo clippy --all-targets` yields an identical warning set before and after. `types.rs` and `conversion.rs` are `rustfmt` clean, and `scan.rs` still has exactly its two pre-existing formatting differences.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate HTML attribute handling so the first occurrence is preserved and later duplicates are ignored.
  * Ensured links and images consistently use the first `href` or `src` value when duplicates are present.

* **Tests**
  * Added coverage for duplicate attributes, including case-insensitive names and mixed quoting styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->