### PR TITLE
fix: rebase blockquote offsets when the nested separator collapses

### DIFF
--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -534,6 +534,11 @@ impl ConvertState {
     if !self.plain_text && !enter_is_literal && tag_id == Some(TAG_BLOCKQUOTE) {
       if !self.blockquotes.is_empty() && self.buffer.ends_with("\n\n") {
         self.buffer.pop();
+        // Frames anchored at the old end move with the popped byte. Siblings can
+        // share an offset, so this is not only the innermost. See `trim_floor`.
+        for frame in &mut self.blockquotes {
+          frame.content_start = frame.content_start.min(self.buffer.len());
+        }
       }
       self.blockquotes.push(BlockquoteFrame {
         content_start: self.buffer.len(),

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -886,6 +886,29 @@ fn nested_blockquotes() {
   assert!(result.contains("> > Inner"));
 }
 
+// Text before an immediately nested blockquote leaves the outer frame anchored at the
+// buffer end, which the separator collapse stranded; the outer quote then rendered one
+// byte too far in, as `>>` with a doubled space.
+#[test]
+fn nested_blockquotes_after_text_quote_both_levels() {
+  assert_eq!(
+    convert("Lead<blockquote><blockquote>Inner</blockquote></blockquote>"),
+    "Lead\n> > Inner"
+  );
+  assert_eq!(
+    convert("Lead<blockquote><blockquote><blockquote>Deep</blockquote></blockquote></blockquote>"),
+    "Lead\n> > > Deep"
+  );
+  // Strands two frames at once; rebasing only the innermost glues the outer marker
+  // to the next one.
+  assert_eq!(
+    convert(
+      "<pre><blockquote><br><blockquote><blockquote>x</blockquote></blockquote></blockquote></pre>"
+    ),
+    "```\n> > > x\n\n\n```"
+  );
+}
+
 #[test]
 fn blockquote_with_paragraphs() {
   assert_eq!(

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -206,6 +206,35 @@ fn streaming_blockquote_structure_matches_every_split() {
   }
 }
 
+// The nested-separator collapse stranded `content_start` past the buffer end, which
+// panicked when streaming picked a yield boundary. Needs leading text so a drain
+// rebases first, and no text between the opens so the outer frame is still empty.
+#[test]
+fn streaming_nested_blockquote_separator_collapse_matches_one_shot() {
+  for html in [
+    "a<blockquote><blockquote>",
+    "a<blockquote><blockquote>x",
+    "a<blockquote><blockquote></blockquote></blockquote>",
+    "a<blockquote><blockquote>b</blockquote></blockquote>",
+    // Any block open as the inner element.
+    "a<blockquote><div><blockquote>",
+    "a<blockquote><blockquote><blockquote><blockquote>d",
+    // Strands two frames at once, so rebasing only the innermost still panics.
+    "<pre><blockquote><br><blockquote><blockquote>",
+    // A list indent makes `content_start` non-zero within the line.
+    "<ul><li>a<blockquote><blockquote>x</blockquote></blockquote></li></ul>",
+  ] {
+    assert_stream_matches(html, HTMLToMarkdownOptions::default());
+    assert_stream_matches(
+      html,
+      HTMLToMarkdownOptions {
+        clean: Some(safe_clean()),
+        ..Default::default()
+      },
+    );
+  }
+}
+
 #[test]
 fn streaming_large_nested_blockquote_drains_without_changing_output() {
   let mut html = String::from("<blockquote><blockquote><blockquote>");


### PR DESCRIPTION
## The defect

Entering a nested `<blockquote>` collapses the blank line between the two `>` markers by popping a byte off the output buffer. `BlockquoteFrame::content_start` is an absolute offset into that buffer, and it sits *at* the buffer's end for a frame whose content has not started yet — so the pop leaves such frames pointing one byte past the end. Nothing rebased them.

Streaming then panics choosing a yield boundary:

```rust
let mut p = MarkdownStreamProcessor::new(HTMLToMarkdownOptions::default());
p.process_chunk("a<blockquote><blockquote>");
// end byte index 2 is out of bounds for string of length 1
//   convert/mod.rs, self.buffer[..frame.content_start]
```

25 bytes, default options, every chunk size. It needs the leading text, so a drain rebases the buffer first, and no text between the two opens, so the outer frame is still empty. I hit it on a real page while scanning a corpus of production HTML.

`trim_floor` already documents exactly this hazard for the trailing-space trims:

> blockquotes record offsets whose bytes are delimiter, not spacing; cutting behind one corrupts the block and **leaves `content_start` past the buffer end, which panics on finalize**

The separator collapse is the one buffer-shrinking site that neither consults `trim_floor` nor rebases, so it is the one that can strand a frame. The fix restores that existing rule at the mutation site, next to the rebasing `drain_streamed_prefix` already does.

## It also silently corrupted one-shot output

One-shot doesn't panic, but a stranded offset makes `finalize_blockquote` render the outer quote from one byte too far in — gluing the markers together and doubling the space:

```
Lead<blockquote><blockquote>Inner</blockquote></blockquote>
before: "Lead\n>>  Inner"
after:  "Lead\n> > Inner"
```

**The JS engine already emitted `> > `**, so this was also a live cross-engine divergence. Over an exhaustive token-space sweep, 1030 one-shot outputs change, and the JS engine agrees with the new Rust output on **1030/1030** and with the old on **0/1030**. JS needs no change: it indexes a fragment array rather than byte offsets, so it never had the bug.

## Why every frame, not just the innermost

Sibling frames can share a `content_start`, so one collapse can strand several at once. Rebasing only `blockquotes.last_mut()` — which is what `trim_floor` and the neighbouring `quote_at_start` get away with, since they only need the maximum — **still panics**:

```
<pre><blockquote><br><blockquote><blockquote>
```

That input strands two frames (`content_start` = `[5, 5]`) and is in the test set for exactly this reason. I only found it after widening a fuzz generator toward deeper nesting; a 2000-page corpus and an exhaustive 5-token sweep both said "one frame at a time", and both were too shallow to reach the tie.

## Verification

- **497 Rust tests** (+2 over `main`), **1552 JS** unchanged, clippy warning set identical, `cargo fmt --check` diff identical to `main`'s.
- Both new tests fail on `main` with the exact panic and the exact `>>  ` string.
- **Exhaustive sweep**: 5 tokens over a 15-symbol alphabet, 759,375 inputs x one-shot + 7 chunk sizes.
- **Blockquote-weighted random sweep**: 300,000 inputs up to 11 open quotes deep, x one-shot + 4 chunk sizes. Zero panics.
- All four new expected values verified byte-for-byte against the JS engine.
- Every part of the fix mutation-tested — removing the rebase, `min`->`max`, innermost-only, outermost-only, `len + 1`, `len - 1`, skip-first, and dropping the pop: **8/8 caught**.
- The clamp only runs when the collapse fires (twice in 222 MB of real HTML), so there is nothing measurable to benchmark.

## Out of scope

An inline element left open across an *empty* blockquote (`a<em>e<blockquote>`, `a<a href=u><blockquote>`) diverges streaming-vs-one-shot **identically on `main`** — a separate pre-existing defect. Single-blockquote controls never reach the collapse, which is how I established it's unrelated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed rendering of nested blockquotes following preceding text.
  - Prevented errors during streaming conversion when nested blockquote separators are collapsed.
  - Improved consistency between streaming and one-shot conversion output.
  - Corrected spacing and fence placement in nested blockquotes, including cases involving preformatted content and line breaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->