### PR TITLE
fix(extraction): support CSS selector lists

### DIFF
--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -1,12 +1,11 @@
 use crate::consts::*;
 use crate::entities::{decode_html_entities, decode_html_entities_for_markdown};
 use crate::scan::{is_whitespace, process_comment_or_doctype, process_tag_attributes};
-use crate::selector::{matches_selector, parse_css_selector};
+use crate::selector::{ParsedSelectorList, matches_selector_list, parse_css_selector_list};
 use crate::tags::get_tag_handler;
 use crate::tailwind::process_tailwind_classes;
 use crate::types::{
-  ElementNode, ExtractedElement, HTMLToMarkdownOptions, OutputFormat, ParsedSelector, TagHandler,
-  TailwindData,
+  ElementNode, ExtractedElement, HTMLToMarkdownOptions, OutputFormat, TagHandler, TailwindData,
 };
 use crate::url::{is_autolink_uri, is_empty_link_href, resolve_url, slugify_heading};
 use std::borrow::Cow;
@@ -338,12 +337,12 @@ pub struct ConvertState {
   pub frontmatter_title: Option<String>,
   pub frontmatter_meta: Vec<(String, String)>,
 
-  extraction_parsed_selectors: Vec<(String, ParsedSelector)>,
+  extraction_parsed_selectors: Vec<(String, ParsedSelectorList)>,
   extraction_tracked: Vec<TrackedExtraction>,
   pub extraction_results: Vec<ExtractedElement>,
 
-  filter_include_parsed: Vec<(String, ParsedSelector)>,
-  filter_exclude_parsed: Vec<(String, ParsedSelector)>,
+  filter_include_parsed: Vec<(String, ParsedSelectorList)>,
+  filter_exclude_parsed: Vec<(String, ParsedSelectorList)>,
   filter_process_children: bool,
 
   // === Markdown output state ===
@@ -587,7 +586,7 @@ impl ConvertState {
         s.extraction_parsed_selectors = extraction
           .selectors
           .iter()
-          .map(|sel| (sel.clone(), parse_css_selector(sel)))
+          .map(|sel| (sel.clone(), parse_css_selector_list(sel)))
           .collect();
       }
       if let Some(filter) = &plugins.filter {
@@ -595,13 +594,13 @@ impl ConvertState {
         if let Some(incl) = &filter.include {
           s.filter_include_parsed = incl
             .iter()
-            .map(|sel| (sel.clone(), parse_css_selector(sel)))
+            .map(|sel| (sel.clone(), parse_css_selector_list(sel)))
             .collect();
         }
         if let Some(excl) = &filter.exclude {
           s.filter_exclude_parsed = excl
             .iter()
-            .map(|sel| (sel.clone(), parse_css_selector(sel)))
+            .map(|sel| (sel.clone(), parse_css_selector_list(sel)))
             .collect();
         }
         s.filter_process_children = filter.process_children.unwrap_or(true);

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -422,7 +422,7 @@ impl ConvertState {
       || self
         .filter_exclude_parsed
         .iter()
-        .any(|(_, parsed)| matches_selector(&node, parsed))
+        .any(|(_, parsed)| matches_selector_list(&node, parsed))
     {
       return 1;
     }
@@ -430,7 +430,7 @@ impl ConvertState {
       self
         .filter_include_parsed
         .iter()
-        .any(|(_, parsed)| matches_selector(&node, parsed)),
+        .any(|(_, parsed)| matches_selector_list(&node, parsed)),
     ) * 2
   }
 
@@ -1055,7 +1055,7 @@ impl ConvertState {
           || self
             .filter_exclude_parsed
             .iter()
-            .any(|(_, parsed)| matches_selector(&tag, parsed))
+            .any(|(_, parsed)| matches_selector_list(&tag, parsed))
         {
           skip_node = true;
           filter_excluded = true;
@@ -1070,7 +1070,7 @@ impl ConvertState {
             && self
               .filter_include_parsed
               .iter()
-              .any(|(_, parsed)| matches_selector(&tag, parsed))
+              .any(|(_, parsed)| matches_selector_list(&tag, parsed))
           {
             match_found = true;
             if self.filter_included_since_depth.is_none() {
@@ -1189,7 +1189,7 @@ impl ConvertState {
     {
       let stack_depth = self.stack.len();
       for (selector, parsed) in &self.extraction_parsed_selectors {
-        if matches_selector(element, parsed) {
+        if matches_selector_list(element, parsed) {
           let attrs: Vec<(String, String)> = element
             .attributes
             .iter()
@@ -1269,18 +1269,19 @@ impl ConvertState {
     // Extraction finalize
     if !self.extraction_tracked.is_empty() {
       let current_depth = self.stack.len();
-      let mut i = 0;
-      while i < self.extraction_tracked.len() {
-        if self.extraction_tracked[i].stack_depth == current_depth {
-          let tracked = self.extraction_tracked.swap_remove(i);
-          self.extraction_results.push(ExtractedElement {
+      if let Some(first) = self
+        .extraction_tracked
+        .iter()
+        .position(|tracked| tracked.stack_depth == current_depth)
+      {
+        let extraction_results = &mut self.extraction_results;
+        for tracked in self.extraction_tracked.drain(first..) {
+          extraction_results.push(ExtractedElement {
             selector: tracked.selector,
             tag_name: tracked.tag_name,
             text_content: tracked.text_content.trim().to_string(),
             attributes: tracked.attributes,
           });
-        } else {
-          i += 1;
         }
       }
     }

--- a/crates/core/src/selector.rs
+++ b/crates/core/src/selector.rs
@@ -8,6 +8,7 @@ pub(crate) enum ParsedSelectorList {
   Multiple(Vec<ParsedSelector>),
 }
 
+/// Parses a comma-separated selector list while preserving attribute values.
 pub(crate) fn parse_css_selector_list(selector: &str) -> ParsedSelectorList {
   let selector = selector.trim();
   if selector.is_empty() {
@@ -183,6 +184,7 @@ pub(crate) fn matches_selector(tag: &ElementNode, selector: &ParsedSelector) -> 
   }
 }
 
+/// Returns whether an element matches any selector in a parsed list.
 pub(crate) fn matches_selector_list(tag: &ElementNode, selectors: &ParsedSelectorList) -> bool {
   match selectors {
     ParsedSelectorList::Single(selector) => matches_selector(tag, selector),

--- a/crates/core/src/selector.rs
+++ b/crates/core/src/selector.rs
@@ -2,6 +2,67 @@
 
 use crate::types::{ElementNode, ParsedSelector};
 
+#[derive(Debug, Clone)]
+pub(crate) enum ParsedSelectorList {
+  Single(ParsedSelector),
+  Multiple(Vec<ParsedSelector>),
+}
+
+pub(crate) fn parse_css_selector_list(selector: &str) -> ParsedSelectorList {
+  let selector = selector.trim();
+  if selector.is_empty() {
+    return ParsedSelectorList::Single(parse_css_selector(selector));
+  }
+
+  let mut selectors = Vec::new();
+  let mut start = 0;
+  let mut in_attr = false;
+  let mut quote = None;
+  let mut escaped = false;
+
+  for (index, ch) in selector.char_indices() {
+    if let Some(active_quote) = quote {
+      if escaped {
+        escaped = false;
+      } else if ch == '\\' {
+        escaped = true;
+      } else if ch == active_quote {
+        quote = None;
+      }
+      continue;
+    }
+    if in_attr {
+      if ch == '"' || ch == '\'' {
+        quote = Some(ch);
+      } else if ch == ']' {
+        in_attr = false;
+      }
+      continue;
+    }
+    if ch == '[' {
+      in_attr = true;
+    } else if ch == ',' {
+      let part = selector[start..index].trim();
+      if part.is_empty() {
+        return ParsedSelectorList::Single(ParsedSelector::Tag(selector.to_string()));
+      }
+      selectors.push(parse_css_selector(part));
+      start = index + ch.len_utf8();
+    }
+  }
+
+  if selectors.is_empty() {
+    return ParsedSelectorList::Single(parse_css_selector(selector));
+  }
+
+  let last = selector[start..].trim();
+  if last.is_empty() {
+    return ParsedSelectorList::Single(ParsedSelector::Tag(selector.to_string()));
+  }
+  selectors.push(parse_css_selector(last));
+  ParsedSelectorList::Multiple(selectors)
+}
+
 pub(crate) fn parse_css_selector(selector: &str) -> ParsedSelector {
   let selector = selector.trim();
   if selector.is_empty() {
@@ -119,6 +180,15 @@ pub(crate) fn matches_selector(tag: &ElementNode, selector: &ParsedSelector) -> 
       },
     },
     ParsedSelector::Compound(parts) => parts.iter().all(|p| matches_selector(tag, p)),
+  }
+}
+
+pub(crate) fn matches_selector_list(tag: &ElementNode, selectors: &ParsedSelectorList) -> bool {
+  match selectors {
+    ParsedSelectorList::Single(selector) => matches_selector(tag, selector),
+    ParsedSelectorList::Multiple(selectors) => selectors
+      .iter()
+      .any(|selector| matches_selector(tag, selector)),
   }
 }
 

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -1739,6 +1739,27 @@ fn extraction_by_tag() {
 }
 
 #[test]
+fn extraction_preserves_declaration_order_for_overlapping_selectors() {
+  let result = html_to_markdown_result(
+    r#"<h1 class="featured">Title</h1>"#,
+    HTMLToMarkdownOptions {
+      plugins: Some(PluginConfig {
+        extraction: Some(ExtractionConfig::new(&["h1", "h1, h2", ".featured"])),
+        ..Default::default()
+      }),
+      ..Default::default()
+    },
+  );
+  let extracted = result.extracted.unwrap();
+  let selectors: Vec<&str> = extracted
+    .iter()
+    .map(|element| element.selector.as_str())
+    .collect();
+
+  assert_eq!(selectors, vec!["h1", "h1, h2", ".featured"]);
+}
+
+#[test]
 fn extraction_by_class() {
   let result = html_to_markdown_result(
     r#"<div class="target">Found</div><div class="other">Ignored</div>"#,

--- a/packages/js/src/libs/query-selector.ts
+++ b/packages/js/src/libs/query-selector.ts
@@ -166,6 +166,7 @@ function createSelectorList(selectors: SelectorMatcher[]): SelectorMatcher {
   }
 }
 
+/** Parses one compound selector without list separators. */
 function parseCompoundSelector(selector: string): SelectorMatcher {
   const selectorParts: SelectorMatcher[] = []
   let current = ''

--- a/packages/js/src/libs/query-selector.ts
+++ b/packages/js/src/libs/query-selector.ts
@@ -151,18 +151,22 @@ export function createCompoundSelector(selectors: SelectorMatcher[]): SelectorMa
 }
 
 /**
- * Parses a CSS selector into a matcher
+ * Creates a selector-list matcher (e.g., 'h1, h2')
  */
-export function parseSelector(selector: string): SelectorMatcher {
-  // Remove whitespace
-  selector = selector.trim()
-
-  if (!selector) {
-    throw new Error('Empty selector')
+function createSelectorList(selectors: SelectorMatcher[]): SelectorMatcher {
+  return {
+    matches(element) {
+      for (let i = 0; i < selectors.length; i++) {
+        if (selectors[i]!.matches(element))
+          return true
+      }
+      return false
+    },
+    toString: () => selectors.map(s => s.toString()).join(', '),
   }
+}
 
-  // Handle compound selectors (without spaces/combinators for now)
-  // This supports basic compound selectors like "div.class#id[attr=val]"
+function parseCompoundSelector(selector: string): SelectorMatcher {
   const selectorParts: SelectorMatcher[] = []
   let current = ''
   let inAttribute = false
@@ -226,4 +230,65 @@ export function parseSelector(selector: string): SelectorMatcher {
 
   // Otherwise, return a compound selector
   return createCompoundSelector(selectorParts)
+}
+
+/**
+ * Parses a CSS selector into a matcher
+ */
+export function parseSelector(selector: string): SelectorMatcher {
+  selector = selector.trim()
+
+  if (!selector) {
+    throw new Error('Empty selector')
+  }
+
+  // Split selector lists on commas outside attribute values. The configured
+  // selector remains intact in extraction results; this only expands matching.
+  const selectors: SelectorMatcher[] = []
+  let start = 0
+  let inAttribute = false
+  let quote = 0
+  let escaped = false
+
+  for (let i = 0; i < selector.length; i++) {
+    const char = selector.charCodeAt(i)
+    if (quote) {
+      if (escaped) {
+        escaped = false
+      }
+      else if (char === 92 /* \ */) {
+        escaped = true
+      }
+      else if (char === quote) {
+        quote = 0
+      }
+      continue
+    }
+    if (inAttribute) {
+      if (char === 34 /* " */ || char === 39 /* ' */)
+        quote = char
+      else if (char === 93 /* ] */)
+        inAttribute = false
+      continue
+    }
+    if (char === 91 /* [ */) {
+      inAttribute = true
+    }
+    else if (char === 44 /* , */) {
+      const part = selector.slice(start, i).trim()
+      if (!part)
+        return createTagSelector(selector)
+      selectors.push(parseCompoundSelector(part))
+      start = i + 1
+    }
+  }
+
+  if (!selectors.length)
+    return parseCompoundSelector(selector)
+
+  const last = selector.slice(start).trim()
+  if (!last)
+    return createTagSelector(selector)
+  selectors.push(parseCompoundSelector(last))
+  return createSelectorList(selectors)
 }

--- a/packages/js/src/plugins/extraction.ts
+++ b/packages/js/src/plugins/extraction.ts
@@ -6,8 +6,10 @@ export interface ExtractedElement extends ElementNode {
   textContent: string
 }
 
+type ExtractionCallback = (element: ExtractedElement, state: MdreamRuntimeState) => void
+
 /** Extract matching elements through the composable JavaScript plugin interface. */
-export function extractionPlugin(selectors: Record<string, (element: ExtractedElement, state: MdreamRuntimeState) => void>): TransformPlugin {
+export function extractionPlugin(selectors: Record<string, ExtractionCallback>): TransformPlugin {
   // Parse selectors and create matcher-callback pairs
   const matcherCallbacks = Object.entries(selectors).map(([selector, callback]) => ({
     matcher: parseSelector(selector),
@@ -15,17 +17,21 @@ export function extractionPlugin(selectors: Record<string, (element: ExtractedEl
   }))
 
   // Track elements we're currently collecting content for
-  const trackedElements = new Map<ElementNode, { textContent: string, callback: (element: ExtractedElement, state: MdreamRuntimeState) => void }>()
+  const trackedElements = new Map<ElementNode, { textContent: string, callbacks: ExtractionCallback[] }>()
 
   return createPlugin({
     onNodeEnter(element) {
       // Check if this element matches any of our selectors
-      matcherCallbacks.forEach(({ matcher, callback }) => {
+      let callbacks: ExtractionCallback[] | undefined
+      for (let i = 0; i < matcherCallbacks.length; i++) {
+        const { matcher, callback } = matcherCallbacks[i]!
         if (matcher.matches(element)) {
-          // Start tracking this element's content
-          trackedElements.set(element, { textContent: '', callback })
+          callbacks ||= []
+          callbacks.push(callback)
         }
-      })
+      }
+      if (callbacks)
+        trackedElements.set(element, { textContent: '', callbacks })
     },
 
     processTextNode(textNode) {
@@ -46,14 +52,15 @@ export function extractionPlugin(selectors: Record<string, (element: ExtractedEl
       // Check if we were tracking this element
       const tracked = trackedElements.get(element)
       if (tracked) {
-        // Create extracted element with textContent
-        const extractedElement: ExtractedElement = {
-          ...element,
-          textContent: tracked.textContent.trim(),
+        for (let i = 0; i < tracked.callbacks.length; i++) {
+          // Each matching handler receives its own extracted element object.
+          const extractedElement: ExtractedElement = {
+            ...element,
+            attributes: { ...element.attributes },
+            textContent: tracked.textContent.trim(),
+          }
+          tracked.callbacks[i]!(extractedElement, state)
         }
-
-        // Call the callback with the complete element and its text content
-        tracked.callback(extractedElement, state)
 
         // Stop tracking this element
         trackedElements.delete(element)
@@ -75,16 +82,20 @@ export function extractionCollectorPlugin(config: Record<string, (element: CoreE
   }))
   const results: CoreExtractedElement[] = []
 
-  const trackedElements = new Map<ElementNode, { textContent: string, selector: string, callback: (element: CoreExtractedElement) => void }>()
+  const trackedElements = new Map<ElementNode, { textContent: string, selectors: string[] }>()
 
   const plugin = createPlugin({
     onNodeEnter(element) {
+      let selectors: string[] | undefined
       for (let i = 0; i < matchers.length; i++) {
         const m = matchers[i]!
         if (m.matcher.matches(element)) {
-          trackedElements.set(element, { textContent: '', selector: m.selector, callback: m.callback })
+          selectors ||= []
+          selectors.push(m.selector)
         }
       }
+      if (selectors)
+        trackedElements.set(element, { textContent: '', selectors })
     },
 
     processTextNode(textNode) {
@@ -102,13 +113,15 @@ export function extractionCollectorPlugin(config: Record<string, (element: CoreE
     onNodeExit(element) {
       const tracked = trackedElements.get(element)
       if (tracked) {
-        const extracted: CoreExtractedElement = {
-          selector: tracked.selector,
-          tagName: element.name,
-          textContent: tracked.textContent.trim(),
-          attributes: { ...element.attributes },
+        for (let i = 0; i < tracked.selectors.length; i++) {
+          const extracted: CoreExtractedElement = {
+            selector: tracked.selectors[i]!,
+            tagName: element.name,
+            textContent: tracked.textContent.trim(),
+            attributes: { ...element.attributes },
+          }
+          results.push(extracted)
         }
-        results.push(extracted)
         trackedElements.delete(element)
       }
     },

--- a/packages/js/src/plugins/filter.ts
+++ b/packages/js/src/plugins/filter.ts
@@ -76,6 +76,10 @@ export function filterPlugin(options: {
   // the parent (set on enter, before children), so isHidden() runs once per
   // element instead of being re-evaluated for every ancestor of every node.
   const skippedSubtrees = new WeakSet<ElementNode>()
+  // Include filtering may skip an element while still allowing a matching
+  // descendant. Track those elements separately so only their direct text is
+  // skipped instead of incorrectly hiding the whole subtree.
+  const skippedByInclude = new WeakSet<ElementNode>()
 
   function excludesSubtree(element: ElementNode): boolean {
     if (skippedSubtrees.has(element))
@@ -104,6 +108,11 @@ export function filterPlugin(options: {
         // Hidden propagates to the immediate parent, so one lookup covers all ancestors.
         if (parent && skippedSubtrees.has(parent)) {
           return { skip: true }
+        }
+        if (parent && skippedByInclude.has(parent)) {
+          // Keep the node visible to downstream hooks (notably extraction),
+          // while preventing the Markdown processor from rendering it.
+          textNode.excludedFromMarkdown = true
         }
         return
       }
@@ -136,6 +145,7 @@ export function filterPlugin(options: {
         }
 
         // If we have include selectors but nothing matched, exclude this element
+        skippedByInclude.add(element)
         return { skip: true }
       }
     },

--- a/packages/mdream/test/unit/plugins/extraction-declarative.test.ts
+++ b/packages/mdream/test/unit/plugins/extraction-declarative.test.ts
@@ -2,9 +2,148 @@ import type { ExtractedElement } from 'mdream'
 import fs from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { htmlToMarkdown as publicHtmlToMarkdown } from '../../../src'
 import { engines, htmlToMarkdown, resolveEngine } from '../../utils/engines'
 
+describe('declarative extraction public API', () => {
+  it('dispatches comma-separated selector lists', () => {
+    const extracted: Array<[string, string]> = []
+
+    publicHtmlToMarkdown(
+      '<main><h1>Alpha</h1><h2>Beta</h2><p>Gamma</p></main>',
+      {
+        extraction: {
+          'h1, h2': element => extracted.push([element.tagName, element.textContent]),
+          'p, li': element => extracted.push([element.tagName, element.textContent]),
+        },
+      },
+    )
+
+    expect(extracted).toEqual([
+      ['h1', 'Alpha'],
+      ['h2', 'Beta'],
+      ['p', 'Gamma'],
+    ])
+  })
+})
+
 describe.each(engines)('declarative extraction (plugins.extraction) $name', (engineConfig) => {
+  it('dispatches nested matches when their text content is complete', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const tags: string[] = []
+
+    htmlToMarkdown('<div><span>Text</span></div>', {
+      plugins: {
+        extraction: {
+          'div, span': element => tags.push(element.tagName),
+        },
+      },
+      engine,
+    })
+
+    // Extraction finalizes on element exit, so a nested element completes first.
+    expect(tags).toEqual(['span', 'div'])
+  })
+
+  it('calls every handler when selector keys overlap', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const calls: string[] = []
+
+    htmlToMarkdown('<h1 class="featured">Title</h1>', {
+      plugins: {
+        extraction: {
+          'h1': element => calls.push(`tag:${element.textContent}`),
+          'h1, h2': element => calls.push(`list:${element.textContent}`),
+          '.featured': element => calls.push(`class:${element.textContent}`),
+        },
+      },
+      engine,
+    })
+
+    expect(calls).toEqual([
+      'tag:Title',
+      'list:Title',
+      'class:Title',
+    ])
+  })
+
+  it('preserves extracted text when include filtering omits a nested element', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const extracted: string[] = []
+
+    const markdown = htmlToMarkdown('<h1>A<span>B</span>C</h1>', {
+      plugins: {
+        filter: {
+          include: ['h1'],
+          processChildren: false,
+        },
+        extraction: {
+          h1: element => extracted.push(element.textContent),
+        },
+      },
+      engine,
+    })
+
+    expect(markdown).not.toContain('B')
+    expect(extracted).toEqual(['ABC'])
+  })
+
+  it('extracts comma-separated selector lists across sibling branches', async () => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const html = `
+      <html>
+        <head><meta name="keywords" content="alpha,beta" /></head>
+        <body>
+          <h1 id="alpha">Alpha</h1>
+          <h2 data-section="beta">Beta</h2>
+          <p class="summary">Gamma</p>
+          <li>Delta</li>
+        </body>
+      </html>
+    `
+    const extracted: ExtractedElement[] = []
+    const keywords: string[] = []
+
+    htmlToMarkdown(html, {
+      plugins: {
+        extraction: {
+          'meta[name="keywords"]': el => keywords.push(el.attributes.content),
+          'h1, h2': el => extracted.push(el),
+          'p, li': el => extracted.push(el),
+        },
+      },
+      engine,
+    })
+
+    expect(keywords).toEqual(['alpha,beta'])
+    expect(extracted).toEqual([
+      {
+        selector: 'h1, h2',
+        tagName: 'h1',
+        textContent: 'Alpha',
+        attributes: { id: 'alpha' },
+      },
+      {
+        selector: 'h1, h2',
+        tagName: 'h2',
+        textContent: 'Beta',
+        attributes: { 'data-section': 'beta' },
+      },
+      {
+        selector: 'p, li',
+        tagName: 'p',
+        textContent: 'Gamma',
+        attributes: { class: 'summary' },
+      },
+      {
+        selector: 'p, li',
+        tagName: 'li',
+        textContent: 'Delta',
+        attributes: {},
+      },
+    ])
+  })
+
   it('extracts elements by tag selector', async () => {
     const engine = await resolveEngine(engineConfig.engine)
     const html = `<html><body><h1>Main Title</h1><h2>Section 1</h2><h2>Section 2</h2><p>Content</p></body></html>`

--- a/packages/mdream/test/unit/plugins/extraction-declarative.test.ts
+++ b/packages/mdream/test/unit/plugins/extraction-declarative.test.ts
@@ -2,8 +2,8 @@ import type { ExtractedElement } from 'mdream'
 import fs from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { htmlToMarkdown as publicHtmlToMarkdown } from '../../../src'
-import { engines, htmlToMarkdown, resolveEngine } from '../../utils/engines'
+import { htmlToMarkdown as publicHtmlToMarkdown } from '../../../src/index.js'
+import { engines, htmlToMarkdown, resolveEngine } from '../../utils/engines.js'
 
 describe('declarative extraction public API', () => {
   it('dispatches comma-separated selector lists', () => {

--- a/packages/mdream/test/unit/plugins/extraction.test.ts
+++ b/packages/mdream/test/unit/plugins/extraction.test.ts
@@ -6,6 +6,41 @@ import { extractionPlugin } from '@mdream/js/plugins'
 import { describe, expect, it } from 'vitest'
 
 describe('extraction plugin', () => {
+  it('calls every handler when selector keys overlap', () => {
+    const calls: string[] = []
+    const plugin = extractionPlugin({
+      'h1': element => calls.push(`tag:${element.textContent}`),
+      'h1, h2': element => calls.push(`list:${element.textContent}`),
+    })
+
+    htmlToMarkdown('<h1>Title</h1>', {
+      hooks: [plugin],
+    })
+
+    expect(calls).toEqual([
+      'tag:Title',
+      'list:Title',
+    ])
+  })
+
+  it('isolates attributes between overlapping handlers', () => {
+    const observedAttributes: Array<Record<string, string>> = []
+    const plugin = extractionPlugin({
+      'h1': (element) => {
+        element.attributes.injected = 'first'
+      },
+      '.featured': (element) => {
+        observedAttributes.push(element.attributes)
+      },
+    })
+
+    htmlToMarkdown('<h1 class="featured">Title</h1>', {
+      hooks: [plugin],
+    })
+
+    expect(observedAttributes).toEqual([{ class: 'featured' }])
+  })
+
   it('should extract elements by tag selector', () => {
     const html = `
       <html>

--- a/packages/mdream/test/unit/plugins/query-selector.test.ts
+++ b/packages/mdream/test/unit/plugins/query-selector.test.ts
@@ -25,6 +25,16 @@ describe.each(engines)('querySelector plugin %s', ({ name, engine }) => {
     expect(markdown).toContain('This paragraph should be included')
   })
 
+  it('does not leak unmatched text when using an include selector list', async () => {
+    const markdown = htmlToMarkdown('<h1>Included</h1><p>secret</p>', {
+      engine: await resolveEngine(engine),
+      plugins: { filter: { include: ['h1, h2'] } },
+    })
+
+    expect(markdown).toContain('# Included')
+    expect(markdown).not.toContain('secret')
+  })
+
   it('excludes specified elements by tag', async () => {
     const html = `
       <div>This should be included</div>


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Declarative extraction treated a CSS selector list such as `h1, h2` as one literal selector in both the JavaScript and Rust engines. No element could match that value, so the conversion output remained correct while the configured extraction handler was never called.

This adds selector-list parsing and OR matching at the shared selector layer for both engines. Commas are split only outside attribute selectors and quoted attribute values, and the original configured selector is retained on extracted results so JavaScript dispatch continues to resolve the correct handler.

The review also exposed adjacent extraction invariants that are fixed here:

- every matching handler is called when independently configured selectors overlap;
- overlapping handlers run in declaration order and receive isolated attribute objects;
- native extraction results preserve declaration order instead of being reordered during finalization;
- include filtering can suppress nested Markdown while extraction still receives the element's complete text.

The Rust matcher retains a single-selector fast path, so existing exact selectors do not pay a per-element selector-list allocation or iteration cost. Exact selectors such as `meta[name="keywords"]` remain unchanged, and there is no tag-specific or consumer-specific special case.

### ✅ Validation

- Focused selector, extraction, filtering, and conversion parity suites: 151 tests passed.
- Full Rust `mdream` test suite passed.
- Workspace TypeScript typechecks passed.
- Rust workspace Clippy passed with warnings denied.
- Targeted ESLint and `git diff --check` passed.
- JavaScript and native N-API engines were rebuilt from the final sources before testing.

### Compatibility

This is an additive bug fix. Existing exact and compound selectors keep their previous behavior; filters additionally gain selector-list support through the same matcher layer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for comma-separated CSS selector lists across conversion, filtering, and extraction (including correct handling of attribute brackets, quoted values, and escapes).
  * Enabled multiple extraction callbacks per matched element.

* **Bug Fixes**
  * Improved include-filter behavior so text is not incorrectly skipped while still excluding the rendered subtree.
  * Preserved extraction/declaration order for overlapping selectors and prevented attribute changes from leaking between overlapping handlers.

* **Tests**
  * Added regression and unit tests covering selector lists, overlapping and nested extraction, include-filter cases, and attribute isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->