### PR TITLE
fix: keep the pending inline separator across a drain

### DIFF
--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -1050,7 +1050,7 @@ impl ConvertState {
       if text.as_bytes().iter().all(|&b| is_whitespace(b)) {
         return;
       }
-      let last = self.buffer.as_bytes().last().copied();
+      let last = self.last_output_byte();
       let first = text.as_bytes()[0];
       if !matches!(last, Some(b' ' | b'\n' | b'\t') | None) && !is_whitespace(first) {
         self.buffer.push(' ');
@@ -1537,6 +1537,18 @@ impl ConvertState {
       floor = floor.max(frame.content_start);
     }
     floor
+  }
+
+  /// Byte the next output will follow, or `None` only at the true start of
+  /// output. Draining, or a rewrite that trims what draining retained, can empty
+  /// the buffer mid-document; `flushed_tail` then holds the bytes before it.
+  #[inline]
+  fn last_output_byte(&self) -> Option<u8> {
+    match self.buffer.as_bytes().last().copied() {
+      Some(byte) => Some(byte),
+      None if self.has_streamed_output => Some(self.flushed_tail[1]),
+      None => None,
+    }
   }
 
   #[inline]
@@ -2189,7 +2201,7 @@ impl ConvertState {
       {
         self.pending_inline_whitespace = false;
       } else if let Some(first) = first_output {
-        let last = self.buffer.as_bytes().last().copied();
+        let last = self.last_output_byte();
         if !matches!(last, Some(b' ' | b'\n' | b'\t') | None) && !is_whitespace(first) {
           self.buffer.push(' ');
         }
@@ -2500,6 +2512,22 @@ mod tests {
     state.write_output(true, false, 2, Some("next"), false);
 
     assert_eq!(state.buffer, "next");
+  }
+
+  // Draining, and then a rewrite trimming what draining retained, leaves the
+  // buffer empty mid-document; only a buffer nothing has streamed past is the
+  // start of output.
+  #[test]
+  fn last_output_byte_sees_through_a_drain() {
+    let mut state = ConvertState::new(HTMLToMarkdownOptions::default(), 64, OutputFormat::Markdown);
+    assert_eq!(state.last_output_byte(), None);
+
+    state.has_streamed_output = true;
+    state.flushed_tail = *b"xy";
+    assert_eq!(state.last_output_byte(), Some(b'y'));
+
+    state.buffer.push('z');
+    assert_eq!(state.last_output_byte(), Some(b'z'));
   }
 
   #[test]

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -798,3 +798,22 @@ fn streaming_text_whitespace_batching_matches_every_split() {
     assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
   }
 }
+
+// A `<br>`'s hard break, trimmed off when the inline element closes, can be the
+// whole buffer after a drain, so the trim empties it and the pending separator
+// was suppressed as if this were the start of output. Each case needs a block
+// inside the inline element for the drain to reach that far, and content after
+// the close to want the separator.
+#[test]
+fn streaming_pending_space_after_drained_hard_break_matches_one_shot() {
+  for html in [
+    "<span><p></p>x<br>\n</span>a",
+    "<span><hr>x<br> </span>a",
+    "<ul><li><span><p></p>x<br>\n</span>a</li></ul>",
+    // A link's `[` is generated markdown, resolved at the other call site.
+    "<p><span><em>x</em><br /> </span><a href=\"u\">a",
+  ] {
+    assert_stream_matches(html, HTMLToMarkdownOptions::default());
+    assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
+  }
+}


### PR DESCRIPTION
## The defect

Streaming drops a space that one-shot conversion keeps:

```rust
let html = "<span><p></p>x<br>\n</span>a";
html_to_markdown(html, Default::default());   // "x a"
// streamed in any chunking:                  // "xa"
```

27 bytes, default options, at 20 of the 27 possible chunk sizes. The link form is the same bug one call site over:

```
<p><span><em>x</em><br /> </span><a href="u">a     one-shot "*x* [a](u)"   streamed "*x*[a](u)"
```

I found it scanning a corpus of production pages for streaming/one-shot divergence.

## Root cause

`<br>` emits the GFM hard break `  \n`. The retro-trim that fires when the enclosing inline element closes cuts that trailing whitespace back off, handing the separator to `pending_inline_whitespace` to re-emit later. Draining can leave the hard break as the *entire* buffer, so the trim empties it — and the flush then read the empty buffer as the start of output, where a separator would be a stray leading space, and dropped it.

`flushed_tail` already exists for exactly this, and its doc comment already states the rule:

> Last two bytes flushed out of the front of the buffer by draining. **When a later rewrite trims the retained buffer empty, spacing and newline counts still need the same two-byte context one-shot conversion sees.**

Three places honour it. The pending-separator flush did not — and `emit_text_with_generated_markdown` **already honours it 30 lines further down**, for its other spacing decision:

```rust
let last_char = if buf_len > 0 {
  buf_bytes[buf_len - 1]
} else if self.has_streamed_output {
  // The buffer was drained (and possibly trimmed) empty, but earlier output
  // ended with this byte. ...
  self.flushed_tail[1]
```

So this restores an invariant the codebase already documents, at the two sites that skipped it.

## Two call sites

Fixing the text path left a second divergence in the corpus. The survivor was the same bug for generated markdown: a link's `[` resolves the pending separator in `write_output`, which had its own copy of the identical start-of-output test. That is why this adds one `last_output_byte()` helper rather than duplicating the change.

## Scope

- **One-shot output is unchanged.** This makes streaming agree with one-shot, not the reverse.
- **The JS engine is unaffected** — it indexes a fragment array rather than tracking a drained byte offset, and has streaming/one-shot parity here either way. No JS change, and its 1552 tests are untouched.
- Independent of #190; the two only touch adjacent lines at the end of `streaming_drain.rs`.
- Out of scope, and **pre-existing**: for these inputs Rust one-shot emits `x a` while JS emits `x  \na`, keeping the break. Before the hard break became `  \n` Rust emitted `x\ a`, so the break was already being eaten and that divergence is older than this code path. Worth a separate look, but not something a streaming-parity fix should change.

## Verification

- **497 Rust tests**, 1552 JS unchanged, clippy warning set identical, `cargo fmt --check` diff identical to `main`'s.
- The added streaming test fails on `main` with exactly `"xa"` vs `"x a"`; reverting either call site alone still fails it.
- Divergences over a 2097-page corpus of production HTML: **2 → 0** (also 0 at chunk 512 and 4096).
- Exhaustive token sweeps at depth 3 (32,768 inputs) and depth 4 (1,048,576), and 3 × 100k random documents, all × 7 chunk sizes: **byte-identical divergence sets to before the change**, so nothing regressed.
- A directed sweep built around this bug's shape is the load-bearing check, since a random sweep will not reach an 8-token sequence by chance: **~5,800 of 50,000 inputs divergent without the fix, 0 with it, across 5 seeds.**
- Every part of the change mutation-tested — dropping the `has_streamed_output` guard, `flushed_tail[0]` for `[1]`, always using the flushed byte, clamping to a non-whitespace `0`, inverting the guard, always returning `None`: **7/7 caught**.

The `| None` arm in the two predicates is left exactly as it was. Dropping it from both changes no output over 1,179,648 exhaustive inputs (one-shot and streamed), so it is unreachable defensive code rather than something this fix relies on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed spacing inconsistencies in streamed Markdown output after hard breaks and drained content.
  * Ensured streamed output matches one-shot conversion results, including when inline elements close after a hard break.
  * Improved handling across different input chunk boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->