### PR TITLE
fix(parser): unify attribute tokenization

### DIFF
--- a/bench/perf-ci.mjs
+++ b/bench/perf-ci.mjs
@@ -45,6 +45,7 @@ const bundle = name => import(pathToFileURL(resolve(distDir, name)).href)
 const html = readFileSync(resolve(currentDir, 'bundle/wiki.html'), 'utf8')
 const htmlBytes = new TextEncoder().encode(html)
 const htmlAnchorChunks = splitAfterAnchors(html)
+const attributeHeavyHtml = '<div id="item" class="card primary" data-a="alpha" data-b="beta" aria-label="Card" title="Title"></div>'.repeat(12_000)
 const STREAM_CHUNK_SIZE = 16 * 1024
 const RUST_STREAM_CHUNK_SIZE = 8 * 1024
 const RUST_STREAM_BODY_SIZE = 2 * 1024 * 1024
@@ -258,6 +259,7 @@ async function main() {
 
   const JS_BENCHES = [
     ['core-wiki', 'JS htmlToMarkdown · wiki (1.8 MB)', () => convert(html), undefined],
+    ['core-attributes', 'JS htmlToMarkdown · attribute-heavy (1.2 MB)', () => convert(attributeHeavyHtml), { warmup: 20, reps: 24, runs: 3 }],
     ['minimal-wiki', 'JS minimal preset · wiki', () => convertMinimal(html), { reps: 12, runs: 1 }],
     ['stream-wiki', 'JS stream drain · wiki', drainStream, undefined],
   ]

--- a/crates/core/src/scan.rs
+++ b/crates/core/src/scan.rs
@@ -142,7 +142,12 @@ fn scan_tag<const EXTRACT: bool>(
       continue;
     }
 
-    if c == SLASH_CHAR && i + 1 < chunk_length && bytes[i + 1] == GT_CHAR {
+    let attribute_state = if EXTRACT { scan.state } else { state };
+    if attribute_state != State::UnquotedValue
+      && c == SLASH_CHAR
+      && i + 1 < chunk_length
+      && bytes[i + 1] == GT_CHAR
+    {
       return (true, i + 2, scan.finish(html_chunk, i), true);
     }
     if c == GT_CHAR {
@@ -403,6 +408,12 @@ mod tests {
 
     let b = parse_attributes("alt=Bob\"s", ATTR_ALL);
     assert_eq!(b.get("alt").map(String::as_str), Some("Bob\"s"));
+  }
+
+  #[test]
+  fn slash_inside_an_unquoted_value_is_an_ordinary_character() {
+    let a = parse_attributes("href=/a/b/", ATTR_ALL);
+    assert_eq!(a.get("href").map(String::as_str), Some("/a/b/"));
   }
 
   /// A repeated name is a duplicate-attribute parse error and the later one is

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -1890,8 +1890,12 @@ function setAttribute(
   if (!rawName)
     return attributes
 
+  const name = rawName.toLowerCase()
+  if (Object.hasOwn(attributes, name))
+    return attributes
+
   const result = attributes === EMPTY_ATTRIBUTES ? {} : attributes
-  result[rawName.toLowerCase()] = rawValue.includes('&')
+  result[name] = rawValue.includes('&')
     ? decodeHTMLEntities(rawValue, true)
     : rawValue
   return result
@@ -1918,7 +1922,8 @@ function scanAttributes(
     const charCode = source.charCodeAt(i)
 
     if (stopAtTagEnd && state !== ATTRIBUTE_QUOTED_VALUE) {
-      if (charCode === SLASH_CHAR
+      if (state !== ATTRIBUTE_UNQUOTED_VALUE
+        && charCode === SLASH_CHAR
         && i + 1 < length
         && source.charCodeAt(i + 1) === GT_CHAR) {
         selfClosing = true

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -78,7 +78,6 @@ const APOS_CHAR = 39 // '\''
 const EXCLAMATION_CHAR = 33 // '!'
 const QUESTION_CHAR = 63 // '?'
 const AMPERSAND_CHAR = 38 // '&'
-const BACKSLASH_CHAR = 92 // '\'
 const DASH_CHAR = 45 // '-'
 const SPACE_CHAR = 32 // ' '
 const TAB_CHAR = 9 // '\t'
@@ -86,6 +85,13 @@ const NEWLINE_CHAR = 10 // '\n'
 const FORM_FEED_CHAR = 12 // '\f'
 const CARRIAGE_RETURN_CHAR = 13 // '\r'
 const OPEN_BRACKET_CHAR = 91 // '['
+
+const ATTRIBUTE_GAP = 0
+const ATTRIBUTE_NAME = 1
+const ATTRIBUTE_AFTER_NAME = 2
+const ATTRIBUTE_BEFORE_VALUE = 3
+const ATTRIBUTE_QUOTED_VALUE = 4
+const ATTRIBUTE_UNQUOTED_VALUE = 5
 
 function isAsciiAlpha(code: number): boolean {
   return (code >= 65 && code <= 90) || (code >= 97 && code <= 122)
@@ -1576,7 +1582,7 @@ function processCdataSection(
     return
   }
 
-  // The `'>'` htmlChunk is a deliberate dummy: processTagAttributes hits the
+  // The `'>'` htmlChunk is a deliberate dummy: scanTagAttributes hits the
   // `>` at position 0 and exits immediately, so the synthetic tag has no
   // attributes to parse. Mirrors the Rust engine's synthetic-tag handling.
   const open = processOpeningTag('#cdata-section', -1, '>', 0, state, handleEvent)
@@ -1629,9 +1635,9 @@ function processOpeningTag(
   }
 
   const tagHandler = state.tagOverrideHandlers?.get(tagName) ?? tagHandlers[tagId]
-  const result = processTagAttributes(htmlChunk, i, tagHandler)
+  const result = scanTagAttributes(htmlChunk, i, tagHandler)
 
-  if (!result.complete) {
+  if (result._tag === 'incomplete') {
     return {
       complete: false,
       newPosition: i,
@@ -1860,76 +1866,195 @@ function processOpeningTag(
 }
 
 /**
- * Extract and process HTML tag attributes
+ * Attribute scanning has two consumers: opening-tag parsing stops at `>` while
+ * the public isolated parser commits at EOF. Both use this state machine so tag
+ * completion and extracted values cannot disagree about quote semantics.
  */
-function processTagAttributes(htmlChunk: string, position: number, tagHandler: Node['tagHandler']): {
-  complete: boolean
-  newPosition: number
-  attributes: Record<string, string>
-  selfClosing: boolean
-  attrBuffer: string
-} {
-  let i = position
-  const chunkLength = htmlChunk.length
+type AttributeScanResult
+  = | {
+    _tag: 'complete'
+    newPosition: number
+    attributes: Record<string, string>
+    selfClosing: boolean
+  }
+  | {
+    _tag: 'incomplete'
+    attrBuffer: string
+  }
 
-  const selfClosing = tagHandler?.isSelfClosing || false
-  const attrStartPos = i
-  let insideQuote = false
+function setAttribute(
+  attributes: Record<string, string>,
+  rawName: string,
+  rawValue: string,
+): Record<string, string> {
+  if (!rawName)
+    return attributes
+
+  const result = attributes === EMPTY_ATTRIBUTES ? {} : attributes
+  result[rawName.toLowerCase()] = rawValue.includes('&')
+    ? decodeHTMLEntities(rawValue, true)
+    : rawValue
+  return result
+}
+
+function scanAttributes(
+  source: string,
+  position: number,
+  selfClosing: boolean,
+  stopAtTagEnd: boolean,
+): AttributeScanResult {
+  const length = source.length
+  let attributes = EMPTY_ATTRIBUTES
+  let state = ATTRIBUTE_GAP
+  let nameStart = 0
+  let nameEnd = 0
+  let valueStart = 0
   let quoteChar = 0
-  let hasAttributeContent = false
+  let newPosition = -1
+  let valueEnd = length
+  let i = position
 
-  let prevChar = 0
-  while (i < chunkLength) {
-    const c = htmlChunk.charCodeAt(i)
+  while (i < length) {
+    const charCode = source.charCodeAt(i)
 
-    if (insideQuote) {
-      if (c === quoteChar && prevChar !== BACKSLASH_CHAR) {
-        insideQuote = false
+    if (stopAtTagEnd && state !== ATTRIBUTE_QUOTED_VALUE) {
+      if (charCode === SLASH_CHAR
+        && i + 1 < length
+        && source.charCodeAt(i + 1) === GT_CHAR) {
+        selfClosing = true
+        valueEnd = i
+        newPosition = i + 2
+        break
       }
-      i++
-      continue
-    }
-    else if (c === QUOTE_CHAR || c === APOS_CHAR) {
-      insideQuote = true
-      quoteChar = c
-      hasAttributeContent = true
-    }
-    else if (c === SLASH_CHAR && i + 1 < chunkLength
-      && htmlChunk.charCodeAt(i + 1) === GT_CHAR) {
-      const attrStr = hasAttributeContent ? htmlChunk.substring(attrStartPos, i).trim() : ''
-      return {
-        complete: true,
-        newPosition: i + 2,
-        attributes: hasAttributeContent ? parseAttributes(attrStr) : EMPTY_ATTRIBUTES,
-        selfClosing: true,
-        attrBuffer: attrStr,
+      if (charCode === GT_CHAR) {
+        valueEnd = i
+        newPosition = i + 1
+        break
       }
     }
-    else if (c === GT_CHAR) {
-      const attrStr = hasAttributeContent ? htmlChunk.substring(attrStartPos, i).trim() : ''
-      return {
-        complete: true,
-        newPosition: i + 1,
-        attributes: hasAttributeContent ? parseAttributes(attrStr) : EMPTY_ATTRIBUTES,
-        selfClosing,
-        attrBuffer: attrStr,
-      }
-    }
-    else if (!isWhitespace(c)) {
-      hasAttributeContent = true
-    }
 
+    const isSpace = isWhitespace(charCode)
+    switch (state) {
+      case ATTRIBUTE_GAP:
+        if (!isSpace) {
+          state = ATTRIBUTE_NAME
+          nameStart = i
+        }
+        break
+
+      case ATTRIBUTE_NAME:
+        if (charCode === EQUALS_CHAR || isSpace) {
+          nameEnd = i
+          state = charCode === EQUALS_CHAR
+            ? ATTRIBUTE_BEFORE_VALUE
+            : ATTRIBUTE_AFTER_NAME
+        }
+        break
+
+      case ATTRIBUTE_AFTER_NAME:
+        if (charCode === EQUALS_CHAR) {
+          state = ATTRIBUTE_BEFORE_VALUE
+        }
+        else if (!isSpace) {
+          attributes = setAttribute(
+            attributes,
+            source.substring(nameStart, nameEnd),
+            '',
+          )
+          state = ATTRIBUTE_NAME
+          nameStart = i
+        }
+        break
+
+      case ATTRIBUTE_BEFORE_VALUE:
+        if (charCode === QUOTE_CHAR || charCode === APOS_CHAR) {
+          quoteChar = charCode
+          state = ATTRIBUTE_QUOTED_VALUE
+          valueStart = i + 1
+        }
+        else if (!isSpace) {
+          state = ATTRIBUTE_UNQUOTED_VALUE
+          valueStart = i
+        }
+        break
+
+      case ATTRIBUTE_QUOTED_VALUE:
+        if (charCode === quoteChar) {
+          attributes = setAttribute(
+            attributes,
+            source.substring(nameStart, nameEnd),
+            source.substring(valueStart, i),
+          )
+          state = ATTRIBUTE_GAP
+        }
+        break
+
+      case ATTRIBUTE_UNQUOTED_VALUE:
+        if (isSpace || (!stopAtTagEnd && charCode === GT_CHAR)) {
+          attributes = setAttribute(
+            attributes,
+            source.substring(nameStart, nameEnd),
+            source.substring(valueStart, i),
+          )
+          state = ATTRIBUTE_GAP
+        }
+        break
+    }
     i++
-    prevChar = c
+  }
+
+  if (stopAtTagEnd && newPosition === -1) {
+    return {
+      _tag: 'incomplete',
+      attrBuffer: source.substring(position),
+    }
+  }
+
+  switch (state) {
+    case ATTRIBUTE_NAME:
+      attributes = setAttribute(
+        attributes,
+        source.substring(nameStart, valueEnd),
+        '',
+      )
+      break
+    case ATTRIBUTE_AFTER_NAME:
+    case ATTRIBUTE_BEFORE_VALUE:
+      attributes = setAttribute(
+        attributes,
+        source.substring(nameStart, nameEnd),
+        '',
+      )
+      break
+    case ATTRIBUTE_QUOTED_VALUE:
+    case ATTRIBUTE_UNQUOTED_VALUE:
+      attributes = setAttribute(
+        attributes,
+        source.substring(nameStart, nameEnd),
+        source.substring(valueStart, valueEnd),
+      )
+      break
   }
 
   return {
-    complete: false,
-    newPosition: i,
-    attributes: EMPTY_ATTRIBUTES,
-    selfClosing: false,
-    attrBuffer: htmlChunk.substring(attrStartPos, i),
+    _tag: 'complete',
+    newPosition: stopAtTagEnd ? newPosition : length,
+    attributes,
+    selfClosing,
   }
+}
+
+function scanTagAttributes(
+  htmlChunk: string,
+  position: number,
+  tagHandler: Node['tagHandler'],
+): AttributeScanResult {
+  return scanAttributes(
+    htmlChunk,
+    position,
+    tagHandler?.isSelfClosing || false,
+    true,
+  )
 }
 
 /**
@@ -1939,107 +2064,8 @@ export function parseAttributes(attrStr: string): Record<string, string> {
   if (!attrStr)
     return EMPTY_ATTRIBUTES
 
-  const result: Record<string, string> = {}
-  const len = attrStr.length
-  let i = 0
-
-  // State machine states
-  const WHITESPACE = 0
-  const NAME = 1
-  const AFTER_NAME = 2
-  const BEFORE_VALUE = 3
-  const QUOTED_VALUE = 4
-  const UNQUOTED_VALUE = 5
-
-  let state = WHITESPACE
-  let nameStart = 0
-  let nameEnd = 0
-  let valueStart = 0
-  let quoteChar = 0
-  let name = ''
-
-  while (i < len) {
-    const charCode = attrStr.charCodeAt(i)
-    const isSpace = isWhitespace(charCode)
-
-    switch (state) {
-      case WHITESPACE:
-        if (!isSpace) {
-          state = NAME
-          nameStart = i
-          nameEnd = 0 // Reset nameEnd when starting a new attribute
-        }
-        break
-
-      case NAME:
-        if (charCode === EQUALS_CHAR || isSpace) {
-          nameEnd = i
-          name = attrStr.substring(nameStart, nameEnd).toLowerCase()
-          state = charCode === EQUALS_CHAR ? BEFORE_VALUE : AFTER_NAME
-        }
-        break
-
-      case AFTER_NAME:
-        if (charCode === EQUALS_CHAR) {
-          state = BEFORE_VALUE
-        }
-        else if (!isSpace) {
-          result[name] = ''
-          state = NAME
-          nameStart = i
-          nameEnd = 0 // Reset nameEnd when starting a new attribute
-        }
-        break
-
-      case BEFORE_VALUE:
-        if (charCode === QUOTE_CHAR || charCode === APOS_CHAR) {
-          quoteChar = charCode
-          state = QUOTED_VALUE
-          valueStart = i + 1
-        }
-        else if (!isSpace) {
-          state = UNQUOTED_VALUE
-          valueStart = i
-        }
-        break
-
-      case QUOTED_VALUE:
-        if (charCode === BACKSLASH_CHAR && i + 1 < len) {
-          i++
-        }
-        else if (charCode === quoteChar) {
-          const raw = attrStr.substring(valueStart, i)
-          result[name] = raw.includes('&') ? decodeHTMLEntities(raw, true) : raw
-          state = WHITESPACE
-        }
-        break
-
-      case UNQUOTED_VALUE:
-        if (isSpace || charCode === GT_CHAR) {
-          const raw = attrStr.substring(valueStart, i)
-          result[name] = raw.includes('&') ? decodeHTMLEntities(raw, true) : raw
-          state = WHITESPACE
-        }
-        break
-    }
-
-    i++
-  }
-
-  // Handle the last attribute
-  if (state === QUOTED_VALUE || state === UNQUOTED_VALUE) {
-    if (name) {
-      const raw = attrStr.substring(valueStart, i)
-      result[name] = raw.includes('&') ? decodeHTMLEntities(raw, true) : raw
-    }
-  }
-  else if (state === NAME || state === AFTER_NAME || state === BEFORE_VALUE) {
-    nameEnd = nameEnd || i
-    const currentName = attrStr.substring(nameStart, nameEnd).toLowerCase()
-    if (currentName) {
-      result[currentName] = ''
-    }
-  }
-
-  return result
+  const result = scanAttributes(attrStr, 0, false, false)
+  if (result._tag === 'incomplete')
+    throw new Error('Isolated attribute scans always complete at EOF')
+  return result.attributes === EMPTY_ATTRIBUTES ? {} : result.attributes
 }

--- a/packages/js/test/integration/attribute-tokenization.browser.test.ts
+++ b/packages/js/test/integration/attribute-tokenization.browser.test.ts
@@ -18,6 +18,8 @@ describe('html attribute browser parity', () => {
     String.raw`href="x\\" title=t`,
     String.raw`href="a\b"`,
     `alt=Bob's src=/i.png`,
+    `href=/a/b/ title=t`,
+    `href=/first HREF=/second`,
   ])('matches Chromium for %s', (source) => {
     expect(parseAttributes(source)).toEqual(browserAttributes(source))
   })

--- a/packages/js/test/integration/attribute-tokenization.browser.test.ts
+++ b/packages/js/test/integration/attribute-tokenization.browser.test.ts
@@ -1,0 +1,24 @@
+import { parseAttributes } from '@mdream/js/parse'
+import { describe, expect, it } from 'vitest'
+
+function browserAttributes(source: string): Record<string, string> {
+  const template = document.createElement('template')
+  template.innerHTML = `<a ${source}>link</a>`
+  const anchor = template.content.querySelector('a')!
+  return Object.fromEntries(
+    Array.from(anchor.attributes, attribute => [attribute.name, attribute.value]),
+  )
+}
+
+describe('html attribute browser parity', () => {
+  it.each([
+    String.raw`href="x\" onclick=alert(1)"`,
+    String.raw`href="c:\path\" title=t`,
+    String.raw`href='x\' title=t`,
+    String.raw`href="x\\" title=t`,
+    String.raw`href="a\b"`,
+    `alt=Bob's src=/i.png`,
+  ])('matches Chromium for %s', (source) => {
+    expect(parseAttributes(source)).toEqual(browserAttributes(source))
+  })
+})

--- a/packages/js/test/unit/attribute-tokenization.test.ts
+++ b/packages/js/test/unit/attribute-tokenization.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { htmlToMarkdown } from '../../src'
+import { parseAttributes } from '../../src/parse'
+
+describe('html attribute tokenization', () => {
+  it.each([
+    [
+      String.raw`href="x\" onclick=alert(1)"`,
+      { href: 'x\\', onclick: 'alert(1)"' },
+    ],
+    [
+      String.raw`href="c:\path\" title=t`,
+      { href: 'c:\\path\\', title: 't' },
+    ],
+    [
+      String.raw`href='x\' title=t`,
+      { href: 'x\\', title: 't' },
+    ],
+    [
+      String.raw`href="x\\" title=t`,
+      { href: 'x\\\\', title: 't' },
+    ],
+    [
+      String.raw`href="a\b"`,
+      { href: String.raw`a\b` },
+    ],
+    [
+      `alt=Bob's src=/i.png`,
+      { alt: `Bob's`, src: '/i.png' },
+    ],
+  ])('treats backslashes and quotes as HTML does for %s', (source, expected) => {
+    expect(parseAttributes(source)).toEqual(expected)
+  })
+
+  it('keeps the isolated parser EOF recovery for an unterminated quoted value', () => {
+    expect(parseAttributes('title="unterminated')).toEqual({ title: 'unterminated' })
+  })
+
+  it.each([
+    [
+      String.raw`<a href="x\" onclick=alert(1)">link</a>`,
+      String.raw`[link](<x\\>)`,
+    ],
+    [
+      String.raw`<a href="c:\path\" title=t>link</a>`,
+      String.raw`[link](<c:\\path\\> "t")`,
+    ],
+    [
+      `<p>ok</p><img alt=Bob's src=/i.png><p>after</p>`,
+      `ok\n\n![Bob's](/i.png)\n\nafter`,
+    ],
+  ])('keeps conversion aligned with browser attributes for %s', (html, expected) => {
+    expect(htmlToMarkdown(html)).toBe(expected)
+  })
+})

--- a/packages/js/test/unit/attribute-tokenization.test.ts
+++ b/packages/js/test/unit/attribute-tokenization.test.ts
@@ -28,6 +28,10 @@ describe('html attribute tokenization', () => {
       `alt=Bob's src=/i.png`,
       { alt: `Bob's`, src: '/i.png' },
     ],
+    [
+      `href=/first HREF=/second`,
+      { href: '/first' },
+    ],
   ])('treats backslashes and quotes as HTML does for %s', (source, expected) => {
     expect(parseAttributes(source)).toEqual(expected)
   })
@@ -48,6 +52,10 @@ describe('html attribute tokenization', () => {
     [
       `<p>ok</p><img alt=Bob's src=/i.png><p>after</p>`,
       `ok\n\n![Bob's](/i.png)\n\nafter`,
+    ],
+    [
+      `<a href=/a/b/>link</a>`,
+      `[link](/a/b/)`,
     ],
   ])('keeps conversion aligned with browser attributes for %s', (html, expected) => {
     expect(htmlToMarkdown(html)).toBe(expected)

--- a/packages/js/test/unit/streaming-parity.test.ts
+++ b/packages/js/test/unit/streaming-parity.test.ts
@@ -41,6 +41,10 @@ describe('streaming parity with the Rust core', () => {
       `<p>ok</p><img alt=Bob's src=/i.png><p>after</p>`,
       `ok\n\n![Bob's](/i.png)\n\nafter`,
     ],
+    [
+      `<a href=/a/b/>link</a>`,
+      `[link](/a/b/)`,
+    ],
   ])('keeps malformed attribute recovery stable across every split for %s', async (html, expected) => {
     expect(htmlToMarkdown(html)).toBe(expected)
     await expectStreamingParity(html)

--- a/packages/js/test/unit/streaming-parity.test.ts
+++ b/packages/js/test/unit/streaming-parity.test.ts
@@ -29,6 +29,24 @@ async function expectStreamingParity(html: string, options: Partial<MdreamOption
 
 describe('streaming parity with the Rust core', () => {
   it.each([
+    [
+      String.raw`<a href="x\" onclick=alert(1)">link</a>`,
+      String.raw`[link](<x\\>)`,
+    ],
+    [
+      String.raw`<a href="c:\path\" title=t>link</a>`,
+      String.raw`[link](<c:\\path\\> "t")`,
+    ],
+    [
+      `<p>ok</p><img alt=Bob's src=/i.png><p>after</p>`,
+      `ok\n\n![Bob's](/i.png)\n\nafter`,
+    ],
+  ])('keeps malformed attribute recovery stable across every split for %s', async (html, expected) => {
+    expect(htmlToMarkdown(html)).toBe(expected)
+    await expectStreamingParity(html)
+  })
+
+  it.each([
     '<pre><code>const x = `hi $' + '{y}`;</code></pre>',
     '<p>use <code>a`b</code> here</p>',
     '<table><tr><td>a`b</td><td>c\\d</td></tr></table>',

--- a/packages/mdream/test/unit/nodes/links.test.ts
+++ b/packages/mdream/test/unit/nodes/links.test.ts
@@ -2,6 +2,20 @@ import { describe, expect, it } from 'vitest'
 import { engines, htmlToMarkdown, resolveEngine } from '../../utils/engines'
 
 describe.each(engines)('links $name', (engineConfig) => {
+  it.each([
+    [
+      String.raw`<a href="x\" onclick=alert(1)">link</a>`,
+      String.raw`[link](<x\\>)`,
+    ],
+    [
+      String.raw`<a href="c:\path\" title=t>link</a>`,
+      String.raw`[link](<c:\\path\\> "t")`,
+    ],
+  ])('treats backslashes as ordinary quoted attribute data for %s', async (html, expected) => {
+    const engine = await resolveEngine(engineConfig.engine)
+    expect(htmlToMarkdown(html, { engine })).toBe(expected)
+  })
+
   it('does not double escape protected link text', async () => {
     const engine = await resolveEngine(engineConfig.engine)
     expect(htmlToMarkdown('<a href="/x">a[b] *c*</a>', { engine }))

--- a/packages/mdream/test/unit/nodes/links.test.ts
+++ b/packages/mdream/test/unit/nodes/links.test.ts
@@ -11,7 +11,11 @@ describe.each(engines)('links $name', (engineConfig) => {
       String.raw`<a href="c:\path\" title=t>link</a>`,
       String.raw`[link](<c:\\path\\> "t")`,
     ],
-  ])('treats backslashes as ordinary quoted attribute data for %s', async (html, expected) => {
+    [
+      `<a href=/a/b/>link</a>`,
+      `[link](/a/b/)`,
+    ],
+  ])('keeps attribute tokenization browser-compatible for %s', async (html, expected) => {
     const engine = await resolveEngine(engineConfig.engine)
     expect(htmlToMarkdown(html, { engine })).toBe(expected)
   })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #185

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The JS tag parser and exported `parseAttributes` used separate state machines, which allowed quote and tag completion rules to drift. This replaces both paths with one scanner. Backslashes remain literal inside quoted values, quotes only open at value boundaries, and one pass returns parsed attributes plus tag termination.

The scanner also keeps the first normalized duplicate attribute. JS and Rust now keep a terminal slash inside an unquoted value instead of treating it as a self-closing marker.

Coverage compares direct parsing with Chromium and pins full conversion, every streaming split, JS/Rust parity, malformed recovery, duplicate names, and slash-heavy values.

A focused CI benchmark now measures 1.2 MB of attribute-heavy HTML. Local same-machine results improved CPU from 15.20 ms to 14.17 ms (6.7%) and gated allocation from 12.63 MiB to 11.79 MiB (6.6%).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML attribute parsing for streamed and chunked content, including more reliable handling of quoted/unquoted values and incomplete tags.
  * Fixed edge cases where `/ >` in unquoted attribute values could incorrectly terminate tag parsing.
  * Improved browser-style alignment for attribute tokenization and end-of-file recovery, improving Markdown conversion results.

* **Tests**
  * Added browser parity, streaming parity, and attribute tokenization tests, plus link rendering coverage for quoted attribute backslashes.
  * Added new performance coverage for attribute-heavy HTML conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->