### PR TITLE
fix: apply URL preprocessing before matching empty-link schemes

### DIFF
--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -8,7 +8,7 @@ use crate::types::{
   ElementNode, ExtractedElement, HTMLToMarkdownOptions, OutputFormat, ParsedSelector, TagHandler,
   TailwindData,
 };
-use crate::url::{is_autolink_uri, resolve_url, slugify_heading};
+use crate::url::{is_autolink_uri, is_empty_link_href, resolve_url, slugify_heading};
 use std::borrow::Cow;
 
 mod output;

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -80,14 +80,6 @@ fn write_image_description(output: &mut String, alt: &str) {
   write_ascii_escaped(output, alt, &IMAGE_DESCRIPTION_ESCAPES);
 }
 
-#[inline]
-fn starts_with_ignore_ascii_case(value: &str, prefix: &[u8]) -> bool {
-  value
-    .as_bytes()
-    .get(..prefix.len())
-    .is_some_and(|candidate| candidate.eq_ignore_ascii_case(prefix))
-}
-
 impl ConvertState {
   #[inline]
   fn inline_marker_type(tag_id: u8) -> Option<u8> {
@@ -500,10 +492,7 @@ impl ConvertState {
         if self.clean_flags & CLEAN_EMPTY_LINKS != 0 {
           let node = &self.stack[self.stack.len() - 1];
           if let Some(href) = node.attributes.get("href")
-            && (href == "#"
-              || starts_with_ignore_ascii_case(href, b"javascript:")
-              || starts_with_ignore_ascii_case(href, b"data:")
-              || starts_with_ignore_ascii_case(href, b"vbscript:"))
+            && is_empty_link_href(href)
           {
             self.skip_current_link = true;
             self.last_node_is_inline = is_inline;

--- a/crates/core/src/url.rs
+++ b/crates/core/src/url.rs
@@ -24,6 +24,55 @@ pub(crate) fn is_autolink_uri(s: &str) -> bool {
     .any(|b| b == b' ' || b == b'<' || b == b'>' || b == b'\n' || b == b'\r' || b == b'\t')
 }
 
+/// Whether the significant bytes of `rest` start with `scheme`, ignoring case.
+/// Tab, LF and CR are skipped: the URL parser removes them before the scheme,
+/// so `java\tscript:` is the `javascript:` scheme.
+fn scheme_matches(rest: &[u8], scheme: &[u8]) -> bool {
+  let mut matched = 0;
+  for &byte in rest {
+    if matches!(byte, b'\t' | b'\n' | b'\r') {
+      continue;
+    }
+    if !byte.eq_ignore_ascii_case(&scheme[matched]) {
+      return false;
+    }
+    matched += 1;
+    if matched == scheme.len() {
+      return true;
+    }
+  }
+  false
+}
+
+/// Whether `href` cannot represent meaningful navigation: a bare `#`, or a
+/// `javascript:`, `data:` or `vbscript:` URL.
+///
+/// Mirrors the URL parser's preprocessing, so `" javascript:"` and the decoded
+/// form of `java&#9;script:` are recognised. An interior space is *not* removed
+/// by the URL parser, so `java script:x` stays an ordinary relative URL.
+pub(crate) fn is_empty_link_href(href: &str) -> bool {
+  let bytes = href.as_bytes();
+  // Leading and trailing C0 controls and spaces are stripped. UTF-8
+  // continuation bytes are all >= 0x80, so this cannot split a character.
+  let start = bytes
+    .iter()
+    .position(|&byte| byte > b' ')
+    .unwrap_or(bytes.len());
+  let end = bytes
+    .iter()
+    .rposition(|&byte| byte > b' ')
+    .map_or(start, |last| last + 1);
+  let rest = &bytes[start..end];
+
+  match rest.first().map(u8::to_ascii_lowercase) {
+    Some(b'#') => rest.len() == 1,
+    Some(b'j') => scheme_matches(rest, b"javascript:"),
+    Some(b'd') => scheme_matches(rest, b"data:"),
+    Some(b'v') => scheme_matches(rest, b"vbscript:"),
+    _ => false,
+  }
+}
+
 /// Check if a query parameter key is a tracking parameter.
 #[inline]
 pub(crate) fn is_tracking_param(key: &str) -> bool {
@@ -243,6 +292,73 @@ pub(crate) fn resolve_url<'a>(url: &'a str, origin: Option<&str>, clean: bool) -
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  #[test]
+  fn empty_link_href_applies_url_preprocessing() {
+    for href in ["#", "javascript:void(0)", "data:text/html,x", "vbscript:x"] {
+      assert!(is_empty_link_href(href), "{href:?}");
+    }
+    // Leading C0 controls and spaces are ignored by the URL parser.
+    for href in [
+      " javascript:void(0)",
+      "\tjavascript:void(0)",
+      "\njavascript:void(0)",
+      "\rjavascript:void(0)",
+      "\u{1}javascript:void(0)",
+      "  \t javascript:void(0)",
+      " data:text/html,x",
+      " vbscript:x",
+    ] {
+      assert!(is_empty_link_href(href), "{href:?}");
+    }
+    // Tab, LF and CR are removed anywhere in the scheme.
+    for href in [
+      "java\tscript:void(0)",
+      "java\nscript:void(0)",
+      "java\rscript:void(0)",
+      "j\ta\nv\ra\tscript:void(0)",
+      "javascript\t:void(0)",
+      "da\tta:x",
+      "vb\tscript:x",
+      " java\tscript:void(0)",
+    ] {
+      assert!(is_empty_link_href(href), "{href:?}");
+    }
+    // Case folding, with controls interleaved.
+    for href in [
+      "JavaScript:x",
+      " JAVASCRIPT:x",
+      "\tJaVa\tScRiPt:x",
+      "DATA:x",
+    ] {
+      assert!(is_empty_link_href(href), "{href:?}");
+    }
+    // A bare `#` keeps its meaning through surrounding whitespace.
+    for href in [" # ", "#\t", "\t#", "\n#\r"] {
+      assert!(is_empty_link_href(href), "{href:?}");
+    }
+
+    // An interior space is NOT removed, so the scheme is not `javascript:`.
+    for href in [
+      "java script:x",
+      "notjavascript:x",
+      "/javascript/guide",
+      "https://x.com/a",
+      "javascript",
+      "#section",
+      " #section",
+      "#a\tb",
+      "",
+      "   ",
+      "mailto:a@b.c",
+    ] {
+      assert!(!is_empty_link_href(href), "{href:?}");
+    }
+    // Only ASCII letters case-fold: `\u{1a}` must not be read as `:`.
+    assert!(!is_empty_link_href("javascript\u{1a}x"));
+    // A non-breaking space is not ASCII whitespace and is not stripped.
+    assert!(!is_empty_link_href("\u{a0}javascript:x"));
+  }
 
   #[test]
   fn autolink_uri_detection() {

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -2349,6 +2349,71 @@ fn clean_strips_executable_link_schemes_case_insensitively() {
 }
 
 #[test]
+fn clean_strips_link_schemes_through_url_preprocessing() {
+  // `url::tests` covers the predicate exhaustively; these pin the wiring for
+  // each mechanism. All are an executable scheme to a browser.
+  for href in [
+    " javascript:void(0)",
+    "\u{1}javascript:void(0)",
+    "java\tscript:void(0)",
+    " data:text/html,payload",
+    "\tVbScRiPt:msgbox(1)",
+  ] {
+    assert_eq!(
+      convert_with_clean(&format!(r#"<a href="{href}">Click</a>"#), clean_all()),
+      "Click",
+      "expected clean.empty_links to strip {href:?}"
+    );
+  }
+}
+
+#[test]
+fn clean_strips_entity_encoded_link_schemes() {
+  // Attribute entities are decoded before the href is inspected. This is the
+  // form these take in real documents.
+  for href in [
+    "java&#9;script:void(0)",
+    "java&#10;script:void(0)",
+    "java&#13;script:void(0)",
+    "&#32;javascript:void(0)",
+  ] {
+    assert_eq!(
+      convert_with_clean(&format!(r#"<a href="{href}">Click</a>"#), clean_all()),
+      "Click",
+      "expected clean.empty_links to strip {href}"
+    );
+  }
+}
+
+#[test]
+fn clean_strips_bare_hash_surrounded_by_whitespace() {
+  for href in [" # ", "#\t", "\t#"] {
+    assert_eq!(
+      convert_with_clean(&format!(r#"<a href="{href}">Link</a>"#), clean_all()),
+      "Link",
+      "expected clean.empty_links to strip {href:?}"
+    );
+  }
+}
+
+#[test]
+fn clean_keeps_links_that_only_look_like_executable_schemes() {
+  // An interior space is not removed, so the scheme is not `javascript:`.
+  for (href, expected) in [
+    ("java script:x", "[Keep](<java script:x>)"),
+    ("notjavascript:x", "[Keep](notjavascript:x)"),
+    ("/javascript/guide", "[Keep](/javascript/guide)"),
+    ("https://x.com/a", "[Keep](https://x.com/a)"),
+  ] {
+    assert_eq!(
+      convert_with_clean(&format!(r#"<a href="{href}">Keep</a>"#), clean_all()),
+      expected,
+      "expected clean.empty_links to keep {href:?}"
+    );
+  }
+}
+
+#[test]
 fn clean_strips_broken_fragment() {
   assert_eq!(
     convert_with_clean(r##"<a href="#nonexistent">Link</a>"##, clean_all()),

--- a/packages/js/src/utils.ts
+++ b/packages/js/src/utils.ts
@@ -6,25 +6,55 @@ import {
   MAX_LEGACY_ENTITY_NAME_LENGTH,
 } from './entities'
 
-function equalsAsciiCaseInsensitive(value: string, expected: string): boolean {
-  for (let index = 0; index < expected.length; index++) {
-    if ((value.charCodeAt(index) | 32) !== expected.charCodeAt(index))
-      return false
-  }
-  return true
+function lowerAscii(code: number): number {
+  return code >= 65 && code <= 90 ? code + 32 : code
 }
 
-export function isEmptyLinkHref(href: string): boolean {
-  if (href === '#')
-    return true
+/**
+ * Whether the significant characters of `href` in `[start, end)` begin with
+ * `scheme`, ignoring case. Tab, LF and CR are skipped: the URL parser removes
+ * them before the scheme, so `java\tscript:` is `javascript:`.
+ */
+function schemeMatches(href: string, start: number, end: number, scheme: string): boolean {
+  let matched = 0
+  for (let index = start; index < end; index++) {
+    const code = href.charCodeAt(index)
+    if (code === 9 || code === 10 || code === 13)
+      continue
+    if (lowerAscii(code) !== scheme.charCodeAt(matched))
+      return false
+    if (++matched === scheme.length)
+      return true
+  }
+  return false
+}
 
-  switch (href.indexOf(':')) {
-    case 4:
-      return equalsAsciiCaseInsensitive(href, 'data')
-    case 8:
-      return equalsAsciiCaseInsensitive(href, 'vbscript')
-    case 10:
-      return equalsAsciiCaseInsensitive(href, 'javascript')
+/**
+ * Whether `href` cannot represent meaningful navigation: a bare `#`, or a
+ * `javascript:`, `data:` or `vbscript:` URL.
+ *
+ * Mirrors the URL parser's preprocessing, so `' javascript:'` and the decoded
+ * form of `java&#9;script:` are recognised. An interior space is *not* removed
+ * by the URL parser, so `java script:x` stays an ordinary relative URL.
+ */
+export function isEmptyLinkHref(href: string): boolean {
+  // Leading and trailing C0 controls and spaces are stripped.
+  let start = 0
+  while (start < href.length && href.charCodeAt(start) <= 32)
+    start++
+  let end = href.length
+  while (end > start && href.charCodeAt(end - 1) <= 32)
+    end--
+
+  switch (lowerAscii(href.charCodeAt(start))) {
+    case 35 /* # */:
+      return end - start === 1
+    case 106 /* j */:
+      return schemeMatches(href, start, end, 'javascript:')
+    case 100 /* d */:
+      return schemeMatches(href, start, end, 'data:')
+    case 118 /* v */:
+      return schemeMatches(href, start, end, 'vbscript:')
     default:
       return false
   }

--- a/packages/mdream/test/unit/plugins/strip-broken-fragments.test.ts
+++ b/packages/mdream/test/unit/plugins/strip-broken-fragments.test.ts
@@ -149,6 +149,59 @@ describe.each(engines)('clean $name', (engineConfig) => {
       const md = htmlToMarkdown(html, { engine, ...opts })
       expect(md).toBe('[Link](#section)')
     })
+
+    // All of these are the `javascript:` scheme to a browser.
+    it.each([
+      ' javascript:void(0)',
+      '\tjavascript:void(0)',
+      '\njavascript:void(0)',
+      '\u0001javascript:void(0)',
+      'java\tscript:void(0)',
+      'java\nscript:void(0)',
+      'java\rscript:void(0)',
+      ' java\tscript:void(0)',
+      ' data:text/html,payload',
+      'da\tta:text/html,payload',
+      ' vbscript:msgbox(1)',
+      '\tVbScRiPt:msgbox(1)',
+    ])('strips %j', async (href) => {
+      const engine = await resolveEngine(engineConfig.engine)
+      const md = htmlToMarkdown(`<a href="${href}">Click</a>`, { engine, ...opts })
+      expect(md).toBe('Click')
+    })
+
+    // Entity-encoded controls are the form these actually take in real HTML.
+    it.each([
+      'java&#9;script:void(0)',
+      'java&#10;script:void(0)',
+      'java&#13;script:void(0)',
+      '&#32;javascript:void(0)',
+    ])('strips the decoded form of %s', async (href) => {
+      const engine = await resolveEngine(engineConfig.engine)
+      const md = htmlToMarkdown(`<a href="${href}">Click</a>`, { engine, ...opts })
+      expect(md).toBe('Click')
+    })
+
+    it('strips a bare # surrounded by whitespace', async () => {
+      const engine = await resolveEngine(engineConfig.engine)
+      for (const href of [' # ', '#\t', '\t#']) {
+        const md = htmlToMarkdown(`<a href="${href}">Link</a>`, { engine, ...opts })
+        expect(md, href).toBe('Link')
+      }
+    })
+
+    // An interior space is NOT removed, so these stay links.
+    it.each([
+      ['java script:x', '[Keep](<java script:x>)'],
+      ['notjavascript:x', '[Keep](notjavascript:x)'],
+      ['/javascript/guide', '[Keep](/javascript/guide)'],
+      ['https://x.com/a', '[Keep](https://x.com/a)'],
+      ['#section', '[Keep](#section)'],
+    ])('keeps %j', async (href, expected) => {
+      const engine = await resolveEngine(engineConfig.engine)
+      const md = htmlToMarkdown(`<a href="${href}">Keep</a>`, { engine, ...opts })
+      expect(md).toBe(expected)
+    })
   })
 
   describe('disabled by default', () => {


### PR DESCRIPTION
## The defect

`clean.empty_links` compared the raw `href` against the `javascript:`, `data:` and `vbscript:` prefixes. The URL parser first strips leading and trailing C0 controls and spaces, and removes every tab, LF and CR, so hrefs a browser treats as executable schemes were kept as ordinary links:

```js
const clean = { emptyLinks: true }
htmlToMarkdown('<a href=" javascript:void(0)">Click</a>', { clean })
// '[Click](< javascript:void(0)>)'   expected 'Click'

htmlToMarkdown('<a href="java&#9;script:void(0)">Click</a>', { clean })
// '[Click](<java\tscript:void(0)>)'  expected 'Click'
```

Attribute entities are decoded before the href is inspected, so the `&#9;`, `&#10;` and `&#13;` forms arrive as literal control characters and miss the prefix compare for the same reason. That is the form these take in real documents.

To be clear about what this is: `empty_links` is a cleaning option, not a security control. A literal-tab scheme survives as `[x](<java\tscript:x>)`, which `marked` percent-encodes to `java%09script:`, and a plain `javascript:` URL passes through `marked` untouched whether or not this option is on. Sanitising output remains the consumer's job. This is about cleaning fidelity — `href=" javascript:void(0)"` is common in real HTML and should be stripped like its unpadded twin.

## The fix

`is_empty_link_href` applies the parser's preprocessing while comparing: skip leading and trailing C0 controls and spaces, skip tab/LF/CR anywhere in the scheme, fold ASCII case.

An interior space is **not** removed by the URL parser, so `java script:x` stays an ordinary relative URL. A bare `#` now also survives surrounding whitespace (`" # "`).

Dispatching on the first significant byte means the common `https://…` case stops after one comparison instead of three. That leaves `starts_with_ignore_ascii_case` and, on the JS side, `equalsAsciiCaseInsensitive` with no callers, so both are removed.

## Correctness

Decisions are pinned against `new URL(href).protocol`, which encodes exactly the preprocessing at issue, over a generated corpus of 140 hrefs (three schemes × leading space/tab/LF/CR/C0 × interior tab/LF/CR at several offsets × case variants × negatives). **Native Rust, the wasm engine and the JS engine each agree with the oracle on 140/140, and with each other on 140/140.**

Two cases worth calling out, both covered:

- `javascript\u001a` must **not** match. Folding with `| 32` maps `0x1a` onto `:`, which would make it match in JS but not in Rust; the JS side folds only ASCII letters.
- `\u00a0javascript:x` must **not** match. A non-breaking space is not ASCII whitespace and the URL parser does not strip it.

Tests are layered: `url::tests` covers the predicate exhaustively, `crates/core/tests/conversion.rs` pins the wiring for each mechanism plus the entity-decoded forms (only reachable end to end), and the cross-engine suite runs the same cases against both engines. Reverting just the JS predicate fails 17 tests; reverting just `url.rs` fails the unit test and all three end-to-end tests.

Each step of the predicate was separately mutated — leading strip, interior skip, trailing strip, scheme case-folding, dispatch case-folding — and each is caught by 2–4 tests.

## Performance

`empty_links` is opt-in, so default conversions are unaffected. With it enabled (min of 6 interleaved runs):

| case | before | after | |
|---|---|---|---|
| 40k http links | 12.38 ms | 12.51 ms | +1.1% |
| 40k javascript links | 9.77 ms | 10.03 ms | +2.7% |
| 40k fragment links | 10.79 ms | 10.75 ms | -0.4% |
| control: 40k paragraphs, no links | 4.17 ms | 4.16 ms | -0.2% |

The worst case is a document made entirely of `javascript:` links, at roughly 6 ns per stripped link.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved empty-link cleanup to consistently remove bare `#` links and executable URL schemes, including mixed-case, whitespace-obfuscated, and entity-encoded variants.
  * Preserved valid links that only resemble executable schemes, including section fragments and external URLs.
  * Applied consistent behavior across Markdown and JavaScript processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->