### PR TITLE
fix: emit GFM that Markdown parsers read back as the intended structure

### DIFF
--- a/crates/core/src/consts.rs
+++ b/crates/core/src/consts.rs
@@ -253,9 +253,8 @@ pub const ATTR_ALIGN: u16 = 1 << 6;
 pub const ATTR_NAME: u16 = 1 << 7;
 pub const ATTR_PROPERTY: u16 = 1 << 8;
 pub const ATTR_CONTENT: u16 = 1 << 9;
-pub const ATTR_LANG: u16 = 1 << 10;
-pub const ATTR_START: u16 = 1 << 11;
-pub const ATTR_COLSPAN: u16 = 1 << 12;
+pub const ATTR_START: u16 = 1 << 10;
+pub const ATTR_COLSPAN: u16 = 1 << 11;
 pub const ATTR_ALL: u16 = u16::MAX;
 
 /// Case-insensitive, length-first so the common miss costs one compare.
@@ -274,8 +273,6 @@ pub(crate) fn attr_bit(name: &[u8]) -> u16 {
     4 => {
       if name.eq_ignore_ascii_case(b"href") {
         ATTR_HREF
-      } else if name.eq_ignore_ascii_case(b"lang") {
-        ATTR_LANG
       } else if name.eq_ignore_ascii_case(b"name") {
         ATTR_NAME
       } else {

--- a/crates/core/src/consts.rs
+++ b/crates/core/src/consts.rs
@@ -253,6 +253,9 @@ pub const ATTR_ALIGN: u16 = 1 << 6;
 pub const ATTR_NAME: u16 = 1 << 7;
 pub const ATTR_PROPERTY: u16 = 1 << 8;
 pub const ATTR_CONTENT: u16 = 1 << 9;
+pub const ATTR_LANG: u16 = 1 << 10;
+pub const ATTR_START: u16 = 1 << 11;
+pub const ATTR_COLSPAN: u16 = 1 << 12;
 pub const ATTR_ALL: u16 = u16::MAX;
 
 /// Case-insensitive, length-first so the common miss costs one compare.
@@ -271,6 +274,8 @@ pub(crate) fn attr_bit(name: &[u8]) -> u16 {
     4 => {
       if name.eq_ignore_ascii_case(b"href") {
         ATTR_HREF
+      } else if name.eq_ignore_ascii_case(b"lang") {
+        ATTR_LANG
       } else if name.eq_ignore_ascii_case(b"name") {
         ATTR_NAME
       } else {
@@ -284,6 +289,8 @@ pub(crate) fn attr_bit(name: &[u8]) -> u16 {
         ATTR_CLASS
       } else if name.eq_ignore_ascii_case(b"align") {
         ATTR_ALIGN
+      } else if name.eq_ignore_ascii_case(b"start") {
+        ATTR_START
       } else {
         ATTR_NONE
       }
@@ -291,6 +298,8 @@ pub(crate) fn attr_bit(name: &[u8]) -> u16 {
     7 => {
       if name.eq_ignore_ascii_case(b"content") {
         ATTR_CONTENT
+      } else if name.eq_ignore_ascii_case(b"colspan") {
+        ATTR_COLSPAN
       } else {
         ATTR_NONE
       }
@@ -313,17 +322,15 @@ pub(crate) fn attr_bit(name: &[u8]) -> u16 {
   }
 }
 
-#[inline]
-pub(crate) fn attr_wanted(mask: u16, name: &[u8]) -> bool {
-  mask == ATTR_ALL || mask & attr_bit(name) != 0
-}
-
 pub const MARKDOWN_STRONG: &str = "**";
 pub const MARKDOWN_EMPHASIS: &str = "*";
 pub const MARKDOWN_STRIKETHROUGH: &str = "~~";
 pub const MARKDOWN_CODE_BLOCK: &str = "```";
 pub const MARKDOWN_INLINE_CODE: &str = "`";
 pub const MARKDOWN_HORIZONTAL_RULE: &str = "---";
+/// Rule sharing a line with a list marker: `- ---` is dashes and spaces only, so
+/// the whole line is a thematic break and the item is lost. `*` cannot collide.
+pub const MARKDOWN_HORIZONTAL_RULE_ALT: &str = "***";
 
 pub const NO_SPACING: [u8; 2] = [0, 0];
 pub const DEFAULT_BLOCK_SPACING: [u8; 2] = [2, 2];

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -149,7 +149,7 @@ enum LineBeforeRow {
   Content,
 }
 
-/// Widest `colspan` honoured.
+/// Widest `colspan` honored.
 const MAX_CELL_SPAN: u8 = 64;
 
 /// Largest `<ol start>` CommonMark can express: an ordered marker is at most
@@ -437,7 +437,7 @@ pub struct ConvertState {
   table_current_row_cells: usize,
   /// A raw-HTML region (`<details>`, `<dl>`, …) stops being raw at the first
   /// blank line: CommonMark ends an HTML block there and reads what follows as
-  /// Markdown, so text past one needs escaping after all. The scan resumes from
+  /// Markdown, so text past one needs escaping. The scan resumes from
   /// `raw_html_scanned_to`, so a region costs one pass however many nodes it holds.
   raw_html_markdown: bool,
   raw_html_scanned_to: usize,
@@ -1362,8 +1362,7 @@ impl ConvertState {
       );
     }
     // A marker still alone on its line has its separating newline inserted at
-    // the line start when the item resolves, so the line stays mutable. Mirrors
-    // the same guard in `drain_streamed_prefix`.
+    // the line start when the item resolves, so the line stays mutable.
     if self.empty_item_hazard {
       stable_end = stable_end.min(keep_two_before(&self.buffer, self.empty_item_line_start));
     }

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -37,20 +37,6 @@ const GFM_HAZARD_HIGH: u64 = (1 << (b'[' - HAZARD_MASK_SPLIT))
   | (1 << (b'`' - HAZARD_MASK_SPLIT))
   | (1 << (b'~' - HAZARD_MASK_SPLIT));
 
-/// Bytes `escape_gfm_text` must inspect one at a time: escape candidates, line
-/// terminators, and block-marker leads. Every other byte only clears both
-/// trackers, so a run of them collapses to one state update.
-const GFM_TEXT_ACTIVE: [bool; 256] = {
-  let mut t = [false; 256];
-  let active = b"\\*_~`[]|><\n\r#-+.) 0123456789";
-  let mut i = 0usize;
-  while i < active.len() {
-    t[active[i] as usize] = true;
-    i += 1;
-  }
-  t
-};
-
 const BATCHABLE_TEXT: [bool; 256] = {
   let mut t = [false; 256];
   let mut c = 33usize;
@@ -69,10 +55,10 @@ const BATCHABLE_TEXT: [bool; 256] = {
 
 const GFM_HAZARD_BIT: u8 = 1;
 const GFM_NEWLINE_BIT: u8 = 2;
+const GFM_TEXT_ACTIVE_BIT: u8 = 4;
 
-/// Per-byte hazard and newline flags checked on every text-node byte; newlines
-/// fold into `<br>`. A table replaces a range guard plus a shift per byte.
-const INLINE_GFM_HAZARD: [u8; 256] = {
+/// Per-byte GFM flags shared by the parser and escaping pass.
+const GFM_BYTE_FLAGS: [u8; 256] = {
   let mut t = [0u8; 256];
   let mut c = 33usize;
   while c < 0x80 {
@@ -82,12 +68,18 @@ const INLINE_GFM_HAZARD: [u8; 256] = {
       GFM_HAZARD_HIGH
     };
     if (mask >> (c & (HAZARD_MASK_SPLIT as usize - 1))) & 1 != 0 {
-      t[c] = GFM_HAZARD_BIT;
+      t[c] |= GFM_HAZARD_BIT;
     }
     c += 1;
   }
   t[b'\n' as usize] |= GFM_NEWLINE_BIT;
   t[b'\r' as usize] |= GFM_NEWLINE_BIT;
+  let active = b"\\*_~`[]|><\n\r#-+.) 0123456789";
+  let mut i = 0usize;
+  while i < active.len() {
+    t[active[i] as usize] |= GFM_TEXT_ACTIVE_BIT;
+    i += 1;
+  }
   t
 };
 
@@ -113,22 +105,14 @@ struct BlockquoteFrame {
 static HEADING_PREFIXES: [&str; 6] = ["# ", "## ", "### ", "#### ", "##### ", "###### "];
 
 /// Inline tags whose delimiters are suppressed inside `<pre>` (content only).
-/// `<code>` and `<br>` are absent — already `<pre>`-aware. Sized 256, not
-/// `MAX_TAG_ID`, so a `u8` tag id indexes it without a bounds check.
-const SUPPRESSED_IN_PRE: [bool; 256] = {
-  let mut t = [false; 256];
-  let ids = [
-    TAG_STRONG, TAG_B, TAG_EM, TAG_I, TAG_DEL, TAG_S, TAG_STRIKE, TAG_CITE, TAG_DFN, TAG_KBD,
-    TAG_SAMP, TAG_VAR, TAG_Q, TAG_SUB, TAG_SUP, TAG_INS, TAG_MARK, TAG_ABBR, TAG_SMALL, TAG_U,
-    TAG_TIME, TAG_BDO, TAG_A,
-  ];
-  let mut i = 0;
-  while i < ids.len() {
-    t[ids[i] as usize] = true;
-    i += 1;
-  }
-  t
-};
+/// The tag ids form three dense ranges plus four exceptions.
+#[inline]
+fn suppresses_formatting_in_pre(tag_id: u8) -> bool {
+  matches!(tag_id, TAG_A | TAG_KBD | TAG_S | TAG_STRIKE)
+    || (TAG_STRONG..=TAG_INS).contains(&tag_id)
+    || (TAG_ABBR..=TAG_SMALL).contains(&tag_id)
+    || (TAG_U..=TAG_BDO).contains(&tag_id)
+}
 
 #[inline]
 fn trailing_spaces(bytes: &[u8]) -> usize {
@@ -155,18 +139,6 @@ const MAX_CELL_SPAN: u8 = 64;
 /// Largest `<ol start>` CommonMark can express: an ordered marker is at most
 /// nine digits, so anything wider stops being a list marker at all.
 const MAX_ORDERED_START: u32 = 999_999_999;
-
-/// `" |"` repeated to `MAX_CELL_SPAN`, so a spanned cell's filler is a slice of
-/// this rather than a string built per cell.
-static SPAN_FILLER: [u8; (MAX_CELL_SPAN as usize - 1) * 2] = {
-  let mut t = [b' '; (MAX_CELL_SPAN as usize - 1) * 2];
-  let mut i = 1;
-  while i < t.len() {
-    t[i] = b'|';
-    i += 2;
-  }
-  t
-};
 
 // Clean mode bitmask flags
 const CLEAN_EMPTY_LINKS: u8 = 1;
@@ -861,7 +833,7 @@ impl ConvertState {
         if cc == AMPERSAND_CHAR {
           self.has_encoded_html_entity = true;
         }
-        if INLINE_GFM_HAZARD[cc as usize] & GFM_HAZARD_BIT != 0 {
+        if GFM_BYTE_FLAGS[cc as usize] & GFM_HAZARD_BIT != 0 {
           self.text_buffer_has_inline_gfm_hazard = true;
         }
 

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -5,7 +5,8 @@ use crate::selector::{ParsedSelectorList, matches_selector_list, parse_css_selec
 use crate::tags::get_tag_handler;
 use crate::tailwind::process_tailwind_classes;
 use crate::types::{
-  ElementNode, ExtractedElement, HTMLToMarkdownOptions, OutputFormat, TagHandler, TailwindData,
+  Attributes, ElementNode, ExtractedElement, HTMLToMarkdownOptions, OutputFormat, TagHandler,
+  TailwindData,
 };
 use crate::url::{is_autolink_uri, is_empty_link_href, resolve_url, slugify_heading};
 use std::borrow::Cow;
@@ -36,6 +37,20 @@ const GFM_HAZARD_HIGH: u64 = (1 << (b'[' - HAZARD_MASK_SPLIT))
   | (1 << (b'`' - HAZARD_MASK_SPLIT))
   | (1 << (b'~' - HAZARD_MASK_SPLIT));
 
+/// Bytes `escape_gfm_text` must inspect one at a time: escape candidates, line
+/// terminators, and block-marker leads. Every other byte only clears both
+/// trackers, so a run of them collapses to one state update.
+const GFM_TEXT_ACTIVE: [bool; 256] = {
+  let mut t = [false; 256];
+  let active = b"\\*_~`[]|><\n\r#-+.) 0123456789";
+  let mut i = 0usize;
+  while i < active.len() {
+    t[active[i] as usize] = true;
+    i += 1;
+  }
+  t
+};
+
 const BATCHABLE_TEXT: [bool; 256] = {
   let mut t = [false; 256];
   let mut c = 33usize;
@@ -52,16 +67,29 @@ const BATCHABLE_TEXT: [bool; 256] = {
   t
 };
 
-/// Callers must range-guard: bytes >= 128 alias into `GFM_HAZARD_HIGH`.
-#[inline(always)]
-fn is_inline_gfm_hazard(byte: u8) -> bool {
-  let mask = if byte < HAZARD_MASK_SPLIT {
-    GFM_HAZARD_LOW
-  } else {
-    GFM_HAZARD_HIGH
-  };
-  (mask >> (byte & (HAZARD_MASK_SPLIT - 1))) & 1 != 0
-}
+const GFM_HAZARD_BIT: u8 = 1;
+const GFM_NEWLINE_BIT: u8 = 2;
+
+/// Per-byte hazard and newline flags checked on every text-node byte; newlines
+/// fold into `<br>`. A table replaces a range guard plus a shift per byte.
+const INLINE_GFM_HAZARD: [u8; 256] = {
+  let mut t = [0u8; 256];
+  let mut c = 33usize;
+  while c < 0x80 {
+    let mask = if c < HAZARD_MASK_SPLIT as usize {
+      GFM_HAZARD_LOW
+    } else {
+      GFM_HAZARD_HIGH
+    };
+    if (mask >> (c & (HAZARD_MASK_SPLIT as usize - 1))) & 1 != 0 {
+      t[c] = GFM_HAZARD_BIT;
+    }
+    c += 1;
+  }
+  t[b'\n' as usize] |= GFM_NEWLINE_BIT;
+  t[b'\r' as usize] |= GFM_NEWLINE_BIT;
+  t
+};
 
 struct CodeSpanState {
   output_start: usize,
@@ -83,6 +111,58 @@ struct BlockquoteFrame {
 }
 
 static HEADING_PREFIXES: [&str; 6] = ["# ", "## ", "### ", "#### ", "##### ", "###### "];
+
+/// Inline tags whose delimiters are suppressed inside `<pre>` (content only).
+/// `<code>` and `<br>` are absent — already `<pre>`-aware. Sized 256, not
+/// `MAX_TAG_ID`, so a `u8` tag id indexes it without a bounds check.
+const SUPPRESSED_IN_PRE: [bool; 256] = {
+  let mut t = [false; 256];
+  let ids = [
+    TAG_STRONG, TAG_B, TAG_EM, TAG_I, TAG_DEL, TAG_S, TAG_STRIKE, TAG_CITE, TAG_DFN, TAG_KBD,
+    TAG_SAMP, TAG_VAR, TAG_Q, TAG_SUB, TAG_SUP, TAG_INS, TAG_MARK, TAG_ABBR, TAG_SMALL, TAG_U,
+    TAG_TIME, TAG_BDO, TAG_A,
+  ];
+  let mut i = 0;
+  while i < ids.len() {
+    t[ids[i] as usize] = true;
+    i += 1;
+  }
+  t
+};
+
+#[inline]
+fn trailing_spaces(bytes: &[u8]) -> usize {
+  bytes.len()
+    - bytes
+      .iter()
+      .rposition(|byte| *byte != b' ')
+      .map_or(0, |i| i + 1)
+}
+
+/// What the current output line holds where a table row is about to be written.
+enum LineBeforeRow {
+  /// Nothing but block prefix, or a pending list marker.
+  Open,
+  /// A row left open mid-line.
+  Row,
+  /// Other content, so the row needs a block break to become a table.
+  Content,
+}
+
+/// Widest `colspan` honoured.
+const MAX_CELL_SPAN: u8 = 64;
+
+/// `" |"` repeated to `MAX_CELL_SPAN`, so a spanned cell's filler is a slice of
+/// this rather than a string built per cell.
+static SPAN_FILLER: [u8; (MAX_CELL_SPAN as usize - 1) * 2] = {
+  let mut t = [b' '; (MAX_CELL_SPAN as usize - 1) * 2];
+  let mut i = 1;
+  while i < t.len() {
+    t[i] = b'|';
+    i += 2;
+  }
+  t
+};
 
 // Clean mode bitmask flags
 const CLEAN_EMPTY_LINKS: u8 = 1;
@@ -351,6 +431,18 @@ pub struct ConvertState {
   last_content_cache_len: usize,
   table_rendered_table: bool,
   table_current_row_cells: usize,
+  /// A raw-HTML region (`<details>`, `<dl>`, …) stops being raw at the first
+  /// blank line: CommonMark ends an HTML block there and reads what follows as
+  /// Markdown, so text past one needs escaping after all. The scan resumes from
+  /// `raw_html_scanned_to`, so a region costs one pass however many nodes it holds.
+  raw_html_markdown: bool,
+  raw_html_scanned_to: usize,
+  /// Index just past the buffer's last `\n`, and how far it was scanned to find
+  /// it. Recomputing walks the whole line, which is quadratic over a long one.
+  line_start: usize,
+  line_start_scanned_to: usize,
+  /// Columns the delimiter row promised; cells past it would be dropped by GFM.
+  table_header_cells: usize,
   // 0=none, 1=left, 2=center, 3=right
   table_column_alignments: Vec<u8>,
   last_text_node_contains_whitespace: bool,
@@ -426,11 +518,19 @@ pub struct ConvertState {
   /// until the first non-whitespace child so empty/whitespace-only blocks emit
   /// nothing. `pre_fence_pending`: inside a `<pre>` whose fence is undecided.
   /// `pre_fence_lang`: language resolved from the `<pre>`'s own class.
-  /// `pre_own_fence`: the `<pre>` opened its own fence (so a nested `<code>`
-  /// must not, and the `<pre>` exit emits the closing fence).
   pre_fence_pending: bool,
   pre_fence_lang: String,
-  pre_own_fence: bool,
+  /// A fence is open for the current `<pre>`, however it was opened. The `<pre>`
+  /// exit owns the closer, so a `<code>` child's trailing siblings stay in the
+  /// block instead of landing on the fence line.
+  pre_fence_open: bool,
+  /// The open `<li>` wrote its marker onto a line that continues the paragraph
+  /// above, so an empty item would read as a setext underline. `empty_item_len`
+  /// is the buffer length that still means "nothing written since the marker",
+  /// and `empty_item_line_start` where the separating newline goes.
+  empty_item_hazard: bool,
+  empty_item_line_start: usize,
+  empty_item_len: usize,
   #[cfg(test)]
   gfm_escape_slow_path_calls: usize,
 }
@@ -508,6 +608,11 @@ impl ConvertState {
       last_content_cache_len: 0,
       table_rendered_table: false,
       table_current_row_cells: 0,
+      raw_html_markdown: false,
+      raw_html_scanned_to: 0,
+      line_start: 0,
+      line_start_scanned_to: 0,
+      table_header_cells: 0,
       table_column_alignments: Vec::new(),
       last_text_node_contains_whitespace: false,
       last_text_node_depth: 0,
@@ -542,7 +647,10 @@ impl ConvertState {
 
       pre_fence_pending: false,
       pre_fence_lang: String::new(),
-      pre_own_fence: false,
+      pre_fence_open: false,
+      empty_item_hazard: false,
+      empty_item_line_start: 0,
+      empty_item_len: 0,
       #[cfg(test)]
       gfm_escape_slow_path_calls: 0,
     };
@@ -749,7 +857,7 @@ impl ConvertState {
         if cc == AMPERSAND_CHAR {
           self.has_encoded_html_entity = true;
         }
-        if cc > 32 && cc < 0x80 && is_inline_gfm_hazard(cc) {
+        if INLINE_GFM_HAZARD[cc as usize] & GFM_HAZARD_BIT != 0 {
           self.text_buffer_has_inline_gfm_hazard = true;
         }
 
@@ -1333,6 +1441,12 @@ impl ConvertState {
     if let Some(frame) = self.blockquotes.first() {
       drain_end = drain_end.min(keep_two_before(&self.buffer, frame.content_start));
     }
+    // Settle a pending marker-line guard when the item's first content already
+    // answers it, so the hold below never outlives the marker's own line.
+    self.resolve_item_marker(false);
+    if self.empty_item_hazard {
+      drain_end = drain_end.min(keep_two_before(&self.buffer, self.empty_item_line_start));
+    }
     if drain_end == 0 {
       return;
     }
@@ -1370,6 +1484,13 @@ impl ConvertState {
     for frame in &mut self.blockquotes {
       frame.content_start -= drain_end;
     }
+    self.empty_item_line_start = self.empty_item_line_start.saturating_sub(drain_end);
+    self.empty_item_len = self.empty_item_len.saturating_sub(drain_end);
+    // Buffer-indexed like every other stored offset: left alone, streaming reads
+    // a different line start than one-shot.
+    self.raw_html_scanned_to = self.raw_html_scanned_to.saturating_sub(drain_end);
+    self.line_start = self.line_start.saturating_sub(drain_end);
+    self.line_start_scanned_to = self.line_start_scanned_to.saturating_sub(drain_end);
   }
 }
 

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -5,8 +5,7 @@ use crate::selector::{ParsedSelectorList, matches_selector_list, parse_css_selec
 use crate::tags::get_tag_handler;
 use crate::tailwind::process_tailwind_classes;
 use crate::types::{
-  Attributes, ElementNode, ExtractedElement, HTMLToMarkdownOptions, OutputFormat, TagHandler,
-  TailwindData,
+  ElementNode, ExtractedElement, HTMLToMarkdownOptions, OutputFormat, TagHandler, TailwindData,
 };
 use crate::url::{is_autolink_uri, is_empty_link_href, resolve_url, slugify_heading};
 use std::borrow::Cow;

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -136,6 +136,16 @@ enum LineBeforeRow {
 /// Widest `colspan` honored.
 const MAX_CELL_SPAN: u8 = 64;
 
+static SPAN_FILLER: [u8; (MAX_CELL_SPAN as usize - 1) * 2] = {
+  let mut filler = [b' '; (MAX_CELL_SPAN as usize - 1) * 2];
+  let mut index = 1;
+  while index < filler.len() {
+    filler[index] = b'|';
+    index += 2;
+  }
+  filler
+};
+
 /// Largest `<ol start>` CommonMark can express: an ordered marker is at most
 /// nine digits, so anything wider stops being a list marker at all.
 const MAX_ORDERED_START: u32 = 999_999_999;
@@ -438,9 +448,9 @@ pub struct ConvertState {
   /// Once streaming starts, whitespace at the front of a drained buffer is
   /// content, not document-leading whitespace.
   has_streamed_output: bool,
-  /// Last two bytes flushed out of the front of the buffer by draining. When a
-  /// later rewrite trims the retained buffer empty, spacing and newline counts
-  /// still need the same two-byte context one-shot conversion sees.
+  /// Two bytes immediately before the retained buffer, initialized as virtual
+  /// newlines at the document start. When a later rewrite trims the buffer
+  /// empty, spacing and newline counts still see the one-shot context.
   flushed_tail: [u8; 2],
   /// Output column immediately before `buffer[0]`. Draining may remove the
   /// beginning of the current line, but wrapping still needs its full column.
@@ -598,7 +608,7 @@ impl ConvertState {
       pending_inline_whitespace: false,
       last_yielded_length: 0,
       has_streamed_output: false,
-      flushed_tail: [0; 2],
+      flushed_tail: [b'\n'; 2],
       buffer_start_column: 0,
       #[cfg(test)]
       disable_drain: false,

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -136,16 +136,6 @@ enum LineBeforeRow {
 /// Widest `colspan` honored.
 const MAX_CELL_SPAN: u8 = 64;
 
-static SPAN_FILLER: [u8; (MAX_CELL_SPAN as usize - 1) * 2] = {
-  let mut filler = [b' '; (MAX_CELL_SPAN as usize - 1) * 2];
-  let mut index = 1;
-  while index < filler.len() {
-    filler[index] = b'|';
-    index += 2;
-  }
-  filler
-};
-
 /// Largest `<ol start>` CommonMark can express: an ordered marker is at most
 /// nine digits, so anything wider stops being a list marker at all.
 const MAX_ORDERED_START: u32 = 999_999_999;

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -152,6 +152,10 @@ enum LineBeforeRow {
 /// Widest `colspan` honoured.
 const MAX_CELL_SPAN: u8 = 64;
 
+/// Largest `<ol start>` CommonMark can express: an ordered marker is at most
+/// nine digits, so anything wider stops being a list marker at all.
+const MAX_ORDERED_START: u32 = 999_999_999;
+
 /// `" |"` repeated to `MAX_CELL_SPAN`, so a spanned cell's filler is a slice of
 /// this rather than a string built per cell.
 static SPAN_FILLER: [u8; (MAX_CELL_SPAN as usize - 1) * 2] = {
@@ -1357,6 +1361,18 @@ impl ConvertState {
           .len(),
       );
     }
+    // A marker still alone on its line has its separating newline inserted at
+    // the line start when the item resolves, so the line stays mutable. Mirrors
+    // the same guard in `drain_streamed_prefix`.
+    if self.empty_item_hazard {
+      stable_end = stable_end.min(keep_two_before(&self.buffer, self.empty_item_line_start));
+    }
+    // A heading's exit escapes the trailing `#` run GFM would read as an ATX
+    // closing sequence, so hold the run (and the spacing that decides whether it
+    // closes) until the heading is complete.
+    if self.in_heading() {
+      stable_end = stable_end.min(self.buffer.trim_end_matches(['#', ' ', '\t']).len());
+    }
     // `last_yielded_length` is an absolute buffer offset (see drain below).
     let mut start = self.last_yielded_length.max(leading);
     if start >= stable_end {
@@ -1419,13 +1435,6 @@ impl ConvertState {
     // there (see `write_output`, which inspects only the last two), so keep
     // those two bytes; otherwise a dropped element leaks an extra newline in
     // streaming.
-    let keep_two_before = |buf: &str, at: usize| {
-      let mut i = at.saturating_sub(2);
-      while i > 0 && !buf.is_char_boundary(i) {
-        i -= 1;
-      }
-      i
-    };
     if self.depth_map[TAG_A as usize] > 0 {
       drain_end = drain_end.min(keep_two_before(&self.buffer, self.link_bracket_pos));
     }
@@ -1492,6 +1501,17 @@ impl ConvertState {
     self.line_start = self.line_start.saturating_sub(drain_end);
     self.line_start_scanned_to = self.line_start_scanned_to.saturating_sub(drain_end);
   }
+}
+
+/// Highest offset that still keeps the two bytes before `at` in the buffer, for
+/// a rewrite that can reach back there. Floored to a UTF-8 boundary, so the
+/// result is always safe to slice at even if `at` has drifted past the end.
+fn keep_two_before(buf: &str, at: usize) -> usize {
+  let mut i = at.saturating_sub(2);
+  while i > 0 && !buf.is_char_boundary(i) {
+    i -= 1;
+  }
+  i
 }
 
 // Internal result structs

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -425,7 +425,8 @@ impl ConvertState {
       && self.stack[stack_len - 1].tag_id == Some(TAG_PRE)
       && !self.in_table_cell()
     {
-      let lang = Self::fence_language(&self.stack[stack_len - 1].attributes).to_string();
+      let lang = Self::get_language_from_class(self.stack[stack_len - 1].attributes.get("class"))
+        .to_string();
       self.pre_fence_pending = true;
       self.pre_fence_lang = lang;
     }
@@ -596,7 +597,9 @@ impl ConvertState {
         && let Some(emitted) = output.as_deref()
       {
         let output_start = self.buffer.len() - emitted.len();
-        let language = Self::fence_language(&self.stack[stack_len - 1].attributes).to_string();
+        let language =
+          Self::get_language_from_class(self.stack[stack_len - 1].attributes.get("class"))
+            .to_string();
         self.start_code_fence(
           output_start,
           self.buffer.len(),
@@ -2096,7 +2099,7 @@ impl ConvertState {
           if self.pre_fence_open {
             return None;
           }
-          let lang = Self::fence_language(&node.attributes);
+          let lang = Self::get_language_from_class(node.attributes.get("class"));
           let li_depth = self.depth_map[TAG_LI as usize] as usize;
           if li_depth > 0 {
             let indent = self.list_indent.as_str();
@@ -2901,27 +2904,6 @@ impl ConvertState {
       .unwrap_or(1)
       .saturating_add(index as u32)
       .min(MAX_ORDERED_START)
-  }
-
-  /// Fence info string for a `<pre>`/`<code>`: `class="language-x"` first, then
-  /// `lang="x"`, the form cmark-gfm itself emits. A `lang` carrying a subtag
-  /// (`en-US`) or spaces is a human language, never an info string.
-  pub(crate) fn fence_language(attributes: &Attributes) -> &str {
-    let from_class = Self::get_language_from_class(attributes.get("class"));
-    if !from_class.is_empty() {
-      return from_class;
-    }
-    match attributes.get("lang") {
-      Some(lang)
-        if !lang.is_empty()
-          && !lang
-            .bytes()
-            .any(|byte| byte == b'-' || byte == b' ' || is_unsafe_fence_info_byte(byte)) =>
-      {
-        lang
-      }
-      _ => "",
-    }
   }
 }
 

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -80,6 +80,30 @@ fn write_image_description(output: &mut String, alt: &str) {
   write_ascii_escaped(output, alt, &IMAGE_DESCRIPTION_ESCAPES);
 }
 
+#[inline(never)]
+#[allow(clippy::cast_possible_truncation)] // `parsed` is bounded by the `u32` maximum argument.
+fn parse_bounded_u32(value: &str, max: u32) -> Option<u32> {
+  let value = value.trim_ascii().as_bytes();
+  let mut index = usize::from(value.first() == Some(&b'+'));
+  if index == value.len() {
+    return None;
+  }
+  let mut parsed = 0u64;
+  while index < value.len() {
+    let byte = value[index];
+    let digit = byte.wrapping_sub(b'0');
+    if digit > 9 {
+      return None;
+    }
+    parsed = parsed * 10 + u64::from(digit);
+    if parsed > u64::from(max) {
+      return None;
+    }
+    index += 1;
+  }
+  Some(parsed as u32)
+}
+
 impl ConvertState {
   #[inline]
   fn inline_marker_type(tag_id: u8) -> Option<u8> {
@@ -2850,21 +2874,20 @@ impl ConvertState {
   /// is written as its content followed by empty cells; without them the
   /// delimiter row is too narrow and GFM drops every cell past it.
   #[inline]
+  #[allow(clippy::cast_possible_truncation)] // Parsing is explicitly bounded to `u8::MAX`.
   pub(crate) fn cell_span(node: &ElementNode) -> u8 {
-    node
+    (node
       .attributes
       .get("colspan")
-      .and_then(|value| value.trim_ascii().parse::<u8>().ok())
-      .unwrap_or(1)
+      .and_then(|value| parse_bounded_u32(value, u8::MAX.into()))
+      .unwrap_or(1) as u8)
       .clamp(1, MAX_CELL_SPAN)
   }
 
   fn span_filler(span: u8) -> Option<Cow<'static, str>> {
     match span {
       1 => None,
-      span => Some(Cow::Borrowed(
-        std::str::from_utf8(&SPAN_FILLER[..(span as usize - 1) * 2]).unwrap_or(" |"),
-      )),
+      span => Some(Cow::Owned(" |".repeat(span as usize - 1))),
     }
   }
 
@@ -2874,8 +2897,7 @@ impl ConvertState {
     list
       .attributes
       .get("start")
-      .and_then(|value| value.trim_ascii().parse::<u32>().ok())
-      .filter(|start| *start <= MAX_ORDERED_START)
+      .and_then(|value| parse_bounded_u32(value, MAX_ORDERED_START))
       .unwrap_or(1)
       .saturating_add(index as u32)
       .min(MAX_ORDERED_START)

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -2862,7 +2862,9 @@ impl ConvertState {
   fn span_filler(span: u8) -> Option<Cow<'static, str>> {
     match span {
       1 => None,
-      span => Some(Cow::Owned(" |".repeat(span as usize - 1))),
+      span => Some(Cow::Borrowed(
+        std::str::from_utf8(&SPAN_FILLER[..(span as usize - 1) * 2]).unwrap_or(" |"),
+      )),
     }
   }
 

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -1493,6 +1493,10 @@ impl ConvertState {
       self.empty_item_hazard = false;
       return;
     }
+    // `output_start` is captured before `write_output`, which can trim trailing
+    // whitespace from behind it, so clamp rather than index past the end.
+    debug_assert!(output_start <= self.buffer.len());
+    let output_start = output_start.min(self.buffer.len());
     let bytes = self.buffer.as_bytes();
     let line_start = bytes[output_start..]
       .iter()
@@ -1522,7 +1526,12 @@ impl ConvertState {
     if !self.empty_item_hazard {
       return;
     }
-    let end = self.empty_item_len.min(self.buffer.len());
+    // A rewrite behind the recorded length followed by multi-byte content can
+    // leave the offset mid-codepoint, which panics on slicing.
+    let mut end = self.empty_item_len.min(self.buffer.len());
+    while end > 0 && !self.buffer.is_char_boundary(end) {
+      end -= 1;
+    }
     let tail = self.buffer[end..].trim_start_matches(' ');
     if tail.is_empty() && !at_exit {
       return;
@@ -1622,7 +1631,7 @@ impl ConvertState {
   }
 
   #[inline]
-  fn in_heading(&self) -> bool {
+  pub(crate) fn in_heading(&self) -> bool {
     self.depth_map[TAG_H1 as usize] > 0
       || self.depth_map[TAG_H2 as usize] > 0
       || self.depth_map[TAG_H3 as usize] > 0
@@ -2787,7 +2796,6 @@ impl ConvertState {
     ""
   }
 
-  /// What the current line holds where a table row is about to be written.
   fn line_state_before_row(&self) -> LineBeforeRow {
     let bytes = self.buffer.as_bytes();
     // Rows end their line, so the row after a row decides on one byte and never
@@ -2805,7 +2813,6 @@ impl ConvertState {
       .position(|byte| !matches!(byte, b' ' | b'\t'))
       .unwrap_or(line.len());
     match line.get(start) {
-      // A row already open only needs its line broken, not a new block.
       Some(b'|') => LineBeforeRow::Row,
       None => LineBeforeRow::Open,
       // A pending list marker is block prefix, not content: a table's first row
@@ -2825,7 +2832,6 @@ impl ConvertState {
     node.cell_span.clamp(1, MAX_CELL_SPAN)
   }
 
-  /// Empty cells standing in for the columns a `colspan` swallowed.
   fn span_filler(&self, node: &ElementNode) -> Option<Cow<'static, str>> {
     match Self::cell_span(node) {
       1 => None,
@@ -2848,8 +2854,10 @@ impl ConvertState {
       .attributes
       .get("start")
       .and_then(|value| value.trim_ascii().parse::<u32>().ok())
+      .filter(|start| *start <= MAX_ORDERED_START)
       .unwrap_or(1)
       .saturating_add(index as u32)
+      .min(MAX_ORDERED_START)
   }
 
   /// Fence info string for a `<pre>`/`<code>`: `class="language-x"` first, then
@@ -2865,7 +2873,7 @@ impl ConvertState {
         if !lang.is_empty()
           && !lang
             .bytes()
-            .any(|byte| byte == b'-' || is_unsafe_fence_info_byte(byte)) =>
+            .any(|byte| byte == b'-' || byte == b' ' || is_unsafe_fence_info_byte(byte)) =>
       {
         lang
       }

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -1459,7 +1459,7 @@ impl ConvertState {
 
   /// Whether `end` sits just past a list marker that is all its line holds:
   /// optional indent, `-`/`*`/`+` or `N.`/`N)`, and nothing else.
-  fn list_marker_line_start(bytes: &[u8], end: usize) -> bool {
+  fn list_marker_line_start(&self, bytes: &[u8], end: usize) -> bool {
     let mut index = end - 1;
     match bytes[index] {
       b'.' | b')' => {
@@ -1479,7 +1479,10 @@ impl ConvertState {
       index -= 1;
       spaces += 1;
     }
-    index == 0 || bytes[index - 1] == b'\n'
+    if index == 0 {
+      return !self.has_streamed_output || self.flushed_tail[1] == b'\n';
+    }
+    bytes[index - 1] == b'\n'
   }
 
   /// Arm the empty-item guard for the `<li>` whose marker was just written from
@@ -1493,9 +1496,6 @@ impl ConvertState {
       self.empty_item_hazard = false;
       return;
     }
-    // `output_start` is captured before `write_output`, which can trim trailing
-    // whitespace from behind it, so clamp rather than index past the end.
-    debug_assert!(output_start <= self.buffer.len());
     let output_start = output_start.min(self.buffer.len());
     let bytes = self.buffer.as_bytes();
     let line_start = bytes[output_start..]
@@ -1604,7 +1604,7 @@ impl ConvertState {
       if byte != b' ' || spaces == 3 {
         // A list marker is block prefix too: its content column opens a fresh
         // block context, so `- # h` escapes exactly like `# h` would.
-        return Self::list_marker_line_start(bytes, offset + 1).then_some(0);
+        return self.list_marker_line_start(bytes, offset + 1).then_some(0);
       }
       spaces += 1;
     }
@@ -1837,9 +1837,20 @@ impl ConvertState {
   /// Separation a block needs to open at the content column `prefix` describes,
   /// or `None` when the buffer already sits there.
   fn block_open_prefix(&self, prefix: &str) -> Option<Cow<'static, str>> {
-    match self.buffer.as_bytes().last() {
-      // Empty output, or a pending list marker already at the content column.
-      None | Some(b' ') => None,
+    let bytes = self.buffer.as_bytes();
+    match bytes.last() {
+      None => None,
+      Some(b' ') => {
+        // A trailing space can be a pending list marker already at the content
+        // column, or ordinary text (`"item "`) that still has to break as a
+        // paragraph. Only the former needs no separator.
+        let end = bytes.len() - trailing_spaces(bytes);
+        if end > 0 && bytes[end - 1] != b'\n' && !self.list_marker_line_start(bytes, end) {
+          Some(Cow::Owned(format!("\n\n{prefix}")))
+        } else {
+          None
+        }
+      }
       Some(b'\n') => (!prefix.is_empty()).then(|| Cow::Owned(prefix.to_string())),
       // Directly under text the block reads as a setext underline or a lazy
       // continuation, so it has to break the paragraph first.
@@ -2817,7 +2828,7 @@ impl ConvertState {
       None => LineBeforeRow::Open,
       // A pending list marker is block prefix, not content: a table's first row
       // belongs on it.
-      Some(_) if Self::list_marker_line_start(bytes, bytes.len() - trailing_spaces(bytes)) => {
+      Some(_) if self.list_marker_line_start(bytes, bytes.len() - trailing_spaces(bytes)) => {
         LineBeforeRow::Open
       }
       Some(_) => LineBeforeRow::Content,

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -659,11 +659,14 @@ impl ConvertState {
       .and_then(|ov| ov.is_inline)
       .unwrap_or(node.is_inline);
 
-    // Table cell count (exit)
-    if (tag_id == Some(TAG_TH) || tag_id == Some(TAG_TD)) && self.depth_map[TAG_TABLE as usize] <= 1
-    {
-      self.table_current_row_cells += Self::cell_span(node) as usize;
-    }
+    let cell_span =
+      if matches!(tag_id, Some(TAG_TH | TAG_TD)) && self.depth_map[TAG_TABLE as usize] <= 1 {
+        let span = Self::cell_span(node);
+        self.table_current_row_cells += span as usize;
+        span
+      } else {
+        1
+      };
 
     let mut output: Option<Cow<'static, str>> = None;
     let mut table_separator: Option<String> = None;
@@ -711,10 +714,10 @@ impl ConvertState {
           self.table_header_cells = col_count;
           table_separator = Some(sep);
         } else {
-          output = self.get_exit_output(node);
+          output = self.get_exit_output(node, cell_span);
         }
       } else if self.plain_text || tag_id != Some(TAG_A) {
-        output = self.get_exit_output(node);
+        output = self.get_exit_output(node, cell_span);
       }
     }
     let closing_code_span = if !has_override
@@ -1071,7 +1074,7 @@ impl ConvertState {
   ) {
     let has_inline_gfm_hazard = text
       .bytes()
-      .any(|byte| INLINE_GFM_HAZARD[byte as usize] != 0);
+      .any(|byte| GFM_BYTE_FLAGS[byte as usize] & (GFM_HAZARD_BIT | GFM_NEWLINE_BIT) != 0);
     self.text_buffer_has_inline_gfm_hazard |= has_inline_gfm_hazard;
     self.emit_text_with_generated_markdown(text, contains_whitespace, depth, index, None, None);
   }
@@ -1307,8 +1310,10 @@ impl ConvertState {
     while index < bytes.len() {
       let byte = bytes[index];
 
-      if !GFM_TEXT_ACTIVE[byte as usize] {
-        while index < bytes.len() && !GFM_TEXT_ACTIVE[bytes[index] as usize] {
+      if GFM_BYTE_FLAGS[byte as usize] & GFM_TEXT_ACTIVE_BIT == 0 {
+        while index < bytes.len()
+          && GFM_BYTE_FLAGS[bytes[index] as usize] & GFM_TEXT_ACTIVE_BIT == 0
+        {
           index += 1;
         }
         line_indent = None;
@@ -1956,7 +1961,7 @@ impl ConvertState {
     }
 
     let tag_id = node.tag_id?;
-    if self.depth_map[TAG_PRE as usize] > 0 && SUPPRESSED_IN_PRE[tag_id as usize] {
+    if self.depth_map[TAG_PRE as usize] > 0 && suppresses_formatting_in_pre(tag_id) {
       return None;
     }
     match tag_id {
@@ -2228,7 +2233,9 @@ impl ConvertState {
         }
         if node.index == 0 {
           Some(Cow::Borrowed(""))
-        } else if self.cell_overflows_header() {
+        } else if self.table_header_cells > 0
+          && self.table_current_row_cells >= self.table_header_cells
+        {
           // GFM discards cells past the delimiter row's width, so this one folds
           // into the previous cell rather than vanishing.
           Some(Cow::Borrowed(" "))
@@ -2262,13 +2269,17 @@ impl ConvertState {
   }
 
   #[inline]
-  pub(crate) fn get_exit_output(&self, node: &ElementNode) -> Option<Cow<'static, str>> {
+  pub(crate) fn get_exit_output(
+    &self,
+    node: &ElementNode,
+    cell_span: u8,
+  ) -> Option<Cow<'static, str>> {
     if self.plain_text {
       return Self::get_text_exit_output(node);
     }
 
     let tag_id = node.tag_id?;
-    if self.depth_map[TAG_PRE as usize] > 0 && SUPPRESSED_IN_PRE[tag_id as usize] {
+    if self.depth_map[TAG_PRE as usize] > 0 && suppresses_formatting_in_pre(tag_id) {
       return None;
     }
     match tag_id {
@@ -2394,7 +2405,7 @@ impl ConvertState {
             "</td>"
           }))
         } else {
-          self.span_filler(node)
+          Self::span_filler(cell_span)
         }
       }
       TAG_CENTER => {
@@ -2840,22 +2851,19 @@ impl ConvertState {
   /// delimiter row is too narrow and GFM drops every cell past it.
   #[inline]
   pub(crate) fn cell_span(node: &ElementNode) -> u8 {
-    node.cell_span.clamp(1, MAX_CELL_SPAN)
+    node
+      .attributes
+      .get("colspan")
+      .and_then(|value| value.trim_ascii().parse::<u8>().ok())
+      .unwrap_or(1)
+      .clamp(1, MAX_CELL_SPAN)
   }
 
-  fn span_filler(&self, node: &ElementNode) -> Option<Cow<'static, str>> {
-    match Self::cell_span(node) {
+  fn span_filler(span: u8) -> Option<Cow<'static, str>> {
+    match span {
       1 => None,
-      span => Some(Cow::Borrowed(
-        std::str::from_utf8(&SPAN_FILLER[..(span as usize - 1) * 2]).unwrap_or(" |"),
-      )),
+      span => Some(Cow::Owned(" |".repeat(span as usize - 1))),
     }
-  }
-
-  /// Whether the cell about to open sits past the width the delimiter promised.
-  #[inline]
-  fn cell_overflows_header(&self) -> bool {
-    self.table_header_cells > 0 && self.table_current_row_cells >= self.table_header_cells
   }
 
   /// Marker number for an `<ol>`'s nth item. GFM numbers a list from its first

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -132,6 +132,13 @@ impl ConvertState {
   #[cold]
   #[inline(never)]
   fn finalize_code_span(&mut self, span: CodeSpanState) -> String {
+    // A pipe splits the row even inside a code span; `\|` is GFM's escape and is
+    // honoured there. Content sits at the buffer tail, so this shifts no offset.
+    if self.depth_map[TAG_TABLE as usize] > 0 && self.buffer[span.content_start..].contains('|') {
+      let escaped = self.buffer[span.content_start..].replace('|', "\\|");
+      self.buffer.truncate(span.content_start);
+      self.buffer.push_str(&escaped);
+    }
     let max_run = Self::max_backtick_run(&self.buffer[span.content_start..]);
     let delimiter = "`".repeat((max_run + 1).max(1));
     let content = &self.buffer[span.content_start..];
@@ -394,10 +401,8 @@ impl ConvertState {
       && self.stack[stack_len - 1].tag_id == Some(TAG_PRE)
       && !self.in_table_cell()
     {
-      let lang = Self::get_language_from_class(self.stack[stack_len - 1].attributes.get("class"))
-        .to_string();
+      let lang = Self::fence_language(&self.stack[stack_len - 1].attributes).to_string();
       self.pre_fence_pending = true;
-      self.pre_own_fence = false;
       self.pre_fence_lang = lang;
     }
 
@@ -436,6 +441,7 @@ impl ConvertState {
         if tag_id == Some(TAG_TABLE) {
           if self.depth_map[TAG_TABLE as usize] <= 1 {
             self.table_rendered_table = false;
+            self.table_header_cells = 0;
           }
           self.table_column_alignments.clear();
         } else if tag_id == Some(TAG_TR) {
@@ -523,6 +529,7 @@ impl ConvertState {
       }
     }
 
+    let output_start = self.buffer.len();
     self.write_output(
       true,
       is_inline,
@@ -530,6 +537,10 @@ impl ConvertState {
       output.as_deref(),
       enter_is_literal,
     );
+
+    if !self.plain_text && !enter_is_literal && tag_id == Some(TAG_LI) && !self.in_table_cell() {
+      self.record_item_marker(self.stack[stack_len - 1].index, output_start);
+    }
 
     if !self.plain_text && !enter_is_literal && tag_id == Some(TAG_BLOCKQUOTE) {
       if !self.blockquotes.is_empty() && self.buffer.ends_with("\n\n") {
@@ -546,28 +557,29 @@ impl ConvertState {
       });
     }
 
-    if !enter_is_literal && tag_id == Some(TAG_CODE) && !self.in_raw_html_block() {
+    if !enter_is_literal && tag_id == Some(TAG_CODE) {
       if self.depth_map[TAG_PRE as usize] == 0 {
-        if let Some(emitted) = output.as_deref() {
+        if !self.in_raw_html_block()
+          && let Some(emitted) = output.as_deref()
+        {
           self.code_spans.push(CodeSpanState {
             output_start: self.buffer.len() - emitted.len(),
             content_start: self.buffer.len(),
           });
         }
-      } else if !self.pre_own_fence
+      } else if !self.pre_fence_open
         && !self.in_table_cell()
         && let Some(emitted) = output.as_deref()
       {
         let output_start = self.buffer.len() - emitted.len();
-        let language =
-          Self::get_language_from_class(self.stack[stack_len - 1].attributes.get("class"))
-            .to_string();
+        let language = Self::fence_language(&self.stack[stack_len - 1].attributes).to_string();
         self.start_code_fence(
           output_start,
           self.buffer.len(),
           language,
           self.list_indent.clone(),
         );
+        self.pre_fence_open = true;
       }
     }
 
@@ -612,7 +624,7 @@ impl ConvertState {
     // Clean: track heading start for slug collection
     if self.clean_flags & CLEAN_FRAGMENTS != 0
       && let Some(id) = tag_id
-      && (TAG_H1..=TAG_H6).contains(&id)
+      && id.wrapping_sub(TAG_H1) < 6
       && self.depth_map[TAG_A as usize] == 0
     {
       self.in_heading = true;
@@ -629,7 +641,7 @@ impl ConvertState {
     }
 
     let tag_id = node.tag_id;
-    let closes_own_pre_fence = tag_id == Some(TAG_PRE) && self.pre_own_fence;
+    let closes_own_pre_fence = tag_id == Some(TAG_PRE) && self.pre_fence_open;
 
     // Check override
     let override_config = if self.has_tag_overrides {
@@ -650,7 +662,7 @@ impl ConvertState {
     // Table cell count (exit)
     if (tag_id == Some(TAG_TH) || tag_id == Some(TAG_TD)) && self.depth_map[TAG_TABLE as usize] <= 1
     {
-      self.table_current_row_cells += 1;
+      self.table_current_row_cells += Self::cell_span(node) as usize;
     }
 
     let mut output: Option<Cow<'static, str>> = None;
@@ -676,8 +688,15 @@ impl ConvertState {
           let col_count = self
             .table_current_row_cells
             .max(self.table_column_alignments.len());
-          let mut sep = String::with_capacity(col_count * 7 + 5);
-          sep.push_str(" |\n|");
+          let indent = if self.depth_map[TAG_LI as usize] > 0 {
+            self.list_indent.as_str()
+          } else {
+            ""
+          };
+          let mut sep = String::with_capacity(col_count * 7 + 5 + indent.len());
+          sep.push_str(" |\n");
+          sep.push_str(indent);
+          sep.push('|');
           for i in 0..col_count {
             let align = self.table_column_alignments.get(i).copied().unwrap_or(0);
             sep.push(' ');
@@ -689,6 +708,7 @@ impl ConvertState {
             });
             sep.push_str(" |");
           }
+          self.table_header_cells = col_count;
           table_separator = Some(sep);
         } else {
           output = self.get_exit_output(node);
@@ -822,21 +842,31 @@ impl ConvertState {
       }
     }
 
-    // Collect heading slug before writing exit output
-    if self.in_heading
-      && let Some(id) = tag_id
-      && (TAG_H1..=TAG_H6).contains(&id)
+    if let Some(id) = tag_id
+      && id.wrapping_sub(TAG_H1) < 6
+      && self.depth_map[TAG_A as usize] == 0
     {
-      let heading_text = &self.buffer[self.heading_buffer_start..];
-      let slug = slugify_heading(heading_text);
-      if !slug.is_empty() {
-        self.heading_slugs.push(slug);
+      if self.in_heading {
+        let slug = slugify_heading(&self.buffer[self.heading_buffer_start..]);
+        if !slug.is_empty() {
+          self.heading_slugs.push(slug);
+        }
+        self.in_heading = false;
       }
-      self.in_heading = false;
+      // Raw `<hN>` in a table cell and plain text both write no ATX prefix, so
+      // there is no closing sequence to protect.
+      if !self.plain_text && !self.in_table_cell() {
+        self.escape_trailing_heading_hashes();
+      }
     }
 
     // TAG_A exit: write ](url) directly to buffer — zero allocation
-    if !self.plain_text && !has_override && tag_id == Some(TAG_A) && table_separator.is_none() {
+    if !self.plain_text
+      && !has_override
+      && tag_id == Some(TAG_A)
+      && table_separator.is_none()
+      && self.depth_map[TAG_PRE as usize] == 0
+    {
       // Handle whitespace trimming (write_output with None)
       self.write_output(false, is_inline, configured_new_lines, None, false);
       // Write link close directly
@@ -867,10 +897,7 @@ impl ConvertState {
         if title.is_empty() && is_autolink_uri(resolved) {
           let bp = self.link_bracket_pos;
           let buf_bytes = self.buffer.as_bytes();
-          if bp < buf_bytes.len()
-            && buf_bytes[bp] == b'['
-            && &self.buffer[bp + 1..] == resolved
-          {
+          if bp < buf_bytes.len() && buf_bytes[bp] == b'[' && &self.buffer[bp + 1..] == resolved {
             self.buffer.truncate(bp);
             self.buffer.push('<');
             self.buffer.push_str(resolved);
@@ -948,8 +975,7 @@ impl ConvertState {
       output = Some(Cow::Owned(self.finalize_code_span(span)));
     }
     if !has_override
-      && ((tag_id == Some(TAG_CODE) && self.depth_map[TAG_PRE as usize] > 0 && !self.pre_own_fence)
-        || closes_own_pre_fence)
+      && closes_own_pre_fence
       && let Some(delimiter) = self.finalize_code_fence()
       && let Some(exit) = output.as_deref()
     {
@@ -967,12 +993,22 @@ impl ConvertState {
       output.as_deref()
     };
 
+    if tag_id == Some(TAG_LI) && !self.plain_text {
+      self.resolve_item_marker(true);
+    }
+
     self.write_output(false, is_inline, configured_new_lines, effective, false);
 
     // Reset <pre> fence deferral once the element closes (issue #97).
     if tag_id == Some(TAG_PRE) {
+      // The closing fence consumed the trailing newline; clear the whitespace
+      // flags too, or the next node trims the blank line through the fence.
+      if self.pre_fence_open {
+        self.last_text_node_contains_whitespace = false;
+        self.has_last_text_node = false;
+      }
       self.pre_fence_pending = false;
-      self.pre_own_fence = false;
+      self.pre_fence_open = false;
     }
 
     // Record fragment link position for deferred fixup (no String alloc)
@@ -997,15 +1033,18 @@ impl ConvertState {
   fn flush_pre_fence(&mut self) {
     if self.plain_text {
       self.pre_fence_pending = false;
-      self.pre_own_fence = false;
       return;
     }
 
     self.pre_fence_pending = false;
-    self.pre_own_fence = true;
+    self.pre_fence_open = true;
     let li_depth = self.depth_map[TAG_LI as usize];
     let fence = if li_depth > 0 {
-      format!("\n\n{0}```{1}\n{0}", self.list_indent, self.pre_fence_lang)
+      // A blank line between the marker and the fence ends the item, leaving the
+      // block a sibling of the list, so a pending marker takes no separator.
+      let indent = self.list_indent.as_str();
+      let open = self.block_open_prefix(indent).unwrap_or(Cow::Borrowed(""));
+      format!("{open}```{1}\n{0}", indent, self.pre_fence_lang)
     } else {
       format!("```{}\n", self.pre_fence_lang)
     };
@@ -1030,9 +1069,9 @@ impl ConvertState {
     depth: usize,
     index: usize,
   ) {
-    let has_inline_gfm_hazard = text.bytes().any(|byte| {
-      (byte > 32 && byte < 0x80 && is_inline_gfm_hazard(byte)) || matches!(byte, b'\n' | b'\r')
-    });
+    let has_inline_gfm_hazard = text
+      .bytes()
+      .any(|byte| INLINE_GFM_HAZARD[byte as usize] != 0);
     self.text_buffer_has_inline_gfm_hazard |= has_inline_gfm_hazard;
     self.emit_text_with_generated_markdown(text, contains_whitespace, depth, index, None, None);
   }
@@ -1162,6 +1201,12 @@ impl ConvertState {
     };
 
     let inside_raw_html_block = self.in_raw_html_block();
+    if inside_raw_html_block {
+      self.track_raw_html_markdown_context();
+    } else {
+      self.raw_html_markdown = false;
+      self.raw_html_scanned_to = self.buffer.len();
+    }
     let raw_html_storage;
     let text = if !self.plain_text && self.depth_map[TAG_PRE as usize] == 0 && inside_raw_html_block
     {
@@ -1171,24 +1216,32 @@ impl ConvertState {
       text
     };
 
-    let has_contextual_escape = self.depth_map[TAG_TABLE as usize] > 0
-      || self.depth_map[TAG_A as usize] > 0
-      || self.depth_map[TAG_BLOCKQUOTE as usize] > 0;
-    let context_has_gfm_hazard = !inside_raw_html_block
-      && has_contextual_escape
-      && text.bytes().any(|byte| {
-        (byte == b'|' && self.depth_map[TAG_TABLE as usize] > 0)
-          || (byte == b']' && self.depth_map[TAG_A as usize] > 0)
-          || (byte == b'>' && self.depth_map[TAG_BLOCKQUOTE as usize] > 0)
-      });
+    // Loop-invariant container tests, behind a closure so the byte scan runs
+    // only when no cheaper test already decided.
+    let in_table = self.depth_map[TAG_TABLE as usize] > 0;
+    let in_link = self.depth_map[TAG_A as usize] > 0;
+    let in_quote = self.depth_map[TAG_BLOCKQUOTE as usize] > 0;
+    let context_has_gfm_hazard = |text: &str| {
+      !inside_raw_html_block
+        && (in_table || in_link || in_quote)
+        && text.bytes().any(|byte| match byte {
+          b'|' => in_table,
+          b']' => in_link,
+          b'>' => in_quote,
+          _ => false,
+        })
+    };
     let escaped_storage;
     let text = if !self.plain_text
       && self.depth_map[TAG_PRE as usize] == 0
       && self.depth_map[TAG_CODE as usize] == 0
-      && !inside_raw_html_block
       && (has_inline_gfm_hazard
-        || context_has_gfm_hazard
+        || context_has_gfm_hazard(text)
         || self.starts_with_gfm_block_candidate(text))
+      // Past a blank line a raw-HTML region is Markdown again, so its text needs
+      // escaping too — unless this line reopens a raw block.
+      && (!inside_raw_html_block
+        || (self.raw_html_markdown && !self.line_opens_raw_html_block()))
     {
       #[cfg(test)]
       {
@@ -1254,12 +1307,21 @@ impl ConvertState {
     while index < bytes.len() {
       let byte = bytes[index];
 
+      if !GFM_TEXT_ACTIVE[byte as usize] {
+        while index < bytes.len() && !GFM_TEXT_ACTIVE[bytes[index] as usize] {
+          index += 1;
+        }
+        line_indent = None;
+        ordered_digits = 0;
+        continue;
+      }
+
       // A `\&` guarding a decoded entity reference is emitted by the entity
       // decoder; preserve the pair verbatim so this pass never doubles the slash.
       if byte == b'\\'
-        && bytes
-          .get(index + 1)
-          .is_some_and(|&next| next == b'&' && Self::is_entity_reference_after_ampersand(&bytes[index + 1..]))
+        && bytes.get(index + 1).is_some_and(|&next| {
+          next == b'&' && Self::is_entity_reference_after_ampersand(&bytes[index + 1..])
+        })
       {
         line_indent = None;
         ordered_digits = 0;
@@ -1341,6 +1403,12 @@ impl ConvertState {
 
   #[inline]
   fn starts_with_gfm_block_candidate(&self, text: &str) -> bool {
+    // Text-side reject first: prose that cannot open a block skips the buffer
+    // scan entirely, which is most text nodes.
+    match text.as_bytes().first() {
+      Some(b' ' | b'#' | b'-' | b'+' | b'>' | b'0'..=b'9') => {}
+      _ => return false,
+    }
     let Some(mut indent) = self.markdown_line_indent() else {
       return false;
     };
@@ -1352,6 +1420,121 @@ impl ConvertState {
       return matches!(byte, b'#' | b'-' | b'+' | b'>' | b'0'..=b'9');
     }
     false
+  }
+
+  /// GFM reads a heading's trailing `#` run as an ATX closing sequence and drops
+  /// it along with the text it was meant to be, so the run is escaped. Only a run
+  /// preceded by whitespace (or forming the whole heading) closes a heading.
+  fn escape_trailing_heading_hashes(&mut self) {
+    let bytes = self.buffer.as_bytes();
+    // Cheap reject: almost no heading ends in `#`.
+    let mut end = bytes.len();
+    while end > 0 && matches!(bytes[end - 1], b' ' | b'\t') {
+      end -= 1;
+    }
+    if end == 0 || bytes[end - 1] != b'#' {
+      return;
+    }
+    // Content begins past the opening `#` prefix, which this pass must not touch.
+    let line = bytes[..end]
+      .iter()
+      .rposition(|&byte| byte == b'\n')
+      .map_or(0, |i| i + 1);
+    let mut start = line;
+    while start < bytes.len() && bytes[start] == b'#' {
+      start += 1;
+    }
+    start += usize::from(bytes.get(start) == Some(&b' '));
+    if end < start {
+      return;
+    }
+    let mut run = end;
+    while run > start && bytes[run - 1] == b'#' {
+      run -= 1;
+    }
+    if run < end && (run == start || matches!(bytes[run - 1], b' ' | b'\t')) {
+      self.buffer.insert(run, '\\');
+    }
+  }
+
+  /// Whether `end` sits just past a list marker that is all its line holds:
+  /// optional indent, `-`/`*`/`+` or `N.`/`N)`, and nothing else.
+  fn list_marker_line_start(bytes: &[u8], end: usize) -> bool {
+    let mut index = end - 1;
+    match bytes[index] {
+      b'.' | b')' => {
+        let digits = index;
+        while index > 0 && bytes[index - 1].is_ascii_digit() {
+          index -= 1;
+        }
+        if index == digits || digits - index > 9 {
+          return false;
+        }
+      }
+      b'-' | b'*' | b'+' => {}
+      _ => return false,
+    }
+    let mut spaces = 0;
+    while index > 0 && bytes[index - 1] == b' ' && spaces < 3 {
+      index -= 1;
+      spaces += 1;
+    }
+    index == 0 || bytes[index - 1] == b'\n'
+  }
+
+  /// Arm the empty-item guard for the `<li>` whose marker was just written from
+  /// `output_start`. A marker line continuing the paragraph above turns a lone
+  /// marker into a setext underline: the text becomes a heading and the item
+  /// disappears. A blank line, or a sibling marker, opens its own block instead.
+  fn record_item_marker(&mut self, index: usize, output_start: usize) {
+    // Only a list's first item can follow a paragraph, so every later sibling
+    // skips the line scan below.
+    if index != 0 {
+      self.empty_item_hazard = false;
+      return;
+    }
+    let bytes = self.buffer.as_bytes();
+    let line_start = bytes[output_start..]
+      .iter()
+      .rposition(|&byte| byte == b'\n')
+      .map_or(output_start, |i| output_start + i + 1);
+    // Draining removes the front of the buffer, so read through it the way
+    // `write_output` does: `flushed_tail` holds the two bytes before `buffer[0]`.
+    let before = |offset: usize| -> u8 {
+      match line_start.checked_sub(offset) {
+        Some(at) => bytes[at],
+        None if self.has_streamed_output => self.flushed_tail[2 - (offset - line_start)],
+        None => 0,
+      }
+    };
+    let starts_document = line_start == 0 && !self.has_streamed_output;
+    let blank_above = before(1) != b'\n' || before(2) == b'\n';
+    self.empty_item_hazard = !starts_document && !blank_above;
+    self.empty_item_line_start = line_start;
+    self.empty_item_len = self.buffer.len();
+  }
+
+  /// Give a marker that ended up alone on its line the blank line it needs: the
+  /// item is empty, or opened with a block starting on the next line. While
+  /// nothing has been written since the marker the answer is still open, so only
+  /// the `<li>` exit forces one.
+  pub(crate) fn resolve_item_marker(&mut self, at_exit: bool) {
+    if !self.empty_item_hazard {
+      return;
+    }
+    let end = self.empty_item_len.min(self.buffer.len());
+    let tail = self.buffer[end..].trim_start_matches(' ');
+    if tail.is_empty() && !at_exit {
+      return;
+    }
+    self.empty_item_hazard = false;
+    if !tail.is_empty() && !tail.starts_with('\n') {
+      return;
+    }
+    self.buffer.insert(self.empty_item_line_start, '\n');
+    // The insertion moves every cached buffer offset at or past the line.
+    self.line_start_scanned_to = usize::MAX;
+    self.raw_html_scanned_to = self.raw_html_scanned_to.min(self.empty_item_line_start);
   }
 
   #[inline]
@@ -1403,13 +1586,16 @@ impl ConvertState {
   /// Current leading-space count when a GFM block marker may start here.
   #[inline]
   fn markdown_line_indent(&self) -> Option<u8> {
+    let bytes = self.buffer.as_bytes();
     let mut spaces = 0u8;
-    for &byte in self.buffer.as_bytes().iter().rev() {
+    for (offset, &byte) in bytes.iter().enumerate().rev() {
       if byte == b'\n' {
         return Some(spaces);
       }
       if byte != b' ' || spaces == 3 {
-        return None;
+        // A list marker is block prefix too: its content column opens a fresh
+        // block context, so `- # h` escapes exactly like `# h` would.
+        return Self::list_marker_line_start(bytes, offset + 1).then_some(0);
       }
       spaces += 1;
     }
@@ -1566,6 +1752,52 @@ impl ConvertState {
   }
 
   #[inline]
+  /// Note whether the open raw-HTML region has been broken by a blank line.
+  fn track_raw_html_markdown_context(&mut self) {
+    if self.raw_html_markdown {
+      return;
+    }
+    let len = self.buffer.len();
+    // Byte scanning, so a resume point inside a multi-byte character is fine.
+    let from = self.raw_html_scanned_to.min(len).saturating_sub(1);
+    if self.buffer.as_bytes()[from..]
+      .windows(2)
+      .any(|pair| pair == b"\n\n")
+    {
+      self.raw_html_markdown = true;
+    }
+    self.raw_html_scanned_to = len;
+  }
+
+  /// Whether the current line opens a raw HTML block, which suspends Markdown
+  /// again until the next blank line.
+  fn line_opens_raw_html_block(&mut self) -> bool {
+    let len = self.buffer.len();
+    let bytes = self.buffer.as_bytes();
+    // Only bytes appended since the last call can move the line start; a buffer
+    // that shrank behind the cache (a trim, or a streaming drain) rebuilds it.
+    if self.line_start_scanned_to > len || self.line_start > len {
+      self.line_start = bytes[..len]
+        .iter()
+        .rposition(|&byte| byte == b'\n')
+        .map_or(0, |i| i + 1);
+    } else if let Some(i) = bytes[self.line_start_scanned_to..len]
+      .iter()
+      .rposition(|&byte| byte == b'\n')
+    {
+      self.line_start = self.line_start_scanned_to + i + 1;
+    }
+    self.line_start_scanned_to = len;
+
+    let line = &bytes[self.line_start..len];
+    let indent = line
+      .iter()
+      .take(3)
+      .take_while(|&&byte| byte == b' ')
+      .count();
+    line.get(indent) == Some(&b'<')
+  }
+
   pub(crate) fn in_raw_html_block(&self) -> bool {
     self.depth_map[TAG_DETAILS as usize] > 0
       || self.depth_map[TAG_SUMMARY as usize] > 0
@@ -1590,6 +1822,19 @@ impl ConvertState {
       self.buffer_start_column.saturating_add(buffered_column)
     } else {
       buffered_column
+    }
+  }
+
+  /// Separation a block needs to open at the content column `prefix` describes,
+  /// or `None` when the buffer already sits there.
+  fn block_open_prefix(&self, prefix: &str) -> Option<Cow<'static, str>> {
+    match self.buffer.as_bytes().last() {
+      // Empty output, or a pending list marker already at the content column.
+      None | Some(b' ') => None,
+      Some(b'\n') => (!prefix.is_empty()).then(|| Cow::Owned(prefix.to_string())),
+      // Directly under text the block reads as a setext underline or a lazy
+      // continuation, so it has to break the paragraph first.
+      _ => Some(Cow::Owned(format!("\n\n{prefix}"))),
     }
   }
 
@@ -1691,6 +1936,9 @@ impl ConvertState {
     }
 
     let tag_id = node.tag_id?;
+    if self.depth_map[TAG_PRE as usize] > 0 && SUPPRESSED_IN_PRE[tag_id as usize] {
+      return None;
+    }
     match tag_id {
       TAG_DETAILS => Some(Cow::Borrowed("<details>")),
       TAG_SUMMARY => Some(Cow::Borrowed("<summary>")),
@@ -1714,7 +1962,8 @@ impl ConvertState {
       }
       TAG_H1 | TAG_H2 | TAG_H3 | TAG_H4 | TAG_H5 | TAG_H6 => {
         let depth = (tag_id - TAG_H1) as usize;
-        if self.depth_map[TAG_A as usize] > 0 {
+        // A `#` prefix needs its own line, which a GFM row cannot give it.
+        if self.depth_map[TAG_A as usize] > 0 || self.in_table_cell() {
           {
             static H_OPEN: [&str; 6] = ["<h1>", "<h2>", "<h3>", "<h4>", "<h5>", "<h6>"];
             Some(Cow::Borrowed(H_OPEN[depth]))
@@ -1723,7 +1972,27 @@ impl ConvertState {
           Some(Cow::Borrowed(HEADING_PREFIXES[depth]))
         }
       }
-      TAG_HR => Some(Cow::Borrowed(MARKDOWN_HORIZONTAL_RULE)),
+      TAG_HR => {
+        if self.in_table_cell() {
+          // A thematic break cannot end a GFM row; raw <hr> can sit in a cell.
+          return Some(Cow::Borrowed("<hr>"));
+        }
+        // `continuation_prefix` walks the open element stack and allocates, so
+        // only a rule that can actually carry a prefix asks for one.
+        if self.depth_map[TAG_LI as usize] == 0 && self.depth_map[TAG_BLOCKQUOTE as usize] == 0 {
+          return Some(Cow::Borrowed(MARKDOWN_HORIZONTAL_RULE));
+        }
+        let prefix = self.continuation_prefix();
+        if prefix.is_empty() {
+          return Some(Cow::Borrowed(MARKDOWN_HORIZONTAL_RULE));
+        }
+        Some(match self.block_open_prefix(&prefix) {
+          // Sharing the marker's line, where `---` would make the whole line a
+          // thematic break and take the item with it.
+          None => Cow::Borrowed(MARKDOWN_HORIZONTAL_RULE_ALT),
+          Some(open) => Cow::Owned(format!("{open}{MARKDOWN_HORIZONTAL_RULE}")),
+        })
+      }
       TAG_STRONG | TAG_B => {
         if self.depth_map[TAG_B as usize] > 1 {
           Some(Cow::Borrowed(""))
@@ -1755,6 +2024,12 @@ impl ConvertState {
         }
         None
       }
+      // A caption has no handler of its own, so inside a list item nothing writes
+      // its content column: glued to preceding text it swallows the table's first
+      // row, and at column 0 it takes the table out of the item.
+      TAG_CAPTION if self.depth_map[TAG_LI as usize] > 0 && !self.in_table_cell() => {
+        self.block_open_prefix(&self.list_indent)
+      }
       TAG_BLOCKQUOTE => {
         // The completed subtree receives quote prefixes once every structural
         // newline is known. Preserve the list marker's trailing space here.
@@ -1767,18 +2042,20 @@ impl ConvertState {
           if self.in_table_cell() {
             return Some(Cow::Borrowed("<code>"));
           }
-          // The enclosing <pre> already opened its own fence (mixed
-          // text + <code> children); don't emit a nested fence.
-          if self.pre_own_fence {
+          // A fence is already open for this <pre> — the <pre> opened it (mixed
+          // text + <code> children) or an earlier <code> sibling did.
+          if self.pre_fence_open {
             return None;
           }
-          let lang = Self::get_language_from_class(node.attributes.get("class"));
+          let lang = Self::fence_language(&node.attributes);
           let li_depth = self.depth_map[TAG_LI as usize] as usize;
           if li_depth > 0 {
             let indent = self.list_indent.as_str();
-            let mut s = String::with_capacity(2 + indent.len() * 2 + 4 + lang.len() + 1);
-            s.push_str("\n\n");
-            s.push_str(indent);
+            // A blank line between the marker and the fence ends the item, leaving
+            // the block a sibling of the list.
+            let open = self.block_open_prefix(indent).unwrap_or(Cow::Borrowed(""));
+            let mut s = String::with_capacity(open.len() + indent.len() + 4 + lang.len() + 1);
+            s.push_str(&open);
             s.push_str("```");
             s.push_str(lang);
             s.push('\n');
@@ -1845,12 +2122,12 @@ impl ConvertState {
         // the parent's accumulated list_indent — this LI's own marker
         // contribution is pushed onto list_indent AFTER this output
         // is written to the buffer.
-        let is_ordered = _ancestors.last().is_some_and(|p| p.tag_id == Some(TAG_OL));
+        let ordered = _ancestors.last().filter(|p| p.tag_id == Some(TAG_OL));
         let mut s = String::with_capacity(self.list_indent.len() + 6);
         s.push_str(&self.list_indent);
-        if is_ordered {
+        if let Some(list) = ordered {
           use std::fmt::Write;
-          let _ = write!(s, "{}. ", node.index + 1);
+          let _ = write!(s, "{}. ", Self::ordered_item_number(list, node.index));
         } else {
           s.push_str("- ");
         }
@@ -1896,27 +2173,45 @@ impl ConvertState {
       }
       TAG_TR => {
         if self.in_table_cell() {
-          Some(Cow::Borrowed("<tr>"))
+          return Some(Cow::Borrowed("<tr>"));
+        }
+        let indent = if self.depth_map[TAG_LI as usize] > 0 {
+          self.list_indent.as_str()
         } else {
-          Some(Cow::Borrowed("| "))
+          ""
+        };
+        // A row must open its own line at the item's content column: sharing one
+        // with preceding content (a `<caption>`) leaves the header as prose and
+        // the delimiter row never forms a table.
+        match self.line_state_before_row() {
+          LineBeforeRow::Row if indent.is_empty() => Some(Cow::Borrowed("\n| ")),
+          LineBeforeRow::Content if indent.is_empty() => Some(Cow::Borrowed("\n\n| ")),
+          LineBeforeRow::Row => Some(Cow::Owned(format!("\n{indent}| "))),
+          LineBeforeRow::Content => Some(Cow::Owned(format!("\n\n{indent}| "))),
+          // A pending list marker already supplies the column; only a fresh line
+          // needs the indent written.
+          LineBeforeRow::Open
+            if !indent.is_empty() && self.buffer.as_bytes().last() == Some(&b'\n') =>
+          {
+            Some(Cow::Owned(format!("{indent}| ")))
+          }
+          LineBeforeRow::Open => Some(Cow::Borrowed("| ")),
         }
       }
-      TAG_TH => {
+      TAG_TH | TAG_TD => {
         if self.depth_map[TAG_TABLE as usize] > 1 {
-          return Some(Cow::Borrowed("<th>"));
+          return Some(Cow::Borrowed(if tag_id == TAG_TH {
+            "<th>"
+          } else {
+            "<td>"
+          }));
         }
         if node.index == 0 {
           Some(Cow::Borrowed(""))
-        } else {
-          Some(Cow::Borrowed(" | "))
-        }
-      }
-      TAG_TD => {
-        if self.depth_map[TAG_TABLE as usize] > 1 {
-          return Some(Cow::Borrowed("<td>"));
-        }
-        if node.index == 0 {
-          Some(Cow::Borrowed(""))
+        } else if self.cell_overflows_header() {
+          // GFM discards cells past the delimiter row's width, so this one folds
+          // into the previous cell rather than vanishing.
+          Some(Cow::Borrowed(" "))
         } else {
           Some(Cow::Borrowed(" | "))
         }
@@ -1953,6 +2248,9 @@ impl ConvertState {
     }
 
     let tag_id = node.tag_id?;
+    if self.depth_map[TAG_PRE as usize] > 0 && SUPPRESSED_IN_PRE[tag_id as usize] {
+      return None;
+    }
     match tag_id {
       // Inside a table cell the trailing block break would split the GFM row,
       // so emit the raw close tags with no newlines (issue #147).
@@ -1962,7 +2260,7 @@ impl ConvertState {
       TAG_SUMMARY => Some(Cow::Borrowed("</summary>\n\n")),
       TAG_H1 | TAG_H2 | TAG_H3 | TAG_H4 | TAG_H5 | TAG_H6 => {
         let depth = (tag_id - TAG_H1 + 1) as usize;
-        if self.depth_map[TAG_A as usize] > 0 {
+        if self.depth_map[TAG_A as usize] > 0 || self.in_table_cell() {
           {
             static H_CLOSE: [&str; 6] = ["</h1>", "</h2>", "</h3>", "</h4>", "</h5>", "</h6>"];
             Some(Cow::Borrowed(H_CLOSE[depth - 1]))
@@ -1995,22 +2293,9 @@ impl ConvertState {
           if self.in_table_cell() {
             return Some(Cow::Borrowed("</code>"));
           }
-          // The enclosing <pre> owns the fence; this <code> opened none.
-          if self.pre_own_fence {
-            return None;
-          }
-          let li_depth = self.depth_map[TAG_LI as usize] as usize;
-          if li_depth > 0 {
-            let indent = self.list_indent.as_str();
-            let mut s = String::with_capacity(1 + indent.len() * 2 + 5);
-            s.push('\n');
-            s.push_str(indent);
-            s.push_str("```\n\n");
-            s.push_str(indent);
-            Some(Cow::Owned(s))
-          } else {
-            Some(Cow::Borrowed("\n```"))
-          }
+          // The <pre> exit owns the closing fence, so a text sibling after this
+          // </code> still lands inside the block.
+          None
         } else if self.in_raw_html_block() {
           Some(Cow::Borrowed("</code>"))
         } else {
@@ -2023,7 +2308,7 @@ impl ConvertState {
       // when the <pre> opened its own fence; otherwise a <code> child or an
       // empty/whitespace-only <pre> means there is nothing to close.
       TAG_PRE => {
-        if !self.pre_own_fence {
+        if !self.pre_fence_open {
           return None;
         }
         let li_depth = self.depth_map[TAG_LI as usize] as usize;
@@ -2060,6 +2345,13 @@ impl ConvertState {
           None
         }
       }
+      TAG_TR => {
+        if self.in_table_cell() || self.depth_map[TAG_TABLE as usize] > 1 {
+          Some(Cow::Borrowed("</tr>"))
+        } else {
+          Some(Cow::Borrowed(" |"))
+        }
+      }
       TAG_TABLE => {
         if self.in_table_cell() {
           Some(Cow::Borrowed("</table>"))
@@ -2074,25 +2366,15 @@ impl ConvertState {
           None
         }
       }
-      TAG_TR => {
-        if self.in_table_cell() || self.depth_map[TAG_TABLE as usize] > 1 {
-          Some(Cow::Borrowed("</tr>"))
-        } else {
-          Some(Cow::Borrowed(" |"))
-        }
-      }
-      TAG_TH => {
+      TAG_TH | TAG_TD => {
         if self.depth_map[TAG_TABLE as usize] > 1 {
-          Some(Cow::Borrowed("</th>"))
+          Some(Cow::Borrowed(if tag_id == TAG_TH {
+            "</th>"
+          } else {
+            "</td>"
+          }))
         } else {
-          None
-        }
-      }
-      TAG_TD => {
-        if self.depth_map[TAG_TABLE as usize] > 1 {
-          Some(Cow::Borrowed("</td>"))
-        } else {
-          None
+          self.span_filler(node)
         }
       }
       TAG_CENTER => {
@@ -2455,8 +2737,11 @@ impl ConvertState {
     } else if self.depth_map[TAG_LI as usize] > 0 || self.depth_map[TAG_BLOCKQUOTE as usize] > 0 {
       return NO_SPACING;
     }
-    let current_heading_owns_collapse =
-      tag_id.is_some_and(|id| (TAG_H1..=TAG_H6).contains(&id)) && self.collapse_non_span_depth == 1;
+    // A heading normally keeps its block spacing inside a collapsing parent, but
+    // in a table cell that newline would end the row.
+    let current_heading_owns_collapse = tag_id.is_some_and(|id| (TAG_H1..=TAG_H6).contains(&id))
+      && self.collapse_non_span_depth == 1
+      && !self.in_table_cell();
     if self.collapse_non_span_depth > 0 && !current_heading_owns_collapse {
       return NO_SPACING;
     }
@@ -2500,6 +2785,92 @@ impl ConvertState {
       }
     }
     ""
+  }
+
+  /// What the current line holds where a table row is about to be written.
+  fn line_state_before_row(&self) -> LineBeforeRow {
+    let bytes = self.buffer.as_bytes();
+    // Rows end their line, so the row after a row decides on one byte and never
+    // rescans the line it just wrote.
+    if matches!(bytes.last(), None | Some(b'\n')) {
+      return LineBeforeRow::Open;
+    }
+    let mut index = bytes.len();
+    while index > 0 && bytes[index - 1] != b'\n' {
+      index -= 1;
+    }
+    let line = &bytes[index..];
+    let start = line
+      .iter()
+      .position(|byte| !matches!(byte, b' ' | b'\t'))
+      .unwrap_or(line.len());
+    match line.get(start) {
+      // A row already open only needs its line broken, not a new block.
+      Some(b'|') => LineBeforeRow::Row,
+      None => LineBeforeRow::Open,
+      // A pending list marker is block prefix, not content: a table's first row
+      // belongs on it.
+      Some(_) if Self::list_marker_line_start(bytes, bytes.len() - trailing_spaces(bytes)) => {
+        LineBeforeRow::Open
+      }
+      Some(_) => LineBeforeRow::Content,
+    }
+  }
+
+  /// How many columns a cell occupies. GFM has no `colspan`, so a spanned cell
+  /// is written as its content followed by empty cells; without them the
+  /// delimiter row is too narrow and GFM drops every cell past it.
+  #[inline]
+  pub(crate) fn cell_span(node: &ElementNode) -> u8 {
+    node.cell_span.clamp(1, MAX_CELL_SPAN)
+  }
+
+  /// Empty cells standing in for the columns a `colspan` swallowed.
+  fn span_filler(&self, node: &ElementNode) -> Option<Cow<'static, str>> {
+    match Self::cell_span(node) {
+      1 => None,
+      span => Some(Cow::Borrowed(
+        std::str::from_utf8(&SPAN_FILLER[..(span as usize - 1) * 2]).unwrap_or(" |"),
+      )),
+    }
+  }
+
+  /// Whether the cell about to open sits past the width the delimiter promised.
+  #[inline]
+  fn cell_overflows_header(&self) -> bool {
+    self.table_header_cells > 0 && self.table_current_row_cells >= self.table_header_cells
+  }
+
+  /// Marker number for an `<ol>`'s nth item. GFM numbers a list from its first
+  /// item's marker, so only that one has to carry `start`.
+  pub(crate) fn ordered_item_number(list: &ElementNode, index: usize) -> u32 {
+    list
+      .attributes
+      .get("start")
+      .and_then(|value| value.trim_ascii().parse::<u32>().ok())
+      .unwrap_or(1)
+      .saturating_add(index as u32)
+  }
+
+  /// Fence info string for a `<pre>`/`<code>`: `class="language-x"` first, then
+  /// `lang="x"`, the form cmark-gfm itself emits. A `lang` carrying a subtag
+  /// (`en-US`) or spaces is a human language, never an info string.
+  pub(crate) fn fence_language(attributes: &Attributes) -> &str {
+    let from_class = Self::get_language_from_class(attributes.get("class"));
+    if !from_class.is_empty() {
+      return from_class;
+    }
+    match attributes.get("lang") {
+      Some(lang)
+        if !lang.is_empty()
+          && !lang
+            .bytes()
+            .any(|byte| byte == b'-' || is_unsafe_fence_info_byte(byte)) =>
+      {
+        lang
+      }
+      _ => "",
+    }
   }
 }
 

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -667,11 +667,11 @@ impl ConvertState {
           walked += 1;
           close_count = walked;
         }
-        // Content left open inside a cell (`<td><p>text` with no `</p>`) sits
-        // above the closeable element and closes with it; stopping here would
-        // leave the new row nested inside the old cell.
-        Some(id) if !ROW_SCOPE_BOUNDARY[id as usize] => walked += 1,
-        _ => break,
+        // Content left open inside a cell (`<td><p>text` with no `</p>`, or an
+        // unknown custom element) sits above the closeable element and closes
+        // with it; stopping here would leave the new row nested in the old cell.
+        Some(id) if ROW_SCOPE_BOUNDARY[id as usize] => break,
+        _ => walked += 1,
       }
     }
     for _ in 0..close_count {

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -166,10 +166,6 @@ const DL_SCOPE_BOUNDARY: [bool; 256] = tag_set(&[
   TAG_HTML,
 ]);
 
-/// Where a row-recovery scan stops: the table itself, and the contexts that hold
-/// their own table structure.
-const ROW_SCOPE_BOUNDARY: [bool; 256] = tag_set(&[TAG_TABLE, TAG_TEMPLATE, TAG_CAPTION]);
-
 /// "Table cell scope" terminators: a new `<td>`/`<th>` closes the current cell
 /// (and any inline content left open inside it), stopping at the row/section.
 const CELL_SCOPE_BOUNDARY: [bool; 256] = tag_set(&[
@@ -409,7 +405,6 @@ impl ConvertState {
       excludes_text_nodes: handler.excludes_text_nodes,
       is_non_nesting: handler.is_non_nesting,
       collapses_inner_white_space: handler.collapses_inner_white_space,
-      cell_span: 0,
       spacing: handler.spacing,
     };
     if self.has_tailwind
@@ -670,7 +665,7 @@ impl ConvertState {
         // Content left open inside a cell (`<td><p>text` with no `</p>`, or an
         // unknown custom element) sits above the closeable element and closes
         // with it; stopping here would leave the new row nested in the old cell.
-        Some(id) if ROW_SCOPE_BOUNDARY[id as usize] => break,
+        Some(TAG_TABLE | TAG_TEMPLATE | TAG_CAPTION) => break,
         _ => walked += 1,
       }
     }
@@ -752,7 +747,7 @@ impl ConvertState {
       } else {
         tag_handler.map_or(ATTR_NONE, |h| h.wanted_attrs)
       };
-    let (complete, new_position, attributes, self_closing, cell_span) =
+    let (complete, new_position, attributes, self_closing) =
       process_tag_attributes(html_chunk, position, tag_handler, attr_mask);
 
     if !complete {
@@ -1002,14 +997,12 @@ impl ConvertState {
       pooled.excludes_text_nodes = h_excludes;
       pooled.is_non_nesting = h_non_nesting;
       pooled.collapses_inner_white_space = h_collapses;
-      pooled.cell_span = cell_span;
       pooled.spacing = h_spacing;
       pooled
     } else {
       ElementNode {
         custom_name,
         attributes,
-        cell_span,
         tag_id,
         depth: self.depth,
         index: current_walk_index,

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -166,6 +166,10 @@ const DL_SCOPE_BOUNDARY: [bool; 256] = tag_set(&[
   TAG_HTML,
 ]);
 
+/// Where a row-recovery scan stops: the table itself, and the contexts that hold
+/// their own table structure.
+const ROW_SCOPE_BOUNDARY: [bool; 256] = tag_set(&[TAG_TABLE, TAG_TEMPLATE, TAG_CAPTION]);
+
 /// "Table cell scope" terminators: a new `<td>`/`<th>` closes the current cell
 /// (and any inline content left open inside it), stopping at the row/section.
 const CELL_SCOPE_BOUNDARY: [bool; 256] = tag_set(&[
@@ -405,6 +409,7 @@ impl ConvertState {
       excludes_text_nodes: handler.excludes_text_nodes,
       is_non_nesting: handler.is_non_nesting,
       collapses_inner_white_space: handler.collapses_inner_white_space,
+      cell_span: 0,
       spacing: handler.spacing,
     };
     if self.has_tailwind
@@ -652,11 +657,25 @@ impl ConvertState {
       self.clear_overflow();
     }
 
-    while let Some(top) = self.stack.last() {
-      match top.tag_id {
-        Some(id) if closeable[id as usize] => self.close_node(),
+    // One reverse pass, as in `close_implied_to`: re-deciding after each close
+    // walks the stack once per closed node.
+    let mut close_count = 0usize;
+    let mut walked = 0usize;
+    for node in self.stack.iter().rev() {
+      match node.tag_id {
+        Some(id) if closeable[id as usize] => {
+          walked += 1;
+          close_count = walked;
+        }
+        // Content left open inside a cell (`<td><p>text` with no `</p>`) sits
+        // above the closeable element and closes with it; stopping here would
+        // leave the new row nested inside the old cell.
+        Some(id) if !ROW_SCOPE_BOUNDARY[id as usize] => walked += 1,
         _ => break,
       }
+    }
+    for _ in 0..close_count {
+      self.close_node();
     }
   }
 
@@ -733,7 +752,7 @@ impl ConvertState {
       } else {
         tag_handler.map_or(ATTR_NONE, |h| h.wanted_attrs)
       };
-    let (complete, new_position, attributes, self_closing) =
+    let (complete, new_position, attributes, self_closing, cell_span) =
       process_tag_attributes(html_chunk, position, tag_handler, attr_mask);
 
     if !complete {
@@ -983,12 +1002,14 @@ impl ConvertState {
       pooled.excludes_text_nodes = h_excludes;
       pooled.is_non_nesting = h_non_nesting;
       pooled.collapses_inner_white_space = h_collapses;
+      pooled.cell_span = cell_span;
       pooled.spacing = h_spacing;
       pooled
     } else {
       ElementNode {
         custom_name,
         attributes,
+        cell_span,
         tag_id,
         depth: self.depth,
         index: current_walk_index,
@@ -1225,7 +1246,9 @@ impl ConvertState {
         let stack_len = self.stack.len();
         let parent_is_ordered = stack_len >= 2 && self.stack[stack_len - 2].tag_id == Some(TAG_OL);
         if parent_is_ordered {
-          let n = li.index + 1;
+          // Must match the marker actually written, `start` included, or the
+          // item's continuation content drifts out of it.
+          let n = Self::ordered_item_number(&self.stack[stack_len - 2], li.index).max(1);
           // n >= 1 so ilog10 never panics; +1 converts floor(log10) to digit count.
           let digits = (n.ilog10() + 1) as usize;
           digits + 2

--- a/crates/core/src/scan.rs
+++ b/crates/core/src/scan.rs
@@ -100,7 +100,7 @@ pub(crate) fn process_tag_attributes(
   position: usize,
   tag_handler: Option<&crate::types::TagHandler>,
   attr_mask: u16,
-) -> (bool, usize, Attributes, bool) {
+) -> (bool, usize, Attributes, bool, u8) {
   let self_closing = tag_handler.is_some_and(|h| h.is_self_closing);
   if attr_mask == ATTR_NONE {
     scan_tag::<false>(html_chunk, position, self_closing, ATTR_NONE)
@@ -118,7 +118,7 @@ fn scan_tag<const EXTRACT: bool>(
   position: usize,
   self_closing: bool,
   attr_mask: u16,
-) -> (bool, usize, Attributes, bool) {
+) -> (bool, usize, Attributes, bool, u8) {
   let bytes = html_chunk.as_bytes();
   let chunk_length = bytes.len();
   let mut scan = AttrScan::new(attr_mask);
@@ -148,10 +148,12 @@ fn scan_tag<const EXTRACT: bool>(
       && i + 1 < chunk_length
       && bytes[i + 1] == GT_CHAR
     {
-      return (true, i + 2, scan.finish(html_chunk, i), true);
+      let (attrs, span) = scan.finish(html_chunk, i);
+      return (true, i + 2, attrs, true, span);
     }
     if c == GT_CHAR {
-      return (true, i + 1, scan.finish(html_chunk, i), self_closing);
+      let (attrs, span) = scan.finish(html_chunk, i);
+      return (true, i + 1, attrs, self_closing, span);
     }
 
     // Run to the closing quote without re-entering the state dispatch.
@@ -163,7 +165,7 @@ fn scan_tag<const EXTRACT: bool>(
       }
       if end == chunk_length {
         // Unterminated: the tag cannot close in this chunk.
-        return (false, chunk_length, Attributes::new(), false);
+        return (false, chunk_length, Attributes::new(), false, 0);
       }
       scan.take_value(html_chunk, value_start, end);
       i = end + 1;
@@ -183,15 +185,26 @@ fn scan_tag<const EXTRACT: bool>(
     i += 1;
   }
 
-  (false, i, Attributes::new(), false)
+  (false, i, Attributes::new(), false, 0)
 }
 
 /// Mask rejection happens before any lowercasing or entity decoding, so
 /// unwanted attributes cost no allocations.
 #[inline]
-fn push_attr(result: &mut Attributes, mask: u16, raw: &str, value: Option<&str>) {
-  if !attr_wanted(mask, raw.as_bytes()) {
+fn push_attr(result: &mut Attributes, mask: u16, raw: &str, value: Option<&str>, span: &mut u8) {
+  let bit = attr_bit(raw.as_bytes());
+  if mask != ATTR_ALL && mask & bit == 0 {
     return;
+  }
+  // Plugins request every attribute, so `ATTR_ALL` stores `colspan` as a string
+  // too; a mask asking for it alone only needs the scalar.
+  if bit == ATTR_COLSPAN {
+    *span = value
+      .and_then(|value| value.trim_ascii().parse::<u8>().ok())
+      .unwrap_or(0);
+    if mask != ATTR_ALL {
+      return;
+    }
   }
   let name = raw.to_ascii_lowercase();
   match value {
@@ -205,6 +218,8 @@ fn push_attr(result: &mut Attributes, mask: u16, raw: &str, value: Option<&str>)
 struct AttrScan {
   mask: u16,
   result: Attributes,
+  /// `colspan`, parsed in place rather than stored as strings. 0 when absent.
+  cell_span: u8,
   state: State,
   name_start: usize,
   name_end: usize,
@@ -279,6 +294,7 @@ impl AttrScan {
       } else {
         Attributes::new()
       },
+      cell_span: 0,
       state: State::Gap,
       name_start: 0,
       name_end: 0,
@@ -298,6 +314,7 @@ impl AttrScan {
       self.mask,
       &chunk[self.name_start..self.name_end],
       Some(&chunk[value_start..value_end]),
+      &mut self.cell_span,
     );
     self.state = State::Gap;
   }
@@ -309,6 +326,7 @@ impl AttrScan {
       self.mask,
       &chunk[self.name_start..name_end],
       None,
+      &mut self.cell_span,
     );
   }
 
@@ -358,14 +376,14 @@ impl AttrScan {
 
   /// Take the attribute still open when the tag ended at `end`.
   #[inline]
-  fn finish(mut self, chunk: &str, end: usize) -> Attributes {
+  fn finish(mut self, chunk: &str, end: usize) -> (Attributes, u8) {
     match self.state {
       State::Name => self.take_bare_name(chunk, end),
       State::AfterName | State::BeforeValue => self.take_bare_name(chunk, self.name_end),
       State::UnquotedValue => self.take_value(chunk, self.value_start, end),
       State::Gap => {}
     }
-    self.result
+    (self.result, self.cell_span)
   }
 }
 
@@ -373,7 +391,7 @@ impl AttrScan {
 /// inside `<…>`.
 #[cfg(test)]
 pub(crate) fn parse_attributes(attr_str: &str, mask: u16) -> Attributes {
-  let (_, _, attrs, _) = process_tag_attributes(&format!("{attr_str}>"), 0, None, mask);
+  let (_, _, attrs, _, _) = process_tag_attributes(&format!("{attr_str}>"), 0, None, mask);
   attrs
 }
 
@@ -509,7 +527,7 @@ mod tests {
   fn process_tag_attributes_finds_close() {
     // "<a href=\"x\">" — scan from after the tag name
     let html = "a href=\"x\">rest";
-    let (complete, new_pos, attrs, self_closing) =
+    let (complete, new_pos, attrs, self_closing, _) =
       process_tag_attributes(html, 1, None, ATTR_ALL);
     assert!(complete);
     assert!(!self_closing);
@@ -522,7 +540,7 @@ mod tests {
     // The closing quote may still arrive in the next chunk, so nothing is
     // reported until it does.
     let html = "a href=\"x";
-    let (complete, _, attrs, _) = process_tag_attributes(html, 1, None, ATTR_ALL);
+    let (complete, _, attrs, _, _) = process_tag_attributes(html, 1, None, ATTR_ALL);
     assert!(!complete);
     assert!(attrs.is_empty());
   }
@@ -530,7 +548,7 @@ mod tests {
   #[test]
   fn a_quoted_value_hides_a_tag_terminator() {
     let html = "a href=\"x>y\">rest";
-    let (complete, new_pos, attrs, _) = process_tag_attributes(html, 1, None, ATTR_ALL);
+    let (complete, new_pos, attrs, _, _) = process_tag_attributes(html, 1, None, ATTR_ALL);
     assert!(complete);
     assert_eq!(attrs.get("href").map(String::as_str), Some("x>y"));
     assert_eq!(&html[new_pos..], "rest");
@@ -551,18 +569,15 @@ mod tests {
       ("a href=x='y>rest", 12),
       ("a>rest", 2),
     ] {
-      let (complete, extracted_pos, _, extracted_self_closing) =
+      let (complete, extracted_pos, _, extracted_self_closing, _) =
         process_tag_attributes(html, 1, None, ATTR_ALL);
-      let (bare_complete, bare_pos, bare_attrs, bare_self_closing) =
+      let (bare_complete, bare_pos, bare_attrs, bare_self_closing, _) =
         process_tag_attributes(html, 1, None, ATTR_NONE);
       assert!(complete, "html={html:?}");
       assert_eq!(extracted_pos, end, "html={html:?}");
       assert_eq!(complete, bare_complete, "html={html:?}");
       assert_eq!(extracted_pos, bare_pos, "html={html:?}");
-      assert_eq!(
-        extracted_self_closing, bare_self_closing,
-        "html={html:?}"
-      );
+      assert_eq!(extracted_self_closing, bare_self_closing, "html={html:?}");
       assert!(bare_attrs.is_empty(), "html={html:?}");
     }
   }
@@ -736,8 +751,9 @@ mod tests {
         encoded /= ALPHABET.len();
       }
       let html = std::str::from_utf8(&input).expect("ASCII alphabet");
-      let (complete, position, _, self_closing) = process_tag_attributes(html, 0, None, ATTR_ALL);
-      let (bare_complete, bare_position, bare_attrs, bare_self_closing) =
+      let (complete, position, _, self_closing, _) =
+        process_tag_attributes(html, 0, None, ATTR_ALL);
+      let (bare_complete, bare_position, bare_attrs, bare_self_closing, _) =
         process_tag_attributes(html, 0, None, ATTR_NONE);
 
       assert_eq!(complete, bare_complete, "html={html:?}");

--- a/crates/core/src/scan.rs
+++ b/crates/core/src/scan.rs
@@ -100,7 +100,7 @@ pub(crate) fn process_tag_attributes(
   position: usize,
   tag_handler: Option<&crate::types::TagHandler>,
   attr_mask: u16,
-) -> (bool, usize, Attributes, bool, u8) {
+) -> (bool, usize, Attributes, bool) {
   let self_closing = tag_handler.is_some_and(|h| h.is_self_closing);
   if attr_mask == ATTR_NONE {
     scan_tag::<false>(html_chunk, position, self_closing, ATTR_NONE)
@@ -118,7 +118,7 @@ fn scan_tag<const EXTRACT: bool>(
   position: usize,
   self_closing: bool,
   attr_mask: u16,
-) -> (bool, usize, Attributes, bool, u8) {
+) -> (bool, usize, Attributes, bool) {
   let bytes = html_chunk.as_bytes();
   let chunk_length = bytes.len();
   let mut scan = AttrScan::new(attr_mask);
@@ -148,12 +148,12 @@ fn scan_tag<const EXTRACT: bool>(
       && i + 1 < chunk_length
       && bytes[i + 1] == GT_CHAR
     {
-      let (attrs, span) = scan.finish(html_chunk, i);
-      return (true, i + 2, attrs, true, span);
+      let attrs = scan.finish(html_chunk, i);
+      return (true, i + 2, attrs, true);
     }
     if c == GT_CHAR {
-      let (attrs, span) = scan.finish(html_chunk, i);
-      return (true, i + 1, attrs, self_closing, span);
+      let attrs = scan.finish(html_chunk, i);
+      return (true, i + 1, attrs, self_closing);
     }
 
     // Run to the closing quote without re-entering the state dispatch.
@@ -165,7 +165,7 @@ fn scan_tag<const EXTRACT: bool>(
       }
       if end == chunk_length {
         // Unterminated: the tag cannot close in this chunk.
-        return (false, chunk_length, Attributes::new(), false, 0);
+        return (false, chunk_length, Attributes::new(), false);
       }
       scan.take_value(html_chunk, value_start, end);
       i = end + 1;
@@ -185,26 +185,16 @@ fn scan_tag<const EXTRACT: bool>(
     i += 1;
   }
 
-  (false, i, Attributes::new(), false, 0)
+  (false, i, Attributes::new(), false)
 }
 
 /// Mask rejection happens before any lowercasing or entity decoding, so
 /// unwanted attributes cost no allocations.
 #[inline]
-fn push_attr(result: &mut Attributes, mask: u16, raw: &str, value: Option<&str>, span: &mut u8) {
+fn push_attr(result: &mut Attributes, mask: u16, raw: &str, value: Option<&str>) {
   let bit = attr_bit(raw.as_bytes());
   if mask != ATTR_ALL && mask & bit == 0 {
     return;
-  }
-  // Plugins request every attribute, so `ATTR_ALL` stores `colspan` as a string
-  // too; a mask asking for it alone only needs the scalar.
-  if bit == ATTR_COLSPAN {
-    *span = value
-      .and_then(|value| value.trim_ascii().parse::<u8>().ok())
-      .unwrap_or(0);
-    if mask != ATTR_ALL {
-      return;
-    }
   }
   let name = raw.to_ascii_lowercase();
   match value {
@@ -218,8 +208,6 @@ fn push_attr(result: &mut Attributes, mask: u16, raw: &str, value: Option<&str>,
 struct AttrScan {
   mask: u16,
   result: Attributes,
-  /// `colspan`, parsed in place rather than stored as strings. 0 when absent.
-  cell_span: u8,
   state: State,
   name_start: usize,
   name_end: usize,
@@ -294,7 +282,6 @@ impl AttrScan {
       } else {
         Attributes::new()
       },
-      cell_span: 0,
       state: State::Gap,
       name_start: 0,
       name_end: 0,
@@ -314,7 +301,6 @@ impl AttrScan {
       self.mask,
       &chunk[self.name_start..self.name_end],
       Some(&chunk[value_start..value_end]),
-      &mut self.cell_span,
     );
     self.state = State::Gap;
   }
@@ -326,7 +312,6 @@ impl AttrScan {
       self.mask,
       &chunk[self.name_start..name_end],
       None,
-      &mut self.cell_span,
     );
   }
 
@@ -376,14 +361,14 @@ impl AttrScan {
 
   /// Take the attribute still open when the tag ended at `end`.
   #[inline]
-  fn finish(mut self, chunk: &str, end: usize) -> (Attributes, u8) {
+  fn finish(mut self, chunk: &str, end: usize) -> Attributes {
     match self.state {
       State::Name => self.take_bare_name(chunk, end),
       State::AfterName | State::BeforeValue => self.take_bare_name(chunk, self.name_end),
       State::UnquotedValue => self.take_value(chunk, self.value_start, end),
       State::Gap => {}
     }
-    (self.result, self.cell_span)
+    self.result
   }
 }
 
@@ -391,7 +376,7 @@ impl AttrScan {
 /// inside `<…>`.
 #[cfg(test)]
 pub(crate) fn parse_attributes(attr_str: &str, mask: u16) -> Attributes {
-  let (_, _, attrs, _, _) = process_tag_attributes(&format!("{attr_str}>"), 0, None, mask);
+  let (_, _, attrs, _) = process_tag_attributes(&format!("{attr_str}>"), 0, None, mask);
   attrs
 }
 
@@ -523,36 +508,18 @@ mod tests {
     assert!(all.contains_key("href") && all.contains_key("class"));
   }
 
-  /// `colspan` is carried out of the scan as a scalar so a cell never has to
-  /// re-parse its own attribute string. A value that is not a `u8` is not a span.
   #[test]
-  fn colspan_is_scanned_into_a_scalar() {
-    fn span(attr_str: &str, mask: u16) -> (u8, bool) {
-      let (_, _, attrs, _, span) = process_tag_attributes(&format!("{attr_str}>"), 0, None, mask);
-      (span, attrs.contains_key("colspan"))
-    }
-
-    assert_eq!(span("colspan=2", ATTR_ALL), (2, true));
-    assert_eq!(span("colspan=\" 3 \"", ATTR_ALL), (3, true));
-    assert_eq!(span("COLSPAN=4", ATTR_ALL), (4, true));
-    assert_eq!(span("colspan=255", ATTR_ALL), (255, true));
-    // Not a span: wider than a `u8`, non-numeric, negative, or absent entirely.
-    assert_eq!(span("colspan=256", ATTR_ALL), (0, true));
-    assert_eq!(span("colspan=abc", ATTR_ALL), (0, true));
-    assert_eq!(span("colspan=-1", ATTR_ALL), (0, true));
-    assert_eq!(span("colspan", ATTR_ALL), (0, true));
-    assert_eq!(span("id=x", ATTR_ALL), (0, false));
-    // A mask asking for the span alone needs no string copy of it.
-    assert_eq!(span("colspan=2 id=x", ATTR_COLSPAN), (2, false));
-    assert_eq!(span("colspan=2", ATTR_NONE), (0, false));
+  fn colspan_uses_the_filtered_attribute_path() {
+    let attrs = parse_attributes("colspan=2 id=x", ATTR_COLSPAN);
+    assert_eq!(attrs.get("colspan").map(String::as_str), Some("2"));
+    assert!(!attrs.contains_key("id"));
   }
 
   #[test]
   fn process_tag_attributes_finds_close() {
     // "<a href=\"x\">" — scan from after the tag name
     let html = "a href=\"x\">rest";
-    let (complete, new_pos, attrs, self_closing, _) =
-      process_tag_attributes(html, 1, None, ATTR_ALL);
+    let (complete, new_pos, attrs, self_closing) = process_tag_attributes(html, 1, None, ATTR_ALL);
     assert!(complete);
     assert!(!self_closing);
     assert_eq!(&html[new_pos..], "rest");
@@ -564,7 +531,7 @@ mod tests {
     // The closing quote may still arrive in the next chunk, so nothing is
     // reported until it does.
     let html = "a href=\"x";
-    let (complete, _, attrs, _, _) = process_tag_attributes(html, 1, None, ATTR_ALL);
+    let (complete, _, attrs, _) = process_tag_attributes(html, 1, None, ATTR_ALL);
     assert!(!complete);
     assert!(attrs.is_empty());
   }
@@ -572,7 +539,7 @@ mod tests {
   #[test]
   fn a_quoted_value_hides_a_tag_terminator() {
     let html = "a href=\"x>y\">rest";
-    let (complete, new_pos, attrs, _, _) = process_tag_attributes(html, 1, None, ATTR_ALL);
+    let (complete, new_pos, attrs, _) = process_tag_attributes(html, 1, None, ATTR_ALL);
     assert!(complete);
     assert_eq!(attrs.get("href").map(String::as_str), Some("x>y"));
     assert_eq!(&html[new_pos..], "rest");
@@ -593,9 +560,9 @@ mod tests {
       ("a href=x='y>rest", 12),
       ("a>rest", 2),
     ] {
-      let (complete, extracted_pos, _, extracted_self_closing, _) =
+      let (complete, extracted_pos, _, extracted_self_closing) =
         process_tag_attributes(html, 1, None, ATTR_ALL);
-      let (bare_complete, bare_pos, bare_attrs, bare_self_closing, _) =
+      let (bare_complete, bare_pos, bare_attrs, bare_self_closing) =
         process_tag_attributes(html, 1, None, ATTR_NONE);
       assert!(complete, "html={html:?}");
       assert_eq!(extracted_pos, end, "html={html:?}");
@@ -775,9 +742,8 @@ mod tests {
         encoded /= ALPHABET.len();
       }
       let html = std::str::from_utf8(&input).expect("ASCII alphabet");
-      let (complete, position, _, self_closing, _) =
-        process_tag_attributes(html, 0, None, ATTR_ALL);
-      let (bare_complete, bare_position, bare_attrs, bare_self_closing, _) =
+      let (complete, position, _, self_closing) = process_tag_attributes(html, 0, None, ATTR_ALL);
+      let (bare_complete, bare_position, bare_attrs, bare_self_closing) =
         process_tag_attributes(html, 0, None, ATTR_NONE);
 
       assert_eq!(complete, bare_complete, "html={html:?}");

--- a/crates/core/src/scan.rs
+++ b/crates/core/src/scan.rs
@@ -523,6 +523,30 @@ mod tests {
     assert!(all.contains_key("href") && all.contains_key("class"));
   }
 
+  /// `colspan` is carried out of the scan as a scalar so a cell never has to
+  /// re-parse its own attribute string. A value that is not a `u8` is not a span.
+  #[test]
+  fn colspan_is_scanned_into_a_scalar() {
+    fn span(attr_str: &str, mask: u16) -> (u8, bool) {
+      let (_, _, attrs, _, span) = process_tag_attributes(&format!("{attr_str}>"), 0, None, mask);
+      (span, attrs.contains_key("colspan"))
+    }
+
+    assert_eq!(span("colspan=2", ATTR_ALL), (2, true));
+    assert_eq!(span("colspan=\" 3 \"", ATTR_ALL), (3, true));
+    assert_eq!(span("COLSPAN=4", ATTR_ALL), (4, true));
+    assert_eq!(span("colspan=255", ATTR_ALL), (255, true));
+    // Not a span: wider than a `u8`, non-numeric, negative, or absent entirely.
+    assert_eq!(span("colspan=256", ATTR_ALL), (0, true));
+    assert_eq!(span("colspan=abc", ATTR_ALL), (0, true));
+    assert_eq!(span("colspan=-1", ATTR_ALL), (0, true));
+    assert_eq!(span("colspan", ATTR_ALL), (0, true));
+    assert_eq!(span("id=x", ATTR_ALL), (0, false));
+    // A mask asking for the span alone needs no string copy of it.
+    assert_eq!(span("colspan=2 id=x", ATTR_COLSPAN), (2, false));
+    assert_eq!(span("colspan=2", ATTR_NONE), (0, false));
+  }
+
   #[test]
   fn process_tag_attributes_finds_close() {
     // "<a href=\"x\">" — scan from after the tag name

--- a/crates/core/src/tags.rs
+++ b/crates/core/src/tags.rs
@@ -149,13 +149,16 @@ static TAG_HANDLERS: [Option<TagHandler>; MAX_TAG_ID] = {
     collapses_inner_white_space: true,
     spacing: Some(NO_SPACING),
     is_inline: true,
-    wanted_attrs: ATTR_CLASS,
+    wanted_attrs: ATTR_CLASS | ATTR_LANG,
     ..NONE
   });
 
   // Lists
   t[TAG_UL as usize] = Some(BLOCK);
-  t[TAG_OL as usize] = Some(BLOCK);
+  t[TAG_OL as usize] = Some(TagHandler {
+    wanted_attrs: ATTR_START,
+    ..NONE
+  });
   t[TAG_LI as usize] = Some(TagHandler {
     spacing: Some(LIST_ITEM_SPACING),
     ..NONE
@@ -192,12 +195,13 @@ static TAG_HANDLERS: [Option<TagHandler>; MAX_TAG_ID] = {
   });
   t[TAG_TH as usize] = Some(TagHandler {
     collapses_inner_white_space: true,
-    wanted_attrs: ATTR_ALIGN,
+    wanted_attrs: ATTR_ALIGN | ATTR_COLSPAN,
     spacing: Some(NO_SPACING),
     ..NONE
   });
   t[TAG_TD as usize] = Some(TagHandler {
     collapses_inner_white_space: true,
+    wanted_attrs: ATTR_COLSPAN,
     spacing: Some(NO_SPACING),
     ..NONE
   });
@@ -224,7 +228,7 @@ static TAG_HANDLERS: [Option<TagHandler>; MAX_TAG_ID] = {
   // `class` is kept so a bare <pre class="language-x"> can resolve its fence
   // language for the deferred code block (issue #97).
   t[TAG_PRE as usize] = Some(TagHandler {
-    wanted_attrs: ATTR_CLASS,
+    wanted_attrs: ATTR_CLASS | ATTR_LANG,
     ..NONE
   });
 

--- a/crates/core/src/tags.rs
+++ b/crates/core/src/tags.rs
@@ -149,7 +149,7 @@ static TAG_HANDLERS: [Option<TagHandler>; MAX_TAG_ID] = {
     collapses_inner_white_space: true,
     spacing: Some(NO_SPACING),
     is_inline: true,
-    wanted_attrs: ATTR_CLASS | ATTR_LANG,
+    wanted_attrs: ATTR_CLASS,
     ..NONE
   });
 
@@ -228,7 +228,7 @@ static TAG_HANDLERS: [Option<TagHandler>; MAX_TAG_ID] = {
   // `class` is kept so a bare <pre class="language-x"> can resolve its fence
   // language for the deferred code block (issue #97).
   t[TAG_PRE as usize] = Some(TagHandler {
-    wanted_attrs: ATTR_CLASS | ATTR_LANG,
+    wanted_attrs: ATTR_CLASS,
     ..NONE
   });
 

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -87,9 +87,6 @@ pub struct ElementNode {
   pub excludes_text_nodes: bool,
   pub is_non_nesting: bool,
   pub collapses_inner_white_space: bool,
-  /// `colspan`, parsed during the tag scan; 0 when absent. A scalar avoids the
-  /// two-string allocation a map entry would cost.
-  pub cell_span: u8,
   pub spacing: Option<[u8; 2]>,
 }
 

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -87,6 +87,9 @@ pub struct ElementNode {
   pub excludes_text_nodes: bool,
   pub is_non_nesting: bool,
   pub collapses_inner_white_space: bool,
+  /// `colspan`, parsed during the tag scan; 0 when absent. A scalar avoids the
+  /// two-string allocation a map entry would cost.
+  pub cell_span: u8,
   pub spacing: Option<[u8; 2]>,
 }
 

--- a/crates/core/src/url.rs
+++ b/crates/core/src/url.rs
@@ -13,10 +13,14 @@ const TRACKING_PREFIXES: [&str; 6] = ["utm_", "fbclid", "gclid", "mc_eid", "mscl
 /// no whitespace or angle brackets that would break the autolink syntax.
 #[inline]
 pub(crate) fn is_autolink_uri(s: &str) -> bool {
-  let has_scheme = s.starts_with("http://")
-    || s.starts_with("https://")
-    || s.starts_with("ftp://")
-    || s.starts_with("mailto:");
+  // First-byte dispatch: the common no-scheme href rejects without a prefix compare.
+  let bytes = s.as_bytes();
+  let has_scheme = match bytes.first() {
+    Some(b'h') => s.starts_with("http://") || s.starts_with("https://"),
+    Some(b'f') => s.starts_with("ftp://"),
+    Some(b'm') => s.starts_with("mailto:"),
+    _ => false,
+  };
   if !has_scheme {
     return false;
   }

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -1405,6 +1405,17 @@ fn a_rule_inside_a_list_item_keeps_its_own_block() {
   // spaces only, so the line would be a thematic break and the item would vanish.
   assert_eq!(convert("<ul><li><hr></li></ul>"), "- ***");
   assert_eq!(convert("<ul><li><hr></li><li>b</li></ul>"), "- ***\n- b");
+  // Regression: text's own trailing space (not a marker's) was mistaken for the
+  // content column, so `<hr>` glued onto it with no break and vanished as `***`.
+  assert_eq!(convert("<ul><li>text <hr></li></ul>"), "- text\n\n  ---");
+  assert_eq!(
+    convert("<ul><li>text <hr>after</li></ul>"),
+    "- text\n\n  --- after"
+  );
+  assert_eq!(
+    convert("<ul><li><blockquote>text <hr></blockquote></li></ul>"),
+    "- \n  > text\n  >\n  > ---"
+  );
 }
 
 // ── Paragraphs and spacing ──
@@ -3685,7 +3696,7 @@ fn a_heading_without_an_atx_prefix_keeps_its_hash_unescaped() {
 }
 
 #[test]
-fn ordered_lists_honour_the_start_attribute() {
+fn ordered_lists_honor_the_start_attribute() {
   assert_eq!(
     convert("<ol start=\"3\"><li>a</li><li>b</li></ol>"),
     "3. a\n4. b"

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -3713,6 +3713,7 @@ fn ordered_lists_honor_the_start_attribute() {
     "0. a\n1. b"
   );
   assert_eq!(convert("<ol start=\" 7 \"><li>a</li></ol>"), "7. a");
+  assert_eq!(convert("<ol start=\"+7\"><li>a</li></ol>"), "7. a");
 }
 
 #[test]
@@ -3765,6 +3766,14 @@ fn colspan_widens_the_delimiter_row() {
       "<table><tr><th colspan=\"3\">h</th></tr><tr><td>a</td><td>b</td><td>c</td></tr></table>"
     ),
     "| h | | |\n| --- | --- | --- |\n| a | b | c |"
+  );
+  assert_eq!(
+    convert("<table><tr><td colspan=\"+2\">wide</td></tr></table>"),
+    "| wide | |\n| --- | --- |"
+  );
+  assert_eq!(
+    convert("<table><tr><td colspan=\"256\">wide</td></tr></table>"),
+    "| wide |\n| --- |"
   );
 }
 

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -3736,24 +3736,6 @@ fn ordered_start_wider_than_a_marker_falls_back_to_default_numbering() {
 }
 
 #[test]
-fn fence_language_falls_back_to_the_lang_attribute() {
-  assert_eq!(convert("<pre lang=\"rust\">x</pre>"), "```rust\nx\n```");
-  assert_eq!(
-    convert("<pre><code lang=\"js\">x</code></pre>"),
-    "```js\nx\n```"
-  );
-  // class wins, and a human language tag is not an info string.
-  assert_eq!(
-    convert("<pre lang=\"en-US\" class=\"language-c\">x</pre>"),
-    "```c\nx\n```"
-  );
-  assert_eq!(convert("<pre lang=\"en-US\">x</pre>"), "```\nx\n```");
-  // A space or tab ends the info string, so the rest would leak onto the fence.
-  assert_eq!(convert("<pre lang=\"en US\">x</pre>"), "```\nx\n```");
-  assert_eq!(convert("<pre lang=\"en\tUS\">x</pre>"), "```\nx\n```");
-}
-
-#[test]
 fn colspan_widens_the_delimiter_row() {
   // The spanned cell is followed by the empty cells it swallowed, so the
   // delimiter row is wide enough for `b` to survive.

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -3696,6 +3696,31 @@ fn ordered_lists_honour_the_start_attribute() {
     convert("<ol start=\"9\"><li><p>a</p><p>b</p></li></ol>"),
     "9. a\n\n   b"
   );
+  // 0 is a valid CommonMark start; browsers render it too.
+  assert_eq!(
+    convert("<ol start=\"0\"><li>a</li><li>b</li></ol>"),
+    "0. a\n1. b"
+  );
+  assert_eq!(convert("<ol start=\" 7 \"><li>a</li></ol>"), "7. a");
+}
+
+#[test]
+fn ordered_start_wider_than_a_marker_falls_back_to_default_numbering() {
+  // An ordered marker is at most nine digits, so a wider `start` is not a marker
+  // at all: it must not emit a ten-digit number GFM would read as a paragraph.
+  assert_eq!(
+    convert("<ol start=\"999999999\"><li>a</li></ol>"),
+    "999999999. a"
+  );
+  assert_eq!(convert("<ol start=\"1000000000\"><li>a</li></ol>"), "1. a");
+  assert_eq!(convert("<ol start=\"99999999999\"><li>a</li></ol>"), "1. a");
+  assert_eq!(convert("<ol start=\"-5\"><li>a</li></ol>"), "1. a");
+  assert_eq!(convert("<ol start=\"\"><li>a</li></ol>"), "1. a");
+  // The running number saturates at the same width rather than overflowing it.
+  assert_eq!(
+    convert("<ol start=\"999999998\"><li>a</li><li>b</li><li>c</li></ol>"),
+    "999999998. a\n999999999. b\n999999999. c"
+  );
 }
 
 #[test]
@@ -3711,6 +3736,9 @@ fn fence_language_falls_back_to_the_lang_attribute() {
     "```c\nx\n```"
   );
   assert_eq!(convert("<pre lang=\"en-US\">x</pre>"), "```\nx\n```");
+  // A space or tab ends the info string, so the rest would leak onto the fence.
+  assert_eq!(convert("<pre lang=\"en US\">x</pre>"), "```\nx\n```");
+  assert_eq!(convert("<pre lang=\"en\tUS\">x</pre>"), "```\nx\n```");
 }
 
 #[test]

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -230,8 +230,10 @@ fn gfm_syntax_in_text_is_escaped() {
 #[test]
 fn gfm_text_escaping_preserves_generated_markers_and_code() {
   assert_eq!(
+    // The trailing `#` is escaped: unescaped it is an ATX closing sequence and
+    // GFM drops it. The leading one and `#hashtag` stay literal.
     convert("<h2># Heading #</h2><p>#hashtag</p><p>Just a - dash</p>"),
-    "## # Heading #\n\n#hashtag\n\nJust a - dash"
+    "## # Heading \\#\n\n#hashtag\n\nJust a - dash"
   );
   assert_eq!(
     convert(
@@ -1371,6 +1373,40 @@ fn horizontal_rule() {
   assert_eq!(convert("<hr/>"), "---");
 }
 
+#[test]
+fn an_empty_list_item_does_not_underline_the_text_above() {
+  // A lone marker continuing the paragraph above is a setext underline: the
+  // text becomes a heading and the item itself disappears.
+  assert_eq!(
+    convert("<ul><li>a<ul><li></li></ul></li></ul>"),
+    "- a\n\n  -"
+  );
+  assert_eq!(
+    convert("<p>a</p><ul><li></li><li>b</li></ul>"),
+    "a\n\n-\n- b"
+  );
+  // A sibling marker above already opens its own block, so nothing is inserted.
+  assert_eq!(
+    convert("<ul><li>a</li><li></li><li>b</li></ul>"),
+    "- a\n-\n- b"
+  );
+  assert_eq!(convert("<ul><li></li><li>a</li></ul>"), "-\n- a");
+}
+
+#[test]
+fn a_rule_inside_a_list_item_keeps_its_own_block() {
+  // Without the blank line `<hr>` reads as a setext underline instead.
+  assert_eq!(convert("<ul><li>a<hr></li></ul>"), "- a\n\n  ---");
+  assert_eq!(
+    convert("<ul><li><p>a</p><hr><p>b</p></li></ul>"),
+    "- a\n\n  ---\n\n  b"
+  );
+  // A pending marker already opened the content column, but `- ---` is dashes and
+  // spaces only, so the line would be a thematic break and the item would vanish.
+  assert_eq!(convert("<ul><li><hr></li></ul>"), "- ***");
+  assert_eq!(convert("<ul><li><hr></li><li>b</li></ul>"), "- ***\n- b");
+}
+
 // ── Paragraphs and spacing ──
 
 #[test]
@@ -1966,11 +2002,13 @@ fn pre_fence_opener_survives_a_trailing_space_trim() {
   let md = html_to_markdown("# h<pre><td></pre>", HTMLToMarkdownOptions::default());
   assert_eq!(md, "\\# h\n\n```\n\n```", "got: {md:?}");
 
+  // A <code> child's fence is closed by the <pre>, so the closer lands after the
+  // trim and the block keeps an empty body. Both forms are an empty code block.
   let md = html_to_markdown(
     "# h<pre><code><td></code></pre>",
     HTMLToMarkdownOptions::default(),
   );
-  assert_eq!(md, "\\# h\n\n```\n```", "got: {md:?}");
+  assert_eq!(md, "\\# h\n\n```\n\n```", "got: {md:?}");
 
   // Every block-marker escape (`#`, `-`, `>`) can precede the fence.
   for html in [
@@ -3610,6 +3648,88 @@ fn lt_before_a_non_letter_is_text_not_a_tag() {
 }
 
 #[test]
+fn block_markers_are_escaped_after_a_list_marker() {
+  for (html, expected) in [
+    ("<ul><li>- text</li></ul>", "- \\- text"),
+    ("<ul><li>+ text</li></ul>", "- \\+ text"),
+    ("<ul><li>1. text</li></ul>", "- 1\\. text"),
+    ("<ul><li>&gt; text</li></ul>", "- \\> text"),
+    ("<ul><li># text</li></ul>", "- \\# text"),
+    ("<ul><li>---</li></ul>", "- \\---"),
+  ] {
+    assert_eq!(convert(html), expected, "html={html:?}");
+  }
+  // An ordered marker gives its content column the same treatment.
+  assert_eq!(convert("<ol><li># text</li></ol>"), "1. \\# text");
+}
+
+#[test]
+fn heading_keeps_a_trailing_hash() {
+  assert_eq!(convert("<h2>Ends with #</h2>"), "## Ends with \\#");
+  assert_eq!(convert("<h3>#</h3>"), "### \\#");
+  assert_eq!(convert("<h2>Ends with ###</h2>"), "## Ends with \\###");
+  // Not a closing sequence without whitespace before it, so nothing to escape.
+  assert_eq!(convert("<h2>C#</h2>"), "## C#");
+  assert_eq!(convert("<h2>plain</h2>"), "## plain");
+}
+
+#[test]
+fn a_heading_without_an_atx_prefix_keeps_its_hash_unescaped() {
+  // No `#` prefix is written in either case, so there is no closing sequence to
+  // protect and a backslash would be literal content.
+  assert_eq!(
+    convert("<table><tr><th>h</th></tr><tr><td><h3>Ends with #</h3></td></tr></table>"),
+    "| h |\n| --- |\n| <h3>Ends with #</h3> |"
+  );
+  assert_eq!(convert_text("<h2>Ends with #</h2>"), "Ends with #");
+}
+
+#[test]
+fn ordered_lists_honour_the_start_attribute() {
+  assert_eq!(
+    convert("<ol start=\"3\"><li>a</li><li>b</li></ol>"),
+    "3. a\n4. b"
+  );
+  assert_eq!(convert("<ol><li>a</li></ol>"), "1. a");
+  // A wider marker widens the continuation column with it.
+  assert_eq!(
+    convert("<ol start=\"9\"><li><p>a</p><p>b</p></li></ol>"),
+    "9. a\n\n   b"
+  );
+}
+
+#[test]
+fn fence_language_falls_back_to_the_lang_attribute() {
+  assert_eq!(convert("<pre lang=\"rust\">x</pre>"), "```rust\nx\n```");
+  assert_eq!(
+    convert("<pre><code lang=\"js\">x</code></pre>"),
+    "```js\nx\n```"
+  );
+  // class wins, and a human language tag is not an info string.
+  assert_eq!(
+    convert("<pre lang=\"en-US\" class=\"language-c\">x</pre>"),
+    "```c\nx\n```"
+  );
+  assert_eq!(convert("<pre lang=\"en-US\">x</pre>"), "```\nx\n```");
+}
+
+#[test]
+fn colspan_widens_the_delimiter_row() {
+  // The spanned cell is followed by the empty cells it swallowed, so the
+  // delimiter row is wide enough for `b` to survive.
+  assert_eq!(
+    convert("<table><tr><td colspan=\"2\">wide</td></tr><tr><td>a</td><td>b</td></tr></table>"),
+    "| wide | |\n| --- | --- |\n| a | b |"
+  );
+  assert_eq!(
+    convert(
+      "<table><tr><th colspan=\"3\">h</th></tr><tr><td>a</td><td>b</td><td>c</td></tr></table>"
+    ),
+    "| h | | |\n| --- | --- | --- |\n| a | b | c |"
+  );
+}
+
+#[test]
 fn abrupt_and_bang_terminated_comments_do_not_swallow_the_document() {
   // `<!-->`, `<!--->` and `--!>` all end a comment. Scanning for `-->` alone
   // left them open, so the scan ran to end of chunk, reported the tag
@@ -3644,6 +3764,36 @@ fn abrupt_and_bang_terminated_comments_do_not_swallow_the_document() {
 }
 
 #[test]
+fn cells_past_the_delimiter_row_merge_instead_of_vanishing() {
+  // GFM would otherwise drop the cells past the delimiter row's width.
+  assert_eq!(
+    convert("<table><tr><th>h</th><th>i</th></tr><tr><td>a</td><td>b</td><td>c</td></tr></table>"),
+    "| h | i |\n| --- | --- |\n| a | b c |"
+  );
+}
+
+#[test]
+fn a_table_inside_a_list_item_stays_a_table() {
+  assert_eq!(
+    convert("<ul><li><table><tr><th>h</th></tr><tr><td>c</td></tr></table></li></ul>"),
+    "- | h |\n  | --- |\n  | c |"
+  );
+  // An item that already holds text opens the table on its own line.
+  assert_eq!(
+    convert("<ul><li><p>intro</p><table><tr><th>h</th></tr><tr><td>c</td></tr></table></li></ul>"),
+    "- intro\n\n  | h |\n  | --- |\n  | c |"
+  );
+}
+
+#[test]
+fn a_caption_does_not_share_a_line_with_the_header_row() {
+  assert_eq!(
+    convert("<table><caption>Cap</caption><tr><th>h</th></tr><tr><td>c</td></tr></table>"),
+    "Cap\n\n| h |\n| --- |\n| c |"
+  );
+}
+
+#[test]
 fn a_short_malformed_comment_does_not_truncate_a_long_document() {
   let mut html = String::from("<p>lead</p><!-->");
   for i in 0..200 {
@@ -3654,4 +3804,121 @@ fn a_short_malformed_comment_does_not_truncate_a_long_document() {
   let out = convert(&html);
   assert_eq!(out.matches("para ").count(), 200, "{out:.120}");
   assert!(out.starts_with("lead"));
+}
+
+#[test]
+fn a_caption_in_a_list_item_keeps_the_content_column() {
+  assert_eq!(
+    convert(
+      "<ul><li><p>Intro:</p><table><caption>Cap</caption><tr><th>h</th></tr><tr><td>c</td></tr></table></li></ul>"
+    ),
+    "- Intro:\n\n  Cap\n\n  | h |\n  | --- |\n  | c |"
+  );
+  assert_eq!(
+    convert("<ul><li>x<br>y<table><caption>Cap</caption><tr><th>h</th></tr></table></li></ul>"),
+    "- x  \n  y\n\n  Cap\n\n  | h |\n  | --- |"
+  );
+}
+
+#[test]
+fn a_heading_in_a_table_cell_stays_in_the_row() {
+  assert_eq!(
+    convert("<table><tr><th>h</th></tr><tr><td><h3>H</h3></td></tr></table>"),
+    "| h |\n| --- |\n| <h3>H</h3> |"
+  );
+}
+
+#[test]
+fn pre_content_carries_no_inline_markup() {
+  assert_eq!(
+    convert("<pre>a <em>b</em> <strong>c</strong>\n</pre>"),
+    "```\na b c\n\n```"
+  );
+  assert_eq!(
+    convert("<pre>a <a href=\"/x\">l</a>\n</pre>"),
+    "```\na l\n\n```"
+  );
+  // Outside a fence the same markup still renders.
+  assert_eq!(
+    convert("<p>a <em>b</em> <a href=\"/x\">l</a></p>"),
+    "a *b* [l](/x)"
+  );
+}
+
+#[test]
+fn a_pipe_inside_a_table_code_span_is_escaped() {
+  assert_eq!(
+    convert("<table><tr><th>h</th></tr><tr><td><code>a|b</code></td></tr></table>"),
+    "| h |\n| --- |\n| `a\\|b` |"
+  );
+  // Outside a table the pipe is ordinary code content.
+  assert_eq!(convert("<p><code>a|b</code></p>"), "`a|b`");
+}
+
+#[test]
+fn raw_html_regions_escape_markdown_past_a_blank_line() {
+  // CommonMark ends the HTML block at the blank line, so what follows is
+  // Markdown and its block markers have to be escaped.
+  let md = convert("<details><summary>S</summary><p>* text</p></details>");
+  assert!(md.contains("\\* text"), "got: {md:?}");
+
+  // A line that opens a fresh HTML block suspends Markdown again, so text on it
+  // must not be escaped.
+  let md = convert(
+    "<dl><dt><code>A_B</code></dt><dd><p>one</p></dd>\
+     <dt><code>C_D</code></dt><dd><p>two</p></dd></dl>",
+  );
+  assert!(md.contains("<code>C_D</code>"), "got: {md:?}");
+  assert!(!md.contains("C\\_D"), "got: {md:?}");
+}
+
+#[test]
+fn a_row_closes_through_content_left_open_in_a_cell() {
+  // `<tr>` must close an unclosed `<p>` inside the previous cell; otherwise the
+  // literal tag lands in the row and every later row merges into one cell.
+  assert_eq!(
+    convert("<table><thead><tr><th>V<th>C<tbody><tr><td>a<td><p>x<tr><td>b<td><p>y</table>"),
+    "| V | C |\n| --- | --- |\n| a | x |\n| b | y |"
+  );
+}
+
+#[test]
+fn pre_keeps_text_after_a_code_child_inside_the_fence() {
+  // A sibling after </code> must stay inside the block: on the fence line it
+  // would read as ``` <text>, an opener that never closes.
+  assert_eq!(
+    convert("<pre><code>compopt</code> [-o option]</pre><p>after</p>"),
+    "```\ncompopt [-o option]\n```\n\nafter"
+  );
+  // Several <code> children share the one fence the <pre> closes.
+  assert_eq!(
+    convert("<pre><code>a</code><code>b</code></pre>"),
+    "```\nab\n```"
+  );
+}
+
+#[test]
+fn a_block_after_a_bare_pre_in_a_list_item_keeps_its_line() {
+  let md = convert("<ul><li><pre>code\n</pre><p>after</p></li></ul>");
+  assert!(md.contains("```\n\n  after"), "got: {md:?}");
+}
+
+#[test]
+fn a_fence_opening_a_list_item_shares_the_marker_line() {
+  // A blank line between the marker and the fence ends the item: CommonMark allows
+  // an item to begin with at most one blank line, so the block becomes a sibling of
+  // the list instead of its content.
+  assert_eq!(
+    convert("<ul><li><pre><code>a\nb</code></pre></li></ul>"),
+    "- ```\n  a\n  b\n  ```"
+  );
+  assert_eq!(
+    convert("<ul><li>a<ul><li><pre><code>x</code></pre></li></ul></li></ul>"),
+    "- a\n  - ```\n    x\n    ```"
+  );
+  // Content already on the line still opens the fence in its own block.
+  assert_eq!(
+    convert("<ul><li>text<pre><code>x</code></pre></li></ul>"),
+    "- text\n\n  ```\n  x\n  ```"
+  );
 }

--- a/crates/core/tests/implied_end_tags.rs
+++ b/crates/core/tests/implied_end_tags.rs
@@ -100,6 +100,43 @@ fn well_formed_table_is_unchanged() {
   );
 }
 
+#[test]
+fn implicit_row_end_closes_content_left_open_in_the_cell() {
+  // Regression: an unclosed child of the cell (an unknown element, or a block
+  // with no end tag) stopped the row scan, so the next <tr> nested inside the
+  // old cell and its markup leaked into the output as text.
+  assert_eq!(
+    convert("<table><tr><td>a<x-widget><tr><td>b</table>"),
+    "| a |\n| --- |\n| b |",
+  );
+  assert_eq!(
+    convert("<table><tr><td>a<p>x<tr><td>b</table>"),
+    "| a x |\n| --- |\n| b |",
+  );
+  assert_eq!(
+    convert("<table><thead><tr><th>V<th>C<tbody><tr><td>a<td><p>x<tr><td>b<td><p>y</table>"),
+    "| V | C |\n| --- | --- |\n| a | x |\n| b | y |",
+  );
+}
+
+#[test]
+fn row_recovery_stops_at_a_nested_table_or_template() {
+  // The scan must not walk out of a nested table, template, or caption: those
+  // hold their own row structure, so the outer <tr> belongs to the outer table.
+  assert_eq!(
+    convert("<table><tr><td><table><tr><td>inner<tr><td>b</table><tr><td>outer</table>"),
+    "| <table><tr><td>inner</td></tr><tr><td>b</td></tr></table> |\n| --- |\n| outer |",
+  );
+  assert_eq!(
+    convert("<table><tr><td>a<template><tr><td>t</template><tr><td>b</table>"),
+    "| a |\n| --- |\n| b |",
+  );
+  assert_eq!(
+    convert("<table><caption>C<tr><td>a<tr><td>b</table>"),
+    "C\n\n| a |\n| --- |\n| b |",
+  );
+}
+
 // ── definition lists ──
 //
 // `<dl>`/`<dt>`/`<dd>` keep their raw-HTML passthrough (valid inline markup for

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -846,3 +846,39 @@ fn streaming_pending_space_after_drained_hard_break_matches_one_shot() {
     assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
   }
 }
+
+// A heading's exit escapes a trailing `#` run so GFM does not read it as an ATX
+// closing sequence. Streaming used to yield the run before the exit could escape
+// it, emitting `## foo ##` where one-shot gives `## foo \#`.
+#[test]
+fn streaming_heading_trailing_hashes_matches_one_shot() {
+  for html in [
+    "<h2>foo #</h2>",
+    "<h2>foo ##</h2>",
+    "<h3>foo ##</h3>",
+    "<h1>#</h1>",
+    "<h2>foo # bar</h2>",
+    "<h2>foo <em>b</em> #</h2>",
+    "<h2>foo #</h2><p>after</p>",
+    "<h2>a</h2><h2>b #</h2>",
+  ] {
+    assert_stream_matches(html, HTMLToMarkdownOptions::default());
+    assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
+  }
+}
+
+// An empty `<li>` inserts a newline at its marker's line start when it resolves,
+// so the line stays mutable. Streaming used to yield the marker first, turning
+// one-shot's `- a\n\n  -` into `- a\n  --`.
+#[test]
+fn streaming_empty_nested_item_marker_matches_one_shot() {
+  for html in [
+    "<ul><li>a<ul><li></li></ul></li></ul>",
+    "<ul><li>a<ol><li></li></ol></li></ul>",
+    "<ul><li></li></ul>",
+    "<ul><li>a<ul><li></li><li>b</li></ul></li></ul>",
+  ] {
+    assert_stream_matches(html, HTMLToMarkdownOptions::default());
+    assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
+  }
+}

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -270,10 +270,12 @@ fn streaming_does_not_re_escape_carried_text() {
 
 #[test]
 fn streaming_gfm_text_escaping_matches_every_split() {
-  assert_stream_matches(
+  for html in [
     r"<p>&#35; heading [label](url) and *bar* ~~baz~~ `qux` &amp;copy;</p><p>> quote</p><p>1. item</p><p>---</p>",
-    HTMLToMarkdownOptions::default(),
-  );
+    r#"<ol start="10"><li>> quote</li><li>after</li></ol>"#,
+  ] {
+    assert_stream_matches(html, HTMLToMarkdownOptions::default());
+  }
 }
 
 #[test]

--- a/packages/js/src/const.ts
+++ b/packages/js/src/const.ts
@@ -247,6 +247,9 @@ export const MARKDOWN_STRIKETHROUGH = '~~'
 export const MARKDOWN_CODE_BLOCK = '```'
 export const MARKDOWN_INLINE_CODE = '`'
 export const MARKDOWN_HORIZONTAL_RULE = '---'
+// Rule sharing a line with a list marker: `- ---` is dashes and spaces only, so
+// the whole line is a thematic break and the item is lost. `*` cannot collide.
+export const MARKDOWN_HORIZONTAL_RULE_ALT = '***'
 
 // Raw-HTML blocks whose text/code is emitted verbatim rather than as Markdown.
 export function isInsideRawHtmlBlock(depthMap: Uint16Array): boolean {
@@ -257,6 +260,12 @@ export function isInsideRawHtmlBlock(depthMap: Uint16Array): boolean {
     || depthMap[TAG_DT]
     || depthMap[TAG_DD])
 }
+
+// Code units for hot-path scanners, compared instead of one-character strings.
+export const TAB_CHAR = 9
+export const NEWLINE_CHAR = 10
+export const CARRIAGE_RETURN_CHAR = 13
+export const SPACE_CHAR = 32
 
 // Newline configurations
 export const NO_SPACING: readonly [number, number] = [0, 0]

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -166,8 +166,7 @@ function suppressesFormattingInPre(tagId: number): boolean {
 }
 
 /**
- * Length of the newline run ending just before fragment `index`, or -1 when
- * nothing but newlines precedes it — the marker opens the document.
+ * Length of the newline run ending just before fragment `index`.
  */
 function newlineRunBefore(buffer: string[], index: number): number {
   let run = 0
@@ -179,7 +178,7 @@ function newlineRunBefore(buffer: string[], index: number): number {
       run++
     }
   }
-  return -1
+  return run
 }
 
 /**
@@ -931,13 +930,7 @@ function finalizeBlockquote(state: MarkdownState): void {
 }
 
 function collapseNestedBlockquoteSeparator(buffer: string[]): void {
-  let trailingNewlines = 0
-  for (let fragmentIndex = buffer.length - 1; fragmentIndex >= 0 && trailingNewlines < 2; fragmentIndex--) {
-    const fragment = buffer[fragmentIndex]!
-    for (let index = fragment.length - 1; index >= 0 && fragment.charCodeAt(index) === 10; index--)
-      trailingNewlines++
-  }
-  if (trailingNewlines < 2)
+  if (newlineRunBefore(buffer, buffer.length) < 2)
     return
 
   const last = buffer.at(-1)!

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -51,7 +51,7 @@ import {
 import { finalizeParse, parseHtmlStream } from './parse'
 import { processPluginsForEvent } from './plugin-processor'
 import { breakHandler, renderBreak, resolveUrl } from './tags'
-import { blockOpenPrefix, continuationPrefix, listMarkerLineStart, orderedItemNumber } from './utils'
+import { blockOpenPrefix, continuationPrefix, isCharacterReferenceTail, isInsideHeading, isInsideTableCell, listMarkerLineStart, orderedItemNumber } from './utils'
 
 export interface MarkdownState {
   /** Configuration options for conversion */
@@ -237,7 +237,7 @@ function resolveItemMarker(state: MarkdownState, atExit: boolean): void {
 function updateListIndent(state: MarkdownState, element: ElementNode, eventType: number): void {
   if (element.tagId !== TAG_LI)
     return
-  if ((state.depthMap[TAG_TD] || 0) > 0 || (state.depthMap[TAG_TH] || 0) > 0)
+  if (isInsideTableCell(state))
     return
   if (eventType === NodeEventEnter) {
     const isOrdered = element.parent?.tagId === TAG_OL
@@ -257,38 +257,23 @@ function updateListIndent(state: MarkdownState, element: ElementNode, eventType:
  * Determines if spacing is needed between two characters
  */
 function needsSpacing(lastChar: string, firstChar: string, state?: MarkdownState): boolean {
-  // Don't add space if last char is already a space or newline
-  if (lastChar === ' ' || lastChar === '\n' || lastChar === '\t') {
+  if (' \n\t'.includes(lastChar) || ' \n\t'.includes(firstChar)) {
     return false
   }
-
-  // Don't add space if first char is a space or newline
-  if (firstChar === ' ' || firstChar === '\n' || firstChar === '\t') {
-    return false
-  }
-
-  // Special cases where we don't want spacing
-  const noSpaceAfter = new Set(['[', '(', '>', '*', '_', '`'])
-  const noSpaceBefore = new Set([']', ')', '<', '.', ',', '!', '?', ':', ';', '*', '_', '`'])
 
   // Special case: Allow spacing between pipe and HTML tags in table cells
   if (lastChar === '|' && firstChar === '<' && state && (state.depthMap[TAG_TABLE] || 0) > 0) {
     return true
   }
 
-  if (noSpaceAfter.has(lastChar) || noSpaceBefore.has(firstChar)) {
-    return false
-  }
-
-  // For everything else, add spacing
-  return true
+  return !'[(>*_`'.includes(lastChar) && !'])<.,!?:;*_`'.includes(firstChar)
 }
 
 /**
  * Determines if spacing should be added before text content
  */
 function shouldAddSpacingBeforeText(lastChar: string, lastNode: ElementNode | TextNode | undefined, textNode: TextNode): boolean {
-  if (!lastChar || lastChar === '\n' || lastChar === ' ' || lastChar === '\t' || lastChar === '[' || lastChar === '>') {
+  if (!lastChar || '\n \t[>'.includes(lastChar)) {
     return false
   }
   if (lastNode?.tagHandler?.isInline) {
@@ -299,20 +284,10 @@ function shouldAddSpacingBeforeText(lastChar: string, lastNode: ElementNode | Te
     return false
   }
   // Skip spacing before punctuation (parity with Rust engine)
-  if (firstChar === '.' || firstChar === ',' || firstChar === '!' || firstChar === '?'
-    || firstChar === ':' || firstChar === ';' || firstChar === '_' || firstChar === '*'
-    || firstChar === '`' || firstChar === ')' || firstChar === ']') {
+  if (firstChar && '.,!?:;_*`)]'.includes(firstChar)) {
     return false
   }
   return true
-}
-
-function isInsideHeading(depthMap: Uint16Array): boolean {
-  for (let h = TAG_H1; h <= TAG_H6; h++) {
-    if (depthMap[h])
-      return true
-  }
-  return false
 }
 
 /**
@@ -548,37 +523,6 @@ function isThematicBreak(value: string, start: number, marker: number): boolean 
   return count >= 3
 }
 
-function isEntityReferenceAfterAmpersand(value: string, ampersand: number): boolean {
-  let index = ampersand + 1
-  if (value.charCodeAt(index) === 35) {
-    index++
-    const hex = value.charCodeAt(index) === 120 || value.charCodeAt(index) === 88
-    if (hex)
-      index++
-    const start = index
-    while (index < value.length) {
-      const code = value.charCodeAt(index)
-      if (!((code >= 48 && code <= 57)
-        || (hex && ((code >= 65 && code <= 70) || (code >= 97 && code <= 102))))) {
-        break
-      }
-      index++
-    }
-    return index > start && value.charCodeAt(index) === 59
-  }
-  const start = index
-  while (index < value.length) {
-    const code = value.charCodeAt(index)
-    if (!((code >= 48 && code <= 57)
-      || (code >= 65 && code <= 90)
-      || (code >= 97 && code <= 122))) {
-      break
-    }
-    index++
-  }
-  return index > start && value.charCodeAt(index) === 59
-}
-
 const GFM_TEXT_NATIVE_TRIGGER = /[\\*_~`[<\r\n]/
 
 /**
@@ -598,8 +542,7 @@ function mayNeedGfmTextEscape(value: string, buffer: string[], depthMap: Uint16A
   // Text-side reject first: prose that cannot open a block skips the buffer
   // scan entirely, which is most text nodes.
   const first = value.charCodeAt(0)
-  if (first !== 32 && first !== 35 && first !== 43 && first !== 45 && first !== 62
-    && !(first >= 48 && first <= 57)) {
+  if (!' #+->'.includes(value[0]!) && !(first >= 48 && first <= 57)) {
     return false
   }
 
@@ -616,10 +559,7 @@ function mayNeedGfmTextEscape(value: string, buffer: string[], depthMap: Uint16A
     return false
 
   const code = value.charCodeAt(index)
-  return code === 35 // #
-    || code === 43 // +
-    || code === 45 // -
-    || code === 62 // >
+  return '#+->'.includes(value[index]!)
     || (code >= 48 && code <= 57)
 }
 
@@ -639,11 +579,12 @@ function escapeGfmText(value: string, buffer: string[], depthMap: Uint16Array): 
 
   for (let index = 0; index < value.length; index++) {
     const code = value.charCodeAt(index)
+    const character = value[index]!
 
     // A `\&` guarding a decoded entity reference is emitted by the entity
     // decoder; preserve the pair verbatim so this pass never doubles the slash.
     const next = index + 1 < value.length ? value.charCodeAt(index + 1) : 0
-    if (code === 92 && next === 38 && isEntityReferenceAfterAmpersand(value, index + 1)) {
+    if (code === 92 && next === 38 && isCharacterReferenceTail(value, index + 2)) {
       lineIndent = -1
       orderedDigits = 0
       index++
@@ -657,12 +598,7 @@ function escapeGfmText(value: string, buffer: string[], depthMap: Uint16Array): 
       continue
     }
 
-    let shouldEscape = code === 92 // \
-      || code === 42 // *
-      || code === 95 // _
-      || code === 126 // ~
-      || code === 96 // `
-      || code === 91 // [
+    let shouldEscape = '\\*_~`['.includes(character)
       || (code === 93 && inLink) // ]
       || (code === 124 && inTable) // |
       || (code === 62 && inBlockquote) // >
@@ -692,7 +628,7 @@ function escapeGfmText(value: string, buffer: string[], depthMap: Uint16Array): 
 
     if (shouldEscape) {
       escaped += value.slice(copiedUntil, index)
-      escaped += `\\${value[index]}`
+      escaped += `\\${character}`
       copiedUntil = index + 1
     }
 
@@ -1139,7 +1075,7 @@ function getPlainTextOutput(node: ElementNode, eventType: number, state: Markdow
   if (eventType === NodeEventEnter) {
     if (tagId === TAG_BR)
       return '\n'
-    if (tagId === TAG_P && ((depthMap[TAG_BLOCKQUOTE] || 0) > 0 || ((depthMap[TAG_LI] || 0) > 0 && !(depthMap[TAG_TD] || 0) && !(depthMap[TAG_TH] || 0)))) {
+    if (tagId === TAG_P && ((depthMap[TAG_BLOCKQUOTE] || 0) > 0 || ((depthMap[TAG_LI] || 0) > 0 && !isInsideTableCell(state)))) {
       const lastEntry = state.buffer.at(-1)
       const lastChar = lastEntry?.charAt(lastEntry.length - 1) || ''
       if (lastChar && lastChar !== ' ' && lastChar !== '\n')
@@ -1220,8 +1156,7 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
         textNode.value = value
       }
 
-      if (state.depthMap[TAG_PRE]! > 0
-        && (state.depthMap[TAG_TD]! > 0 || state.depthMap[TAG_TH]! > 0)) {
+      if (state.depthMap[TAG_PRE]! > 0 && isInsideTableCell(state)) {
         textNode.value = foldPreLinesToBr(textNode.value)
       }
 
@@ -1621,7 +1556,7 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
     if (gfmAction)
       commitGfmAction(gfmAction, state, gfmLifecycle, outputStart)
 
-    if (element.tagId === TAG_LI && !state.plainText && !(state.depthMap[TAG_TD] || state.depthMap[TAG_TH])) {
+    if (element.tagId === TAG_LI && !state.plainText && !isInsideTableCell(state)) {
       if (eventType === NodeEventEnter)
         recordItemMarker(state, element.index)
       else

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -11,7 +11,9 @@ import {
   NodeEventEnter,
   NodeEventExit,
   TAG_A,
+  TAG_ABBR,
   TAG_B,
+  TAG_BDO,
   TAG_BLOCKQUOTE,
   TAG_BR,
   TAG_CITE,
@@ -26,27 +28,34 @@ import {
   TAG_HR,
   TAG_I,
   TAG_IMG,
+  TAG_INS,
   TAG_KBD,
   TAG_LI,
+  TAG_MARK,
   TAG_OL,
   TAG_P,
   TAG_PRE,
   TAG_Q,
   TAG_S,
   TAG_SAMP,
+  TAG_SMALL,
   TAG_SPAN,
   TAG_STRIKE,
   TAG_STRONG,
+  TAG_SUB,
+  TAG_SUP,
   TAG_TABLE,
   TAG_TD,
   TAG_TH,
+  TAG_TIME,
+  TAG_U,
   TAG_VAR,
   TEXT_NODE,
 } from './const'
 import { finalizeParse, parseHtmlStream } from './parse'
 import { processPluginsForEvent } from './plugin-processor'
 import { breakHandler, renderBreak, resolveUrl } from './tags'
-import { continuationPrefix } from './utils'
+import { blockOpenPrefix, continuationPrefix, isListMarkerTail, listMarkerLineStart, orderedItemNumber } from './utils'
 
 export interface MarkdownState {
   /** Configuration options for conversion */
@@ -65,6 +74,8 @@ export interface MarkdownState {
   tableRenderedTable?: boolean
   tableCurrentRowCells?: number
   tableColumnAlignments?: string[]
+  /** Column count the delimiter row promised; cells past it are folded in. */
+  tableHeaderCells?: number
   /** Map of tag names to their current nesting depth */
   depthMap: Uint16Array
   /** Current depth for plugin access */
@@ -86,11 +97,11 @@ export interface MarkdownState {
    * first non-whitespace content so empty/whitespace-only blocks emit nothing.
    * `preFencePending`: inside a <pre> whose fence is not yet decided.
    * `preFenceLang`: language resolved from the <pre>'s own class.
-   * `preOwnFence`: the <pre> opened its own fence (so a nested <code> must not).
    */
   preFencePending?: boolean
   preFenceLang?: string
-  preOwnFence?: boolean
+  /** A fence is open for the current <pre>, whoever wrote its opener. */
+  preFenceOpen?: boolean
   /** Open fenced block whose delimiter is finalized after its content is known. */
   codeFence?: CodeFence
   /** Internal observer used by the splitter to track the fence actually opened. */
@@ -99,6 +110,22 @@ export interface MarkdownState {
   blockquotes: BlockquoteFrame[]
   /** Public runtime view used by tag handlers without exposing frame internals. */
   bufferedBlockquoteDepth: number
+  /** Marker line at risk of reading as a setext underline; see `recordItemMarker`. */
+  emptyItemHazard?: boolean
+  emptyItemFragment?: number
+  /**
+   * Raw-HTML region tracking. A blank line inside a raw HTML block ends it and
+   * the text after it is Markdown again, so it needs escaping; a line that opens
+   * a fresh HTML block suspends Markdown once more.
+   * `rawHtmlMarkdown`: a blank line has been seen inside the current block.
+   * The scan cursors hold how far the buffer was walked to decide that.
+   */
+  inRawHtmlRegion?: boolean
+  rawHtmlMarkdown?: boolean
+  rawHtmlScannedTo?: number
+  lineScannedTo?: number
+  lineStartFragment?: number
+  lineStartOffset?: number
   /** Whether output should omit Markdown/HTML markup */
   plainText?: boolean
 }
@@ -143,6 +170,101 @@ INLINE_MARKER_TYPE[TAG_SAMP] = 5 // `
 INLINE_MARKER_TYPE[TAG_VAR] = 5 // `
 INLINE_MARKER_TYPE[TAG_Q] = 6 // "
 
+// Inline tags whose Markdown delimiters are literal text inside a `<pre>`, so
+// only their content is emitted there. `<code>` and `<br>` are absent: both
+// already have `<pre>`-aware handlers.
+const SUPPRESSED_IN_PRE = new Uint8Array(MAX_TAG_ID)
+for (const tagId of [
+  TAG_STRONG,
+  TAG_B,
+  TAG_EM,
+  TAG_I,
+  TAG_DEL,
+  TAG_S,
+  TAG_STRIKE,
+  TAG_CITE,
+  TAG_DFN,
+  TAG_KBD,
+  TAG_SAMP,
+  TAG_VAR,
+  TAG_Q,
+  TAG_SUB,
+  TAG_SUP,
+  TAG_INS,
+  TAG_MARK,
+  TAG_ABBR,
+  TAG_SMALL,
+  TAG_U,
+  TAG_TIME,
+  TAG_BDO,
+  TAG_A,
+])
+  SUPPRESSED_IN_PRE[tagId] = 1
+
+/**
+ * Length of the newline run ending just before fragment `index`, or -1 when
+ * nothing but newlines precedes it — the marker opens the document.
+ */
+function newlineRunBefore(buffer: string[], index: number): number {
+  let run = 0
+  for (let i = index - 1; i >= 0; i--) {
+    const fragment = buffer[i]!
+    for (let j = fragment.length - 1; j >= 0; j--) {
+      if (fragment.charCodeAt(j) !== 10)
+        return run
+      run++
+    }
+  }
+  return -1
+}
+
+/**
+ * Arm the empty-item guard for the `<li>` whose marker was just written. A marker
+ * line continuing the paragraph above turns a lone marker into a setext
+ * underline: the text becomes a heading and the item disappears. A blank line, or
+ * a sibling marker, opens its own block instead.
+ */
+function recordItemMarker(state: MarkdownState, index: number): void {
+  // Only a list's first item can follow a paragraph, so every later sibling
+  // skips the scan below.
+  if (index !== 0 || newlineRunBefore(state.buffer, state.buffer.length - 1) !== 1) {
+    state.emptyItemHazard = false
+    return
+  }
+  state.emptyItemHazard = true
+  state.emptyItemFragment = state.buffer.length - 1
+}
+
+/**
+ * Give a marker that ended up alone on its line the blank line it needs: the item
+ * is empty, or opened with a block starting on the next line. While nothing has
+ * been written since the marker the answer is still open, so only the `<li>` exit
+ * forces one.
+ */
+function resolveItemMarker(state: MarkdownState, atExit: boolean): void {
+  if (!state.emptyItemHazard)
+    return
+  const buffer = state.buffer
+  let first = -1
+  for (let i = state.emptyItemFragment! + 1; i < buffer.length && first === -1; i++) {
+    const fragment = buffer[i]!
+    for (let j = 0; j < fragment.length; j++) {
+      const code = fragment.charCodeAt(j)
+      if (code !== 32) {
+        first = code
+        break
+      }
+    }
+  }
+  if (first === -1 && !atExit)
+    return
+  state.emptyItemHazard = false
+  if (first !== -1 && first !== 10)
+    return
+  const fragment = state.emptyItemFragment!
+  buffer[fragment] = `\n${buffer[fragment]}`
+}
+
 /**
  * Maintain the list-item indent stack. On `<li>` enter, push this item's
  * marker-width of spaces so subsequent continuation content (code blocks,
@@ -156,7 +278,9 @@ function updateListIndent(state: MarkdownState, element: ElementNode, eventType:
     return
   if (eventType === NodeEventEnter) {
     const isOrdered = element.parent?.tagId === TAG_OL
-    const width = state.plainText ? 0 : (isOrdered ? String(element.index + 1).length + 2 : 2)
+    const width = state.plainText
+      ? 0
+      : (isOrdered ? String(orderedItemNumber(element.parent, element.index)).length + 2 : 2)
     state.listIndentWidths.push(width)
     state.listIndent += ' '.repeat(width)
   }
@@ -326,6 +450,75 @@ function escapeRawHtmlText(value: string, depthMap: Uint16Array): string {
   return copiedUntil === 0 ? value : escaped + value.slice(copiedUntil)
 }
 
+// The streaming drain replaces the buffer, so fragment-indexed scan cursors
+// have to start over; the `rawHtmlMarkdown` latch itself still holds.
+function resetBufferScanCursors(state: MarkdownState): void {
+  state.rawHtmlScannedTo = 0
+  state.lineScannedTo = 0
+  state.lineStartFragment = 0
+  state.lineStartOffset = 0
+}
+
+function trackRawHtmlMarkdownContext(state: MarkdownState): void {
+  if (state.rawHtmlMarkdown)
+    return
+  const buffer = state.buffer
+  let index = state.rawHtmlScannedTo ?? 0
+  if (index > buffer.length)
+    index = 0
+  let previous = index > 0 ? buffer[index - 1]!.charCodeAt(buffer[index - 1]!.length - 1) : -1
+  for (; index < buffer.length; index++) {
+    const fragment = buffer[index]!
+    if (!fragment)
+      continue
+    if (fragment.includes('\n\n') || (previous === 10 && fragment.charCodeAt(0) === 10)) {
+      state.rawHtmlMarkdown = true
+      break
+    }
+    previous = fragment.charCodeAt(fragment.length - 1)
+  }
+  state.rawHtmlScannedTo = buffer.length
+}
+
+/**
+ * Whether the current line opens a raw HTML block. Only fragments appended
+ * since the last call can move the line start, so a line spanning many
+ * fragments is walked once instead of once per text node.
+ */
+function lineOpensRawHtmlBlock(state: MarkdownState): boolean {
+  const buffer = state.buffer
+  let scanned = state.lineScannedTo ?? 0
+  if (scanned > buffer.length) {
+    scanned = 0
+    state.lineStartFragment = 0
+    state.lineStartOffset = 0
+  }
+  for (let index = scanned; index < buffer.length; index++) {
+    const newline = buffer[index]!.lastIndexOf('\n')
+    if (newline !== -1) {
+      state.lineStartFragment = index
+      state.lineStartOffset = newline + 1
+    }
+  }
+  state.lineScannedTo = buffer.length
+
+  let spaces = 0
+  let offset = state.lineStartOffset ?? 0
+  for (let index = state.lineStartFragment ?? 0; index < buffer.length; index++) {
+    const fragment = buffer[index]!
+    while (offset < fragment.length) {
+      const code = fragment.charCodeAt(offset)
+      if (code !== 32)
+        return code === 60 // <
+      if (++spaces > 3)
+        return false
+      offset++
+    }
+    offset = 0
+  }
+  return false
+}
+
 /**
  * Return the current GFM line indent when a block marker may still start at
  * this position. A non-space byte, or more than three leading spaces, makes
@@ -338,14 +531,18 @@ function markdownLineIndent(buffer: string[]): number {
     for (let index = fragment.length - 1; index >= 0; index--) {
       const code = fragment.charCodeAt(index)
       if (code === 10)
-        return spaces <= 3 ? spaces : -1
-      if (code !== 32)
-        return -1
-      if (++spaces > 3)
-        return -1
+        return spaces
+      // A list marker is block prefix too: its content column opens a fresh
+      // block context, so `- # h` escapes exactly like `# h` would.
+      if (code !== 32 || spaces === 3) {
+        return isListMarkerTail(code) && listMarkerLineStart(buffer, fragmentIndex, index)
+          ? 0
+          : -1
+      }
+      spaces++
     }
   }
-  return spaces <= 3 ? spaces : -1
+  return spaces
 }
 
 function isMarkdownMarkerWhitespace(code: number): boolean {
@@ -422,6 +619,14 @@ function mayNeedGfmTextEscape(value: string, buffer: string[], depthMap: Uint16A
     || (depthMap[TAG_A] && value.includes(']'))
     || (depthMap[TAG_BLOCKQUOTE] && value.includes('>'))) {
     return true
+  }
+
+  // Text-side reject first: prose that cannot open a block skips the buffer
+  // scan entirely, which is most text nodes.
+  const first = value.charCodeAt(0)
+  if (first !== 32 && first !== 35 && first !== 43 && first !== 45 && first !== 62
+    && !(first >= 48 && first <= 57)) {
+    return false
   }
 
   let lineIndent = markdownLineIndent(buffer)
@@ -755,7 +960,14 @@ function maxLineLeadingRun(value: string, marker: number, indent: string): numbe
 }
 
 function finalizeCodeSpan(state: MarkdownState, span: CodeSpan): string {
-  const content = state.buffer.slice(span.fragment + 1).join('')
+  let content = state.buffer.slice(span.fragment + 1).join('')
+  // A pipe splits the row even inside a code span; `\|` is GFM's escape and is
+  // honoured there. The span is the buffer tail, so rewriting it moves nothing.
+  if ((state.depthMap[TAG_TABLE] || 0) > 0 && content.includes('|')) {
+    content = content.replaceAll('|', '\\|')
+    state.buffer.length = span.fragment + 1
+    state.buffer.push(content)
+  }
   const delimiter = '`'.repeat(Math.max(1, maxBacktickRun(content) + 1))
   const padded = content.startsWith('`') || content.endsWith('`')
   state.buffer[span.fragment] = `${span.prefix}${delimiter}${padded ? ' ' : ''}`
@@ -834,15 +1046,16 @@ function collapseNestedBlockquoteSeparator(buffer: string[]): void {
 function flushPreFence(state: MarkdownState): void {
   if (state.plainText) {
     state.preFencePending = false
-    state.preOwnFence = false
     return
   }
   state.preFencePending = false
-  state.preOwnFence = true
+  state.preFenceOpen = true
   const lang = state.preFenceLang || ''
   const liDepth = state.depthMap[TAG_LI] || 0
+  // A blank line between the marker and the fence ends the item, leaving the block
+  // a sibling of the list, so a pending marker takes no separator.
   const fence = liDepth > 0
-    ? `\n\n${state.listIndent}${MARKDOWN_CODE_BLOCK}${lang}\n${state.listIndent}`
+    ? `${blockOpenPrefix(state.buffer, state.listIndent) ?? ''}${MARKDOWN_CODE_BLOCK}${lang}\n${state.listIndent}`
     : `${MARKDOWN_CODE_BLOCK}${lang}\n`
   state.buffer.push(fence)
   startCodeFence(state, state.buffer.length - 1, lang, state.listIndent)
@@ -876,14 +1089,14 @@ function consumeGfmAction(action: GfmAction, state: MarkdownState, lifecycle: Gf
       return undefined
     case 'PreEnter':
       state.preFencePending = true
-      state.preOwnFence = false
+      state.preFenceOpen = false
       state.preFenceLang = action.language
       return undefined
     case 'PreExit': {
-      const ownFence = state.preOwnFence
+      const fenceOpen = state.preFenceOpen
       state.preFencePending = false
-      state.preOwnFence = false
-      if (!ownFence)
+      state.preFenceOpen = false
+      if (!fenceOpen)
         return undefined
       const indent = state.listIndent
       const output = (state.depthMap[TAG_LI] || 0) > 0
@@ -900,11 +1113,8 @@ function consumeGfmAction(action: GfmAction, state: MarkdownState, lifecycle: Gf
     }
     case 'CodeFenceEnter':
       state.preFencePending = false
+      state.preFenceOpen = true
       return action.output
-    case 'CodeFenceExit': {
-      const delimiter = finalizeCodeFence(state)
-      return delimiter ? action.output.replace(MARKDOWN_CODE_BLOCK, delimiter) : action.output
-    }
   }
 }
 
@@ -991,6 +1201,15 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
     blockquotes: [],
     bufferedBlockquoteDepth: 0,
     plainText: options.format === 'text',
+    // Declared up front, not assigned lazily, to keep the hidden class stable.
+    emptyItemHazard: false,
+    emptyItemFragment: 0,
+    inRawHtmlRegion: false,
+    rawHtmlMarkdown: false,
+    rawHtmlScannedTo: 0,
+    lineScannedTo: 0,
+    lineStartFragment: 0,
+    lineStartOffset: 0,
   }
   // Open inline-marker enter positions, packed as (buffer fragment index << 3 | kind).
   const openMarkers: number[] = []
@@ -1038,6 +1257,19 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
       }
 
       const insideRawHtmlBlock = isInsideRawHtmlBlock(state.depthMap)
+      if (insideRawHtmlBlock) {
+        // Anchor the scan on the way in, so the region never sees a blank line
+        // that preceded it, and text outside one pays only this test.
+        if (!state.inRawHtmlRegion) {
+          state.inRawHtmlRegion = true
+          state.rawHtmlMarkdown = false
+          state.rawHtmlScannedTo = state.buffer.length
+        }
+        trackRawHtmlMarkdownContext(state)
+      }
+      else if (state.inRawHtmlRegion) {
+        state.inRawHtmlRegion = false
+      }
       if (!state.plainText
         && !state.depthMap[TAG_PRE]
         && insideRawHtmlBlock) {
@@ -1047,8 +1279,12 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
       if (!state.plainText
         && !state.depthMap[TAG_PRE]
         && !state.depthMap[TAG_CODE]
-        && !insideRawHtmlBlock
-        && mayNeedGfmTextEscape(textNode.value, state.buffer, state.depthMap)) {
+        // Inside a raw-HTML region only text past a blank line is Markdown
+        // again. That test is O(1), so it goes before the text scans; the line
+        // scan stays last, paid only by text that would be escaped anyway.
+        && (!insideRawHtmlBlock || state.rawHtmlMarkdown)
+        && mayNeedGfmTextEscape(textNode.value, state.buffer, state.depthMap)
+        && (!insideRawHtmlBlock || !lineOpensRawHtmlBlock(state))) {
         textNode.value = escapeGfmText(textNode.value, state.buffer, state.depthMap)
       }
 
@@ -1203,7 +1439,10 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
     const isInlineElement = handler?.isInline === true
     let gfmAction: GfmAction | undefined
     let handlerOutput: string | undefined
-    if (!output && handler?.[eventFn]) {
+    const suppressedInPre = !state.plainText
+      && (state.depthMap[TAG_PRE] || 0) > 0
+      && SUPPRESSED_IN_PRE[element.tagId!] === 1
+    if (!output && !suppressedInPre && handler?.[eventFn]) {
       const res = state.plainText
         ? getPlainTextOutput(element, eventType, state)
         : handler[eventFn]({ node: element, state })
@@ -1417,6 +1656,13 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
     if (gfmAction)
       commitGfmAction(gfmAction, state, gfmLifecycle, outputStart)
 
+    if (element.tagId === TAG_LI && !state.plainText && !(state.depthMap[TAG_TD] || state.depthMap[TAG_TH])) {
+      if (eventType === NodeEventEnter)
+        recordItemMarker(state, element.index)
+      else
+        resolveItemMarker(state, true)
+    }
+
     if (eventType === NodeEventEnter && element.tagId === TAG_A && handlerOutput === '[' && buff.at(-1) === '[')
       openLinkFragment = buff.length - 1
 
@@ -1482,6 +1728,9 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
    * Get new markdown content since the last call (for streaming)
    */
   function getMarkdownChunk(): string {
+    // Settle an open marker-line guard when the item's first content already
+    // answers it, so the hold below never outlives the marker's own line.
+    resolveItemMarker(state, false)
     const content = state.buffer.join('')
     const currentContent = hasYieldedContent || (state.plainText && preserveLeadingWhitespace)
       ? content
@@ -1538,6 +1787,16 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
       if (spanPos < stableLength)
         stableLength = spanPos
     }
+    // An empty `<li>` rewrites its own marker fragment on exit.
+    const emptyItemHeld = state.emptyItemHazard === true
+    if (emptyItemHeld) {
+      const itemPos = Math.max(
+        lastYieldedLength,
+        trimBufferedWhitespacePosition(currentContent, fragmentPosition(state.buffer, state.emptyItemFragment!) - leadingTrimmed),
+      )
+      if (itemPos < stableLength)
+        stableLength = itemPos
+    }
     const codeFenceHeld = state.codeFence !== undefined
     if (codeFenceHeld) {
       const fencePos = Math.max(
@@ -1588,7 +1847,7 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
     // from joining and slicing the entire cumulative output. Plugin, wrapping,
     // and open-link paths retain the full buffer because they can inspect or
     // rewrite earlier content.
-    if (!markerHeld && !codeSpanHeld && !codeFenceHeld && !blockquoteHeld && !linkHeld && (!retainMutableFragments || !inPre)) {
+    if (!markerHeld && !codeSpanHeld && !codeFenceHeld && !blockquoteHeld && !linkHeld && !emptyItemHeld && (!retainMutableFragments || !inPre)) {
       if (!resolvedPlugins.length && !options.wrapWidth && !state.depthMap[TAG_A]) {
         if (retainMutableFragments && leadingTrimmed === 0) {
           // Preserve the final fragment as a separate value: close handlers
@@ -1598,6 +1857,7 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
           const tailStart = Math.max(0, Math.min(stableLength - 2, fragmentStart))
           const emittedTail = currentContent.slice(tailStart, fragmentStart)
           state.buffer.length = 0
+          resetBufferScanCursors(state)
           if (emittedTail)
             state.buffer.push(emittedTail)
           state.buffer.push(lastFragment)
@@ -1607,6 +1867,7 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
           const tailStart = Math.max(0, stableLength - 2)
           const emittedTail = currentContent.slice(tailStart, stableLength)
           state.buffer.length = 0
+          resetBufferScanCursors(state)
           if (emittedTail)
             state.buffer.push(emittedTail)
           lastYieldedLength = emittedTail.length
@@ -1614,6 +1875,7 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
       }
       else if (!retainMutableFragments && state.buffer.length > 1) {
         state.buffer.length = 0
+        resetBufferScanCursors(state)
         state.buffer.push(currentContent)
       }
     }

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -120,7 +120,6 @@ export interface MarkdownState {
    * `rawHtmlMarkdown`: a blank line has been seen inside the current block.
    * The scan cursors hold how far the buffer was walked to decide that.
    */
-  inRawHtmlRegion?: boolean
   rawHtmlMarkdown?: boolean
   rawHtmlScannedTo?: number
   lineScannedTo?: number
@@ -344,6 +343,15 @@ function shouldAddSpacingBeforeText(lastChar: string, lastNode: ElementNode | Te
   return true
 }
 
+/** Parity with the Rust engine's `in_heading`. */
+function isInsideHeading(depthMap: Uint16Array): boolean {
+  for (let h = TAG_H1; h <= TAG_H6; h++) {
+    if (depthMap[h])
+      return true
+  }
+  return false
+}
+
 /**
  * Whether prose at the current position may be hard-wrapped. Code blocks
  * (`<pre>`/`<code>`), table cells, and headings are emitted verbatim so wrapping
@@ -354,11 +362,7 @@ function canWrapHere(depthMap: Uint16Array): boolean {
   if (depthMap[TAG_PRE] || depthMap[TAG_CODE] || depthMap[TAG_TD] || depthMap[TAG_TH]) {
     return false
   }
-  for (let h = TAG_H1; h <= TAG_H6; h++) {
-    if (depthMap[h])
-      return false
-  }
-  return true
+  return !isInsideHeading(depthMap)
 }
 
 /**
@@ -1204,7 +1208,6 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
     // Declared up front, not assigned lazily, to keep the hidden class stable.
     emptyItemHazard: false,
     emptyItemFragment: 0,
-    inRawHtmlRegion: false,
     rawHtmlMarkdown: false,
     rawHtmlScannedTo: 0,
     lineScannedTo: 0,
@@ -1258,17 +1261,14 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
 
       const insideRawHtmlBlock = isInsideRawHtmlBlock(state.depthMap)
       if (insideRawHtmlBlock) {
-        // Anchor the scan on the way in, so the region never sees a blank line
-        // that preceded it, and text outside one pays only this test.
-        if (!state.inRawHtmlRegion) {
-          state.inRawHtmlRegion = true
-          state.rawHtmlMarkdown = false
-          state.rawHtmlScannedTo = state.buffer.length
-        }
+        // The scan starts where the last text outside a block left it, so the
+        // blank line the block's own opening tag wrote counts: that line ends
+        // the HTML block, and what follows is Markdown again.
         trackRawHtmlMarkdownContext(state)
       }
-      else if (state.inRawHtmlRegion) {
-        state.inRawHtmlRegion = false
+      else {
+        state.rawHtmlMarkdown = false
+        state.rawHtmlScannedTo = state.buffer.length
       }
       if (!state.plainText
         && !state.depthMap[TAG_PRE]
@@ -1831,6 +1831,22 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
         stableLength = linkPos
     }
 
+    // A heading's exit escapes the trailing `#` run GFM would read as an ATX
+    // closing sequence, so hold the run (and the spacing that decides whether it
+    // closes) until the heading is complete.
+    const headingHeld = isInsideHeading(state.depthMap)
+    if (headingHeld) {
+      let headingPos = currentContent.length
+      while (headingPos > 0) {
+        const char = currentContent[headingPos - 1]
+        if (char !== '#' && char !== ' ' && char !== '\t')
+          break
+        headingPos--
+      }
+      if (headingPos < stableLength)
+        stableLength = headingPos
+    }
+
     // A later mutable tail can move the stable boundary behind bytes already
     // returned to the caller. Keep the cursor monotonic so those bytes are not
     // emitted a second time once following content makes the tail stable.
@@ -1847,7 +1863,7 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
     // from joining and slicing the entire cumulative output. Plugin, wrapping,
     // and open-link paths retain the full buffer because they can inspect or
     // rewrite earlier content.
-    if (!markerHeld && !codeSpanHeld && !codeFenceHeld && !blockquoteHeld && !linkHeld && !emptyItemHeld && (!retainMutableFragments || !inPre)) {
+    if (!markerHeld && !codeSpanHeld && !codeFenceHeld && !blockquoteHeld && !linkHeld && !emptyItemHeld && !headingHeld && (!retainMutableFragments || !inPre)) {
       if (!resolvedPlugins.length && !options.wrapWidth && !state.depthMap[TAG_A]) {
         if (retainMutableFragments && leadingTrimmed === 0) {
           // Preserve the final fragment as a separate value: close handlers

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -1179,6 +1179,7 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
     emptyItemFragment: undefined,
   }
   const bufferScan: BufferScanState = [false, 0, 0, 0, 0]
+  let inRawHtmlRegion = false
   // Open inline-marker enter positions, packed as (buffer fragment index << 3 | kind).
   const openMarkers: number[] = []
   let openMarkerCount = 0
@@ -1226,13 +1227,8 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
 
       const insideRawHtmlBlock = isInsideRawHtmlBlock(state.depthMap)
       let rawHtmlMarkdown = false
-      if (insideRawHtmlBlock) {
+      if (insideRawHtmlBlock)
         rawHtmlMarkdown = trackRawHtmlMarkdownContext(state.buffer, bufferScan)
-      }
-      else {
-        bufferScan[0] = false
-        bufferScan[1] = state.buffer.length
-      }
       if (!state.plainText
         && !state.depthMap[TAG_PRE]
         && insideRawHtmlBlock) {
@@ -1318,6 +1314,12 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
 
     const element = node as ElementNode
     const handler = node.tagHandler
+    const insideRawHtmlRegion = isInsideRawHtmlBlock(state.depthMap)
+    if (insideRawHtmlRegion && !inRawHtmlRegion) {
+      bufferScan[0] = false
+      bufferScan[1] = state.buffer.length
+      inRawHtmlRegion = true
+    }
 
     // The built-in break has zero structural spacing and no exit event. Keep it
     // out of the generic element pipeline, which otherwise scans ancestry and
@@ -1654,6 +1656,12 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
       openLinkFragment = -1
 
     updateListIndent(state, element, eventType)
+
+    if (!insideRawHtmlRegion && inRawHtmlRegion) {
+      bufferScan[0] = false
+      bufferScan[1] = state.buffer.length
+      inRawHtmlRegion = false
+    }
   }
 
   /**

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -343,7 +343,6 @@ function shouldAddSpacingBeforeText(lastChar: string, lastNode: ElementNode | Te
   return true
 }
 
-/** Parity with the Rust engine's `in_heading`. */
 function isInsideHeading(depthMap: Uint16Array): boolean {
   for (let h = TAG_H1; h <= TAG_H6; h++) {
     if (depthMap[h])
@@ -1261,9 +1260,6 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
 
       const insideRawHtmlBlock = isInsideRawHtmlBlock(state.depthMap)
       if (insideRawHtmlBlock) {
-        // The scan starts where the last text outside a block left it, so the
-        // blank line the block's own opening tag wrote counts: that line ends
-        // the HTML block, and what follows is Markdown again.
         trackRawHtmlMarkdownContext(state)
       }
       else {
@@ -1838,8 +1834,8 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
     if (headingHeld) {
       let headingPos = currentContent.length
       while (headingPos > 0) {
-        const char = currentContent[headingPos - 1]
-        if (char !== '#' && char !== ' ' && char !== '\t')
+        const code = currentContent.charCodeAt(headingPos - 1)
+        if (code !== 35 && code !== 32 && code !== 9) // # space tab
           break
         headingPos--
       }

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -31,7 +31,6 @@ import {
   TAG_INS,
   TAG_KBD,
   TAG_LI,
-  TAG_MARK,
   TAG_OL,
   TAG_P,
   TAG_PRE,
@@ -42,12 +41,9 @@ import {
   TAG_SPAN,
   TAG_STRIKE,
   TAG_STRONG,
-  TAG_SUB,
-  TAG_SUP,
   TAG_TABLE,
   TAG_TD,
   TAG_TH,
-  TAG_TIME,
   TAG_U,
   TAG_VAR,
   TEXT_NODE,
@@ -55,7 +51,7 @@ import {
 import { finalizeParse, parseHtmlStream } from './parse'
 import { processPluginsForEvent } from './plugin-processor'
 import { breakHandler, renderBreak, resolveUrl } from './tags'
-import { blockOpenPrefix, continuationPrefix, isListMarkerTail, listMarkerLineStart, orderedItemNumber } from './utils'
+import { blockOpenPrefix, continuationPrefix, listMarkerLineStart, orderedItemNumber } from './utils'
 
 export interface MarkdownState {
   /** Configuration options for conversion */
@@ -110,21 +106,8 @@ export interface MarkdownState {
   blockquotes: BlockquoteFrame[]
   /** Public runtime view used by tag handlers without exposing frame internals. */
   bufferedBlockquoteDepth: number
-  /** Marker line at risk of reading as a setext underline; see `recordItemMarker`. */
-  emptyItemHazard?: boolean
+  /** Fragment for a marker line at risk of becoming a setext underline. */
   emptyItemFragment?: number
-  /**
-   * Raw-HTML region tracking. A blank line inside a raw HTML block ends it and
-   * the text after it is Markdown again, so it needs escaping; a line that opens
-   * a fresh HTML block suspends Markdown once more.
-   * `rawHtmlMarkdown`: a blank line has been seen inside the current block.
-   * The scan cursors hold how far the buffer was walked to decide that.
-   */
-  rawHtmlMarkdown?: boolean
-  rawHtmlScannedTo?: number
-  lineScannedTo?: number
-  lineStartFragment?: number
-  lineStartOffset?: number
   /** Whether output should omit Markdown/HTML markup */
   plainText?: boolean
 }
@@ -172,33 +155,15 @@ INLINE_MARKER_TYPE[TAG_Q] = 6 // "
 // Inline tags whose Markdown delimiters are literal text inside a `<pre>`, so
 // only their content is emitted there. `<code>` and `<br>` are absent: both
 // already have `<pre>`-aware handlers.
-const SUPPRESSED_IN_PRE = new Uint8Array(MAX_TAG_ID)
-for (const tagId of [
-  TAG_STRONG,
-  TAG_B,
-  TAG_EM,
-  TAG_I,
-  TAG_DEL,
-  TAG_S,
-  TAG_STRIKE,
-  TAG_CITE,
-  TAG_DFN,
-  TAG_KBD,
-  TAG_SAMP,
-  TAG_VAR,
-  TAG_Q,
-  TAG_SUB,
-  TAG_SUP,
-  TAG_INS,
-  TAG_MARK,
-  TAG_ABBR,
-  TAG_SMALL,
-  TAG_U,
-  TAG_TIME,
-  TAG_BDO,
-  TAG_A,
-])
-  SUPPRESSED_IN_PRE[tagId] = 1
+function suppressesFormattingInPre(tagId: number): boolean {
+  return tagId === TAG_A
+    || tagId === TAG_KBD
+    || tagId === TAG_S
+    || tagId === TAG_STRIKE
+    || (tagId >= TAG_STRONG && tagId <= TAG_INS)
+    || (tagId >= TAG_ABBR && tagId <= TAG_SMALL)
+    || (tagId >= TAG_U && tagId <= TAG_BDO)
+}
 
 /**
  * Length of the newline run ending just before fragment `index`, or -1 when
@@ -227,10 +192,9 @@ function recordItemMarker(state: MarkdownState, index: number): void {
   // Only a list's first item can follow a paragraph, so every later sibling
   // skips the scan below.
   if (index !== 0 || newlineRunBefore(state.buffer, state.buffer.length - 1) !== 1) {
-    state.emptyItemHazard = false
+    state.emptyItemFragment = undefined
     return
   }
-  state.emptyItemHazard = true
   state.emptyItemFragment = state.buffer.length - 1
 }
 
@@ -241,11 +205,12 @@ function recordItemMarker(state: MarkdownState, index: number): void {
  * forces one.
  */
 function resolveItemMarker(state: MarkdownState, atExit: boolean): void {
-  if (!state.emptyItemHazard)
+  const fragment = state.emptyItemFragment
+  if (fragment === undefined)
     return
   const buffer = state.buffer
   let first = -1
-  for (let i = state.emptyItemFragment! + 1; i < buffer.length && first === -1; i++) {
+  for (let i = fragment + 1; i < buffer.length && first === -1; i++) {
     const fragment = buffer[i]!
     for (let j = 0; j < fragment.length; j++) {
       const code = fragment.charCodeAt(j)
@@ -257,10 +222,9 @@ function resolveItemMarker(state: MarkdownState, atExit: boolean): void {
   }
   if (first === -1 && !atExit)
     return
-  state.emptyItemHazard = false
+  state.emptyItemFragment = undefined
   if (first !== -1 && first !== 10)
     return
-  const fragment = state.emptyItemFragment!
   buffer[fragment] = `\n${buffer[fragment]}`
 }
 
@@ -453,20 +417,29 @@ function escapeRawHtmlText(value: string, depthMap: Uint16Array): string {
   return copiedUntil === 0 ? value : escaped + value.slice(copiedUntil)
 }
 
+// Private scan state stays outside the handler-facing MarkdownState interface.
+// Tuple labels retain meaning in source while minifying to compact indexes.
+type BufferScanState = [
+  rawHtmlMarkdown: boolean,
+  rawHtmlScannedTo: number,
+  lineScannedTo: number,
+  lineStartFragment: number,
+  lineStartOffset: number,
+]
+
 // The streaming drain replaces the buffer, so fragment-indexed scan cursors
-// have to start over; the `rawHtmlMarkdown` latch itself still holds.
-function resetBufferScanCursors(state: MarkdownState): void {
-  state.rawHtmlScannedTo = 0
-  state.lineScannedTo = 0
-  state.lineStartFragment = 0
-  state.lineStartOffset = 0
+// start over while the raw-HTML Markdown latch survives.
+function resetBufferScanCursors(scan: BufferScanState): void {
+  scan[1] = 0
+  scan[2] = 0
+  scan[3] = 0
+  scan[4] = 0
 }
 
-function trackRawHtmlMarkdownContext(state: MarkdownState): void {
-  if (state.rawHtmlMarkdown)
-    return
-  const buffer = state.buffer
-  let index = state.rawHtmlScannedTo ?? 0
+function trackRawHtmlMarkdownContext(buffer: string[], scan: BufferScanState): boolean {
+  if (scan[0])
+    return true
+  let index = scan[1]
   if (index > buffer.length)
     index = 0
   let previous = index > 0 ? buffer[index - 1]!.charCodeAt(buffer[index - 1]!.length - 1) : -1
@@ -475,12 +448,13 @@ function trackRawHtmlMarkdownContext(state: MarkdownState): void {
     if (!fragment)
       continue
     if (fragment.includes('\n\n') || (previous === 10 && fragment.charCodeAt(0) === 10)) {
-      state.rawHtmlMarkdown = true
+      scan[0] = true
       break
     }
     previous = fragment.charCodeAt(fragment.length - 1)
   }
-  state.rawHtmlScannedTo = buffer.length
+  scan[1] = buffer.length
+  return scan[0]
 }
 
 /**
@@ -488,26 +462,25 @@ function trackRawHtmlMarkdownContext(state: MarkdownState): void {
  * since the last call can move the line start, so a line spanning many
  * fragments is walked once instead of once per text node.
  */
-function lineOpensRawHtmlBlock(state: MarkdownState): boolean {
-  const buffer = state.buffer
-  let scanned = state.lineScannedTo ?? 0
+function lineOpensRawHtmlBlock(buffer: string[], scan: BufferScanState): boolean {
+  let scanned = scan[2]
   if (scanned > buffer.length) {
     scanned = 0
-    state.lineStartFragment = 0
-    state.lineStartOffset = 0
+    scan[3] = 0
+    scan[4] = 0
   }
   for (let index = scanned; index < buffer.length; index++) {
     const newline = buffer[index]!.lastIndexOf('\n')
     if (newline !== -1) {
-      state.lineStartFragment = index
-      state.lineStartOffset = newline + 1
+      scan[3] = index
+      scan[4] = newline + 1
     }
   }
-  state.lineScannedTo = buffer.length
+  scan[2] = buffer.length
 
   let spaces = 0
-  let offset = state.lineStartOffset ?? 0
-  for (let index = state.lineStartFragment ?? 0; index < buffer.length; index++) {
+  let offset = scan[4]
+  for (let index = scan[3]; index < buffer.length; index++) {
     const fragment = buffer[index]!
     while (offset < fragment.length) {
       const code = fragment.charCodeAt(offset)
@@ -538,9 +511,7 @@ function markdownLineIndent(buffer: string[]): number {
       // A list marker is block prefix too: its content column opens a fresh
       // block context, so `- # h` escapes exactly like `# h` would.
       if (code !== 32 || spaces === 3) {
-        return isListMarkerTail(code) && listMarkerLineStart(buffer, fragmentIndex, index)
-          ? 0
-          : -1
+        return listMarkerLineStart(buffer, fragmentIndex, index) ? 0 : -1
       }
       spaces++
     }
@@ -1205,14 +1176,9 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
     bufferedBlockquoteDepth: 0,
     plainText: options.format === 'text',
     // Declared up front, not assigned lazily, to keep the hidden class stable.
-    emptyItemHazard: false,
-    emptyItemFragment: 0,
-    rawHtmlMarkdown: false,
-    rawHtmlScannedTo: 0,
-    lineScannedTo: 0,
-    lineStartFragment: 0,
-    lineStartOffset: 0,
+    emptyItemFragment: undefined,
   }
+  const bufferScan: BufferScanState = [false, 0, 0, 0, 0]
   // Open inline-marker enter positions, packed as (buffer fragment index << 3 | kind).
   const openMarkers: number[] = []
   let openMarkerCount = 0
@@ -1259,12 +1225,13 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
       }
 
       const insideRawHtmlBlock = isInsideRawHtmlBlock(state.depthMap)
+      let rawHtmlMarkdown = false
       if (insideRawHtmlBlock) {
-        trackRawHtmlMarkdownContext(state)
+        rawHtmlMarkdown = trackRawHtmlMarkdownContext(state.buffer, bufferScan)
       }
       else {
-        state.rawHtmlMarkdown = false
-        state.rawHtmlScannedTo = state.buffer.length
+        bufferScan[0] = false
+        bufferScan[1] = state.buffer.length
       }
       if (!state.plainText
         && !state.depthMap[TAG_PRE]
@@ -1278,9 +1245,9 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
         // Inside a raw-HTML region only text past a blank line is Markdown
         // again. That test is O(1), so it goes before the text scans; the line
         // scan stays last, paid only by text that would be escaped anyway.
-        && (!insideRawHtmlBlock || state.rawHtmlMarkdown)
+        && (!insideRawHtmlBlock || rawHtmlMarkdown)
         && mayNeedGfmTextEscape(textNode.value, state.buffer, state.depthMap)
-        && (!insideRawHtmlBlock || !lineOpensRawHtmlBlock(state))) {
+        && (!insideRawHtmlBlock || !lineOpensRawHtmlBlock(state.buffer, bufferScan))) {
         textNode.value = escapeGfmText(textNode.value, state.buffer, state.depthMap)
       }
 
@@ -1437,7 +1404,7 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
     let handlerOutput: string | undefined
     const suppressedInPre = !state.plainText
       && (state.depthMap[TAG_PRE] || 0) > 0
-      && SUPPRESSED_IN_PRE[element.tagId!] === 1
+      && suppressesFormattingInPre(element.tagId!)
     if (!output && !suppressedInPre && handler?.[eventFn]) {
       const res = state.plainText
         ? getPlainTextOutput(element, eventType, state)
@@ -1784,11 +1751,12 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
         stableLength = spanPos
     }
     // An empty `<li>` rewrites its own marker fragment on exit.
-    const emptyItemHeld = state.emptyItemHazard === true
+    const emptyItemFragment = state.emptyItemFragment
+    const emptyItemHeld = emptyItemFragment !== undefined
     if (emptyItemHeld) {
       const itemPos = Math.max(
         lastYieldedLength,
-        trimBufferedWhitespacePosition(currentContent, fragmentPosition(state.buffer, state.emptyItemFragment!) - leadingTrimmed),
+        trimBufferedWhitespacePosition(currentContent, fragmentPosition(state.buffer, emptyItemFragment) - leadingTrimmed),
       )
       if (itemPos < stableLength)
         stableLength = itemPos
@@ -1869,7 +1837,7 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
           const tailStart = Math.max(0, Math.min(stableLength - 2, fragmentStart))
           const emittedTail = currentContent.slice(tailStart, fragmentStart)
           state.buffer.length = 0
-          resetBufferScanCursors(state)
+          resetBufferScanCursors(bufferScan)
           if (emittedTail)
             state.buffer.push(emittedTail)
           state.buffer.push(lastFragment)
@@ -1879,7 +1847,7 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
           const tailStart = Math.max(0, stableLength - 2)
           const emittedTail = currentContent.slice(tailStart, stableLength)
           state.buffer.length = 0
-          resetBufferScanCursors(state)
+          resetBufferScanCursors(bufferScan)
           if (emittedTail)
             state.buffer.push(emittedTail)
           lastYieldedLength = emittedTail.length
@@ -1887,7 +1855,7 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
       }
       else if (!retainMutableFragments && state.buffer.length > 1) {
         state.buffer.length = 0
-        resetBufferScanCursors(state)
+        resetBufferScanCursors(bufferScan)
         state.buffer.push(currentContent)
       }
     }

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -244,10 +244,6 @@ const DL_SCOPE_BOUNDARY = new Set<number>([
   TAG_HTML,
 ])
 
-// Where a row-recovery scan stops: the table itself, and the contexts that hold
-// their own table structure.
-const ROW_SCOPE_BOUNDARY = new Set<number>([TAG_TABLE, TAG_TEMPLATE, TAG_CAPTION])
-
 // "Table cell scope": a new `<td>`/`<th>` closes the current cell, stopping at
 // the row/section.
 const CELL_SCOPE_BOUNDARY = new Set<number>([
@@ -390,7 +386,7 @@ function closeTableContext(
     // Content left open inside a cell (`<td><p>text` with no `</p>`, or an
     // unknown custom element) sits above the closeable element and closes with
     // it; stopping here would leave the new row nested in the old cell.
-    else if (id !== undefined && ROW_SCOPE_BOUNDARY.has(id)) {
+    else if (id === TAG_TABLE || id === TAG_TEMPLATE || id === TAG_CAPTION) {
       break
     }
     else {

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -397,8 +397,9 @@ function closeTableContext(
       walked++
     }
   }
-  for (let i = 0; i < closeCount && state.currentNode; i++)
+  for (let i = 0; i < closeCount && state.currentNode; i++) {
     closeNode(state.currentNode, state, handleEvent)
+  }
 }
 
 /**

--- a/packages/js/src/parse.ts
+++ b/packages/js/src/parse.ts
@@ -244,6 +244,10 @@ const DL_SCOPE_BOUNDARY = new Set<number>([
   TAG_HTML,
 ])
 
+// Where a row-recovery scan stops: the table itself, and the contexts that hold
+// their own table structure.
+const ROW_SCOPE_BOUNDARY = new Set<number>([TAG_TABLE, TAG_TEMPLATE, TAG_CAPTION])
+
 // "Table cell scope": a new `<td>`/`<th>` closes the current cell, stopping at
 // the row/section.
 const CELL_SCOPE_BOUNDARY = new Set<number>([
@@ -373,13 +377,28 @@ function closeTableContext(
       return
     clearFlattenedElements(state)
   }
-  while (state.currentNode) {
-    const id = state.currentNode.tagId
-    if (id === undefined || !closeable.has(id)) {
+  // One reverse pass, as in `closeImpliedTo`: re-deciding after each close walks
+  // the stack once per closed node.
+  let closeCount = 0
+  let walked = 0
+  for (let node = state.currentNode; node; node = node.parent) {
+    const id = node.tagId
+    if (id !== undefined && closeable.has(id)) {
+      walked++
+      closeCount = walked
+    }
+    // Content left open inside a cell (`<td><p>text` with no `</p>`, or an
+    // unknown custom element) sits above the closeable element and closes with
+    // it; stopping here would leave the new row nested in the old cell.
+    else if (id !== undefined && ROW_SCOPE_BOUNDARY.has(id)) {
       break
     }
-    closeNode(state.currentNode, state, handleEvent)
+    else {
+      walked++
+    }
   }
+  for (let i = 0; i < closeCount && state.currentNode; i++)
+    closeNode(state.currentNode, state, handleEvent)
 }
 
 /**

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -6,6 +6,7 @@ import {
   MARKDOWN_CODE_BLOCK,
   MARKDOWN_EMPHASIS,
   MARKDOWN_HORIZONTAL_RULE,
+  MARKDOWN_HORIZONTAL_RULE_ALT,
   MARKDOWN_INLINE_CODE,
   MARKDOWN_STRIKETHROUGH,
   MARKDOWN_STRONG,
@@ -26,6 +27,7 @@ import {
   TAG_BR,
   TAG_BUTTON,
   TAG_CANVAS,
+  TAG_CAPTION,
   TAG_CENTER,
   TAG_CITE,
   TAG_CODE,
@@ -122,7 +124,7 @@ import {
   TAG_XMP,
   TagIdMap,
 } from './const'
-import { continuationPrefix, getLanguageFromClass, isEmptyLinkHref } from './utils'
+import { blockOpenPrefix, continuationPrefix, endsOutputLine, fenceLanguage, isEmptyLinkHref, listMarkerLineStart, orderedItemNumber } from './utils'
 
 const TRACKING_PARAM_RE = /^(?:utm_|fbclid|gclid|mc_eid|msclkid|oly_)/
 const URL_SCHEME_RE = /^[\dA-Z+.-]+:/i
@@ -248,18 +250,154 @@ export const breakHandler: TagHandler = {
   isInline: true,
 }
 
+// A `#` run closing a heading is an ATX closing sequence and is dropped by the
+// renderer, so the last one is escaped back into content.
+function escapeTrailingHeadingHashes(buffer: string[]): void {
+  let index = buffer.length - 1
+  while (index >= 0 && buffer[index] === '')
+    index--
+  if (index < 0)
+    return
+
+  const entry = buffer[index]!
+  let end = entry.length
+  while (end > 0 && (entry[end - 1] === ' ' || entry[end - 1] === '\t'))
+    end--
+  let run = end
+  while (run > 0 && entry[run - 1] === '#')
+    run--
+  if (run === end)
+    return
+
+  // Only a run opening the heading content or preceded by whitespace closes it.
+  // Requiring a space also rejects the `## ` prefix entry of an empty heading.
+  const previous = buffer[index - 1]
+  const before = run > 0 ? entry[run - 1] : previous?.charAt(previous.length - 1)
+  if (before !== ' ' && before !== '\t')
+    return
+
+  buffer[index] = `${entry.slice(0, run)}\\${entry.slice(run)}`
+}
+
+// What the current output line holds where a table row is about to be written.
+const LINE_OPEN = 0 // nothing but block prefix, or a pending list marker
+const LINE_ROW = 1 // a row left open mid-line
+const LINE_CONTENT = 2 // other content, so the row needs a block break
+
+// A row must open its own line at the item's content column: sharing one with
+// preceding content (a `<caption>`) leaves the header as prose and the
+// delimiter row never forms a table.
+function lineStateBeforeRow(buffer: string[]): number {
+  let fragment = buffer.length - 1
+  while (fragment >= 0 && buffer[fragment]!.length === 0)
+    fragment--
+  if (fragment < 0)
+    return LINE_OPEN
+  // Rows end their line, so the row after a row decides on one character and
+  // never rescans the line it just wrote.
+  const tail = buffer[fragment]!
+  if (tail.charCodeAt(tail.length - 1) === 10)
+    return LINE_OPEN
+
+  let firstNonSpace = -1
+  let markerFragment = -1
+  let markerIndex = -1
+  let cursor = tail.length
+  for (;;) {
+    if (cursor === 0) {
+      if (--fragment < 0)
+        break
+      cursor = buffer[fragment]!.length
+      continue
+    }
+    const code = buffer[fragment]!.charCodeAt(--cursor)
+    if (code === 10)
+      break
+    if (code !== 32 && code !== 9) {
+      firstNonSpace = code
+      if (markerFragment < 0) {
+        markerFragment = fragment
+        markerIndex = cursor
+      }
+    }
+  }
+
+  if (firstNonSpace === -1)
+    return LINE_OPEN
+  // A row already open only needs its line broken, not a new block.
+  if (firstNonSpace === 124) // |
+    return LINE_ROW
+  // A pending list marker is block prefix, not content: a table's first row
+  // belongs on it.
+  return listMarkerLineStart(buffer, markerFragment, markerIndex) ? LINE_OPEN : LINE_CONTENT
+}
+
+// A row's own line at the enclosing list item's content column. Outside a list
+// the marker is constant, which covers most tables.
+function rowMarker(state: HandlerContext['state']): string {
+  const indent = state.listIndent
+  const lineState = lineStateBeforeRow(state.buffer)
+  if (!indent) {
+    return lineState === LINE_ROW ? '\n| ' : lineState === LINE_CONTENT ? '\n\n| ' : '| '
+  }
+  switch (lineState) {
+    case LINE_ROW:
+      return `\n${indent}| `
+    case LINE_CONTENT:
+      return `\n\n${indent}| `
+    default:
+      // A pending list marker already supplies the column; only a fresh line
+      // needs the indent written.
+      return endsOutputLine(state.buffer) ? `${indent}| ` : '| '
+  }
+}
+
+const MAX_CELL_SPAN = 64
+
+// GFM has no `colspan`: a spanned cell is written as its content followed by empty
+// cells, or the delimiter row is too narrow and GFM drops every cell past it.
+function cellSpan(node: HandlerContext['node']): number {
+  const raw = (node as { attributes?: Record<string, string> }).attributes?.colspan
+  if (raw === undefined)
+    return 1
+  const span = Number.parseInt(raw, 10)
+  return span > 1 ? Math.min(span, MAX_CELL_SPAN) : 1
+}
+
+// Whether the cell about to open sits past the width the delimiter promised.
+function cellOverflowsHeader(state: HandlerContext['state']): boolean {
+  const header = state.tableHeaderCells || 0
+  return header > 0 && (state.tableCurrentRowCells || 0) >= header
+}
+
+function cellEnter(node: HandlerContext['node'], state: HandlerContext['state']): string {
+  if (node.index === 0)
+    return ''
+  // GFM discards cells past the delimiter row's width, so this one folds into
+  // the previous cell rather than vanishing.
+  return cellOverflowsHeader(state) ? ' ' : ' | '
+}
+
+function cellExit(node: HandlerContext['node'], state: HandlerContext['state']): string | undefined {
+  const span = cellSpan(node)
+  state.tableCurrentRowCells! += span
+  return span > 1 ? ' |'.repeat(span - 1) : undefined
+}
+
 function handleHeading(depth: number): TagHandler {
   return {
+    // A `#` prefix needs its own line, which a GFM row cannot give it.
     enter: ({ state }) => {
-      if ((state.depthMap?.[TAG_A] || 0) > 0) {
+      if ((state.depthMap?.[TAG_A] || 0) > 0 || isInsideTableCell(state)) {
         return `<h${depth}>`
       }
       return `${'#'.repeat(depth)} `
     },
     exit: ({ state }) => {
-      if ((state.depthMap?.[TAG_A] || 0) > 0) {
+      if ((state.depthMap?.[TAG_A] || 0) > 0 || isInsideTableCell(state)) {
         return `</h${depth}>`
       }
+      escapeTrailingHeadingHashes(state.buffer)
     },
     collapsesInnerWhiteSpace: true,
   }
@@ -368,7 +506,28 @@ export const tagHandlers: Record<number, TagHandler> = {
   [TAG_H5]: handleHeading(5),
   [TAG_H6]: handleHeading(6),
   [TAG_HR]: {
-    enter: () => MARKDOWN_HORIZONTAL_RULE,
+    enter: ({ node, state }) => {
+      // A thematic break cannot end a GFM row; raw <hr> can sit in a cell.
+      if (isInsideTableCell(state))
+        return '<hr>'
+      // `continuationPrefix` allocates an ancestor chain, so only a rule that
+      // can actually carry a prefix asks for one.
+      if (!(state.depthMap?.[TAG_LI] || state.bufferedBlockquoteDepth))
+        return MARKDOWN_HORIZONTAL_RULE
+      const prefix = continuationPrefix(
+        node,
+        state.listIndentWidths || [],
+        !state.bufferedBlockquoteDepth,
+      )
+      if (!prefix)
+        return MARKDOWN_HORIZONTAL_RULE
+      const open = blockOpenPrefix(state.buffer, prefix)
+      // Sharing the marker's line, where `---` would make the whole line a
+      // thematic break and take the item with it.
+      return open === undefined
+        ? MARKDOWN_HORIZONTAL_RULE_ALT
+        : `${open}${MARKDOWN_HORIZONTAL_RULE}`
+    },
     isSelfClosing: true,
   },
   [TAG_STRONG]: Strong,
@@ -422,7 +581,7 @@ export const tagHandlers: Record<number, TagHandler> = {
       }
       return {
         _tag: 'PreEnter',
-        language: getLanguageFromClass(node.attributes?.class),
+        language: fenceLanguage(node.attributes),
       }
     },
     exit: ({ state }) => {
@@ -440,19 +599,22 @@ export const tagHandlers: Record<number, TagHandler> = {
         if (isInsideTableCell(state)) {
           return '<code>'
         }
-        // The enclosing <pre> already opened its own fence (e.g. <pre> with
-        // mixed text and <code> children); don't emit a nested fence.
-        if (state.preOwnFence) {
+        // A fence is already open for this <pre>: the <pre> opened it (mixed text
+        // + <code> children) or an earlier <code> sibling did.
+        if (state.preFenceOpen) {
           return undefined
         }
-        const language = getLanguageFromClass(node.attributes?.class)
+        const language = fenceLanguage(node.attributes)
         const liDepth = state.depthMap?.[TAG_LI] || 0
         if (liDepth > 0) {
           const indent = state.listIndent
+          // A blank line between the marker and the fence ends the item, leaving
+          // the block a sibling of the list.
+          const open = blockOpenPrefix(state.buffer, indent) ?? ''
           return {
             _tag: 'CodeFenceEnter',
             language,
-            output: `\n\n${indent}${MARKDOWN_CODE_BLOCK}${language}\n`,
+            output: `${open}${MARKDOWN_CODE_BLOCK}${language}\n`,
           }
         }
         return {
@@ -489,19 +651,9 @@ export const tagHandlers: Record<number, TagHandler> = {
         if (isInsideTableCell(state)) {
           return '</code>'
         }
-        // The enclosing <pre> owns the fence; this <code> emitted no opener.
-        if (state.preOwnFence) {
-          return undefined
-        }
-        const liDepth = state.depthMap?.[TAG_LI] || 0
-        if (liDepth > 0) {
-          const indent = state.listIndent
-          return {
-            _tag: 'CodeFenceExit',
-            output: `\n${indent}${MARKDOWN_CODE_BLOCK}\n\n${indent}`,
-          }
-        }
-        return { _tag: 'CodeFenceExit', output: `\n${MARKDOWN_CODE_BLOCK}` }
+        // The <pre> exit owns the closing fence, so a text sibling after this
+        // </code> still lands inside the block.
+        return undefined
       }
       if (isInsideRawHtmlBlock(state.depthMap!)) {
         return '</code>'
@@ -531,7 +683,7 @@ export const tagHandlers: Record<number, TagHandler> = {
       // is pushed onto state.listIndent after the enter output is written
       // (see markdown-processor.ts).
       const isOrdered = node.parent?.tagId === TAG_OL
-      const marker = isOrdered ? `${node.index + 1}. ` : '- '
+      const marker = isOrdered ? `${orderedItemNumber(node.parent, node.index)}. ` : '- '
       return `${state.listIndent}${marker}`
     },
     exit: ({ state }) => isInsideTableCell(state) ? '</li>' : undefined,
@@ -609,8 +761,19 @@ export const tagHandlers: Record<number, TagHandler> = {
       }
       // Initialize table state
       state.tableColumnAlignments = []
+      state.tableHeaderCells = 0
     },
     exit: ({ state }) => isInsideTableCell(state) ? '</table>' : undefined,
+  },
+  // Inside a list item nothing else writes the caption's content column: glued to
+  // preceding text it swallows the table's first row, and at column 0 it takes the
+  // table out of the item.
+  [TAG_CAPTION]: {
+    enter: ({ state }) => {
+      if ((state.depthMap?.[TAG_LI] || 0) === 0 || isInsideTableCell(state))
+        return undefined
+      return blockOpenPrefix(state.buffer, state.listIndent)
+    },
   },
   [TAG_THEAD]: {
     enter: ({ state }) => {
@@ -628,7 +791,7 @@ export const tagHandlers: Record<number, TagHandler> = {
         return '<tr>'
       }
       state.tableCurrentRowCells = 0
-      return '| '
+      return rowMarker(state)
     },
     exit: ({ state }) => {
       if (isInsideTableCell(state) || (state.depthMap?.[TAG_TABLE] || 0) > 1) {
@@ -655,7 +818,9 @@ export const tagHandlers: Record<number, TagHandler> = {
           }
         })
 
-        return ` |\n| ${alignmentMarkers.join(' | ')} |`
+        state.tableHeaderCells = alignments.length
+        const indent = (state.depthMap?.[TAG_LI] || 0) > 0 ? state.listIndent : ''
+        return ` |\n${indent}| ${alignmentMarkers.join(' | ')} |`
       }
 
       return ' |'
@@ -678,13 +843,13 @@ export const tagHandlers: Record<number, TagHandler> = {
         state.tableColumnAlignments!.push('')
       }
 
-      return node.index === 0 ? '' : ' | '
+      return cellEnter(node, state)
     },
-    exit: ({ state }) => {
+    exit: ({ node, state }) => {
       if ((state.depthMap?.[TAG_TABLE] || 0) > 1) {
         return '</th>'
       }
-      state.tableCurrentRowCells!++
+      return cellExit(node, state)
     },
     collapsesInnerWhiteSpace: true,
     spacing: NO_SPACING,
@@ -694,13 +859,13 @@ export const tagHandlers: Record<number, TagHandler> = {
       if ((state.depthMap?.[TAG_TABLE] || 0) > 1) {
         return '<td>'
       }
-      return node.index === 0 ? '' : ' | '
+      return cellEnter(node, state)
     },
-    exit: ({ state }) => {
+    exit: ({ node, state }) => {
       if ((state.depthMap?.[TAG_TABLE] || 0) > 1) {
         return '</td>'
       }
-      state.tableCurrentRowCells!++
+      return cellExit(node, state)
     },
     collapsesInnerWhiteSpace: true,
     spacing: NO_SPACING,

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -124,7 +124,7 @@ import {
   TAG_XMP,
   TagIdMap,
 } from './const'
-import { blockOpenPrefix, continuationPrefix, fenceLanguage, isEmptyLinkHref, isInsideHeading, isInsideTableCell, listMarkerLineStart, orderedItemNumber, parseUnsignedInteger } from './utils'
+import { blockOpenPrefix, continuationPrefix, getLanguageFromClass, isEmptyLinkHref, isInsideHeading, isInsideTableCell, listMarkerLineStart, orderedItemNumber, parseUnsignedInteger } from './utils'
 
 const TRACKING_PARAM_RE = /^(?:utm_|fbclid|gclid|mc_eid|msclkid|oly_)/
 const URL_SCHEME_RE = /^[\dA-Z+.-]+:/i
@@ -559,7 +559,7 @@ export const tagHandlers: Record<number, TagHandler> = {
       }
       return {
         _tag: 'PreEnter',
-        language: fenceLanguage(node.attributes),
+        language: getLanguageFromClass(node.attributes?.class),
       }
     },
     exit: ({ state }) => {
@@ -582,7 +582,7 @@ export const tagHandlers: Record<number, TagHandler> = {
         if (state.preFenceOpen) {
           return undefined
         }
-        const language = fenceLanguage(node.attributes)
+        const language = getLanguageFromClass(node.attributes?.class)
         const liDepth = state.depthMap?.[TAG_LI] || 0
         if (liDepth > 0) {
           const indent = state.listIndent

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -369,7 +369,7 @@ function cellEnter(node: HandlerContext['node'], state: HandlerContext['state'])
 
 function cellExit(node: HandlerContext['node'], state: HandlerContext['state']): string | undefined {
   const parsedSpan = parseUnsignedInteger((node as { attributes?: Record<string, string> }).attributes?.colspan)
-  const span = parsedSpan && parsedSpan > 1 ? Math.min(parsedSpan, MAX_CELL_SPAN) : 1
+  const span = parsedSpan && parsedSpan < 256 ? Math.min(parsedSpan, MAX_CELL_SPAN) : 1
   state.tableCurrentRowCells! += span
   return span > 1 ? ' |'.repeat(span - 1) : undefined
 }

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -124,7 +124,7 @@ import {
   TAG_XMP,
   TagIdMap,
 } from './const'
-import { blockOpenPrefix, continuationPrefix, fenceLanguage, isEmptyLinkHref, listMarkerLineStart, orderedItemNumber, parseUnsignedInteger } from './utils'
+import { blockOpenPrefix, continuationPrefix, fenceLanguage, isEmptyLinkHref, isInsideHeading, isInsideTableCell, listMarkerLineStart, orderedItemNumber, parseUnsignedInteger } from './utils'
 
 const TRACKING_PARAM_RE = /^(?:utm_|fbclid|gclid|mc_eid|msclkid|oly_)/
 const URL_SCHEME_RE = /^[\dA-Z+.-]+:/i
@@ -211,23 +211,11 @@ function isAutolinkUri(s: string): boolean {
   return true
 }
 
-// Helper function to check if we're inside a table cell
-function isInsideTableCell(state: HandlerContext['state']): boolean {
-  const depthMap = state.depthMap!
-  return depthMap[TAG_TD]! > 0 || depthMap[TAG_TH]! > 0
-}
-
 export function renderBreak(node: HandlerContext['node'], state: HandlerContext['state']): string {
   // A literal newline would terminate a table row/ATX heading or collapse
   // inside a raw HTML block, so preserve the inline HTML there.
   const depthMap = state.depthMap!
-  if (isInsideTableCell(state) || isInsideRawHtmlBlock(depthMap)
-    || depthMap[TAG_H1]
-    || depthMap[TAG_H2]
-    || depthMap[TAG_H3]
-    || depthMap[TAG_H4]
-    || depthMap[TAG_H5]
-    || depthMap[TAG_H6]) {
+  if (isInsideTableCell(state) || isInsideRawHtmlBlock(depthMap) || isInsideHeading(depthMap)) {
     return '<br>'
   }
   // Hard-break markers are literal content inside code.

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -124,7 +124,7 @@ import {
   TAG_XMP,
   TagIdMap,
 } from './const'
-import { blockOpenPrefix, continuationPrefix, endsOutputLine, fenceLanguage, isEmptyLinkHref, listMarkerLineStart, orderedItemNumber } from './utils'
+import { blockOpenPrefix, continuationPrefix, fenceLanguage, isEmptyLinkHref, listMarkerLineStart, orderedItemNumber, parseUnsignedInteger } from './utils'
 
 const TRACKING_PARAM_RE = /^(?:utm_|fbclid|gclid|mc_eid|msclkid|oly_)/
 const URL_SCHEME_RE = /^[\dA-Z+.-]+:/i
@@ -280,6 +280,7 @@ function escapeTrailingHeadingHashes(buffer: string[]): void {
 }
 
 // What the current output line holds where a table row is about to be written.
+const LINE_FRESH = -1 // a newline already opened the content column
 const LINE_OPEN = 0 // nothing but block prefix, or a pending list marker
 const LINE_ROW = 1 // a row left open mid-line
 const LINE_CONTENT = 2 // other content, so the row needs a block break
@@ -297,7 +298,7 @@ function lineStateBeforeRow(buffer: string[]): number {
   // never rescans the line it just wrote.
   const tail = buffer[fragment]!
   if (tail.charCodeAt(tail.length - 1) === 10)
-    return LINE_OPEN
+    return LINE_FRESH
 
   let firstNonSpace = -1
   let markerFragment = -1
@@ -345,10 +346,11 @@ function rowMarker(state: HandlerContext['state']): string {
       return `\n${indent}| `
     case LINE_CONTENT:
       return `\n\n${indent}| `
+    case LINE_FRESH:
+      return `${indent}| `
     default:
-      // A pending list marker already supplies the column; only a fresh line
-      // needs the indent written.
-      return endsOutputLine(state.buffer) ? `${indent}| ` : '| '
+      // A pending list marker already supplies the content column.
+      return '| '
   }
 }
 
@@ -356,30 +358,18 @@ const MAX_CELL_SPAN = 64
 
 // GFM has no `colspan`: a spanned cell is written as its content followed by empty
 // cells, or the delimiter row is too narrow and GFM drops every cell past it.
-function cellSpan(node: HandlerContext['node']): number {
-  const raw = (node as { attributes?: Record<string, string> }).attributes?.colspan
-  if (raw === undefined)
-    return 1
-  const span = Number.parseInt(raw, 10)
-  return span > 1 ? Math.min(span, MAX_CELL_SPAN) : 1
-}
-
-// Whether the cell about to open sits past the width the delimiter promised.
-function cellOverflowsHeader(state: HandlerContext['state']): boolean {
-  const header = state.tableHeaderCells || 0
-  return header > 0 && (state.tableCurrentRowCells || 0) >= header
-}
-
 function cellEnter(node: HandlerContext['node'], state: HandlerContext['state']): string {
   if (node.index === 0)
     return ''
   // GFM discards cells past the delimiter row's width, so this one folds into
   // the previous cell rather than vanishing.
-  return cellOverflowsHeader(state) ? ' ' : ' | '
+  const header = state.tableHeaderCells || 0
+  return header > 0 && (state.tableCurrentRowCells || 0) >= header ? ' ' : ' | '
 }
 
 function cellExit(node: HandlerContext['node'], state: HandlerContext['state']): string | undefined {
-  const span = cellSpan(node)
+  const parsedSpan = parseUnsignedInteger((node as { attributes?: Record<string, string> }).attributes?.colspan)
+  const span = parsedSpan && parsedSpan > 1 ? Math.min(parsedSpan, MAX_CELL_SPAN) : 1
   state.tableCurrentRowCells! += span
   return span > 1 ? ' |'.repeat(span - 1) : undefined
 }

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -295,6 +295,8 @@ export interface MdreamRuntimeState extends Partial<MdreamProcessingState> {
   tableRenderedTable?: boolean
   tableCurrentRowCells?: number
   tableColumnAlignments?: string[]
+  /** See MarkdownState for semantics. */
+  tableHeaderCells?: number
 
   /** Resolved plugin instances for efficient iteration */
   resolvedPlugins?: TransformPlugin[]
@@ -323,7 +325,7 @@ export interface MdreamRuntimeState extends Partial<MdreamProcessingState> {
    */
   preFencePending?: boolean
   preFenceLang?: string
-  preOwnFence?: boolean
+  preFenceOpen?: boolean
   /** Number of default blockquotes currently buffered for line prefixing. */
   bufferedBlockquoteDepth?: number
   /** Whether output should omit Markdown/HTML markup */
@@ -369,7 +371,6 @@ export type GfmAction
     | { _tag: 'CodeSpanEnter', output: string }
     | { _tag: 'CodeSpanExit' }
     | { _tag: 'CodeFenceEnter', language: string, output: string }
-    | { _tag: 'CodeFenceExit', output: string }
 
 type TagHandlerResult = string | GfmAction | undefined | void
 

--- a/packages/js/src/utils.ts
+++ b/packages/js/src/utils.ts
@@ -190,7 +190,8 @@ export function fenceLanguage(attributes: Record<string, string> | undefined): s
     return ''
   for (let index = 0; index < lang.length; index++) {
     const code = lang.charCodeAt(index)
-    if (code === 45 || isUnsafeFenceInfoCode(code))
+    // `-` and ` ` mark a human language; tab and the rest are unsafe outright.
+    if (code === 45 || code === 32 || isUnsafeFenceInfoCode(code))
       return ''
   }
   return lang
@@ -281,13 +282,20 @@ export function listMarkerLineStart(buffer: string[], fragmentIndex: number, mar
   }
 }
 
-// The rendered number of an ordered list item, honouring `<ol start>`.
+// Largest `<ol start>` CommonMark can express: an ordered marker is at most nine
+// digits, so anything wider stops being a list marker at all.
+const MAX_ORDERED_START = 999_999_999
+
+// The rendered number of an ordered list item, honouring `<ol start>`. A `start`
+// too wide for an ordered marker is not one, so it falls back to the default
+// numbering, and the running number stops at the same width.
 export function orderedItemNumber(list: ElementNode | null | undefined, index: number): number {
   const raw = list?.attributes?.start
   if (raw === undefined)
     return index + 1
   const start = Number.parseInt(raw, 10)
-  return (Number.isNaN(start) ? 1 : start) + index
+  const valid = start >= 0 && start <= MAX_ORDERED_START
+  return Math.min((valid ? start : 1) + index, MAX_ORDERED_START)
 }
 
 function numericReplacement(codePoint: number): string {

--- a/packages/js/src/utils.ts
+++ b/packages/js/src/utils.ts
@@ -1,5 +1,5 @@
 import type { ElementNode, Node } from './types'
-import { NEWLINE_CHAR, SPACE_CHAR, TAG_BLOCKQUOTE, TAG_LI } from './const'
+import { NEWLINE_CHAR, SPACE_CHAR, TAG_BLOCKQUOTE, TAG_H1, TAG_H6, TAG_LI, TAG_TD, TAG_TH } from './const'
 import {
   HTML_ENTITIES,
   MAX_ENTITY_NAME_LENGTH,
@@ -8,6 +8,19 @@ import {
 
 function lowerAscii(code: number): number {
   return code >= 65 && code <= 90 ? code + 32 : code
+}
+
+export function isInsideHeading(depthMap: Uint16Array): boolean {
+  for (let tagId = TAG_H1; tagId <= TAG_H6; tagId++) {
+    if (depthMap[tagId])
+      return true
+  }
+  return false
+}
+
+export function isInsideTableCell(state: { depthMap?: Uint16Array }): boolean {
+  const depthMap = state.depthMap!
+  return depthMap[TAG_TD]! > 0 || depthMap[TAG_TH]! > 0
 }
 
 /**
@@ -317,7 +330,7 @@ function numericReplacement(codePoint: number): string {
   return String.fromCodePoint(codePoint)
 }
 
-function isCharacterReferenceTail(text: string, start: number): boolean {
+export function isCharacterReferenceTail(text: string, start: number): boolean {
   let index = start
   if (text.charCodeAt(index) === 35) { // #
     index++

--- a/packages/js/src/utils.ts
+++ b/packages/js/src/utils.ts
@@ -1,5 +1,5 @@
 import type { ElementNode, Node } from './types'
-import { TAG_BLOCKQUOTE, TAG_LI } from './const'
+import { NEWLINE_CHAR, SPACE_CHAR, TAG_BLOCKQUOTE, TAG_LI } from './const'
 import {
   HTML_ENTITIES,
   MAX_ENTITY_NAME_LENGTH,
@@ -175,6 +175,119 @@ export function getLanguageFromClass(className: string | undefined): string {
   }
 
   return ''
+}
+
+// Fence info string for a <pre>/<code>: `class="language-x"` first, then
+// `lang="x"`, the form cmark-gfm itself emits. A `lang` carrying a subtag
+// (`en-US`) or spaces is a human language, never an info string.
+export function fenceLanguage(attributes: Record<string, string> | undefined): string {
+  const fromClass = getLanguageFromClass(attributes?.class)
+  if (fromClass)
+    return fromClass
+
+  const lang = attributes?.lang
+  if (!lang)
+    return ''
+  for (let index = 0; index < lang.length; index++) {
+    const code = lang.charCodeAt(index)
+    if (code === 45 || isUnsafeFenceInfoCode(code))
+      return ''
+  }
+  return lang
+}
+
+/**
+ * Code unit last written to the buffer, or -1 when nothing has been. Handlers
+ * legitimately return `''`, so the last *fragment* is not always the last
+ * character.
+ */
+function lastOutputChar(buffer: readonly string[]): number {
+  for (let index = buffer.length - 1; index >= 0; index--) {
+    const fragment = buffer[index]!
+    if (fragment.length > 0)
+      return fragment.charCodeAt(fragment.length - 1)
+  }
+  return -1
+}
+
+/**
+ * Separation a block needs to open at the content column `prefix` describes, or
+ * `undefined` when the buffer already sits there.
+ */
+export function blockOpenPrefix(
+  buffer: readonly string[],
+  prefix: string | undefined,
+): string | undefined {
+  switch (lastOutputChar(buffer)) {
+    // Empty output, or a pending list marker already at the content column.
+    case -1:
+    case SPACE_CHAR:
+      return undefined
+    case NEWLINE_CHAR:
+      return prefix || undefined
+    // Directly under text the block reads as a setext underline or a lazy
+    // continuation, so it has to break the paragraph first.
+    default:
+      return `\n\n${prefix ?? ''}`
+  }
+}
+
+/** Whether the buffer sits at the start of a fresh line. */
+export function endsOutputLine(buffer: readonly string[]): boolean {
+  return lastOutputChar(buffer) === NEWLINE_CHAR
+}
+
+// The last character of a list marker: `-`/`*`/`+`, or the `.`/`)` closing an
+// ordered one. Rejects ordinary prose before the backward walk starts.
+export function isListMarkerTail(code: number): boolean {
+  return code === 45 || code === 42 || code === 43 || code === 46 || code === 41
+}
+
+/**
+ * Whether the list marker ending at `fragmentIndex`/`markerIndex` is all its
+ * line holds: optional indent, `-`/`*`/`+` or `N.`/`N)`, and nothing else.
+ */
+export function listMarkerLineStart(buffer: string[], fragmentIndex: number, markerIndex: number): boolean {
+  const marker = buffer[fragmentIndex]!.charCodeAt(markerIndex)
+  const ordered = marker === 46 || marker === 41 // . )
+  if (!ordered && marker !== 45 && marker !== 42 && marker !== 43) // - * +
+    return false
+
+  let digits = 0
+  let spaces = 0
+  let fragment = fragmentIndex
+  let cursor = markerIndex
+  for (;;) {
+    if (cursor === 0) {
+      if (--fragment < 0)
+        return !ordered || digits > 0
+      cursor = buffer[fragment]!.length
+      continue
+    }
+    const code = buffer[fragment]!.charCodeAt(--cursor)
+    if (ordered && spaces === 0 && code >= 48 && code <= 57) {
+      if (++digits > 9)
+        return false
+      continue
+    }
+    if (ordered && digits === 0)
+      return false
+    if (code === 32) {
+      if (++spaces > 3)
+        return false
+      continue
+    }
+    return code === 10
+  }
+}
+
+// The rendered number of an ordered list item, honouring `<ol start>`.
+export function orderedItemNumber(list: ElementNode | null | undefined, index: number): number {
+  const raw = list?.attributes?.start
+  if (raw === undefined)
+    return index + 1
+  const start = Number.parseInt(raw, 10)
+  return (Number.isNaN(start) ? 1 : start) + index
 }
 
 function numericReplacement(codePoint: number): string {

--- a/packages/js/src/utils.ts
+++ b/packages/js/src/utils.ts
@@ -186,15 +186,16 @@ export function fenceLanguage(attributes: Record<string, string> | undefined): s
     return fromClass
 
   const lang = attributes?.lang
-  if (!lang)
-    return ''
-  for (let index = 0; index < lang.length; index++) {
-    const code = lang.charCodeAt(index)
-    // `-` and ` ` mark a human language; tab and the rest are unsafe outright.
-    if (code === 45 || code === 32 || isUnsafeFenceInfoCode(code))
-      return ''
-  }
-  return lang
+  // eslint-disable-next-line no-control-regex
+  return lang && !/[-\x00-\x20\x7F"'&<>`~]/.test(lang) ? lang : ''
+}
+
+// Strict unsigned integer parsing shared by numeric HTML attributes. Partial
+// reads such as `2x` must not disagree with Rust's full-string parse.
+export function parseUnsignedInteger(raw: string | undefined): number | undefined {
+  return raw !== undefined && /^[\t\n\f\r ]*\+?\d+[\t\n\f\r ]*$/.test(raw)
+    ? Number(raw)
+    : undefined
 }
 
 /**
@@ -253,17 +254,6 @@ export function blockOpenPrefix(
   }
 }
 
-/** Whether the buffer sits at the start of a fresh line. */
-export function endsOutputLine(buffer: readonly string[]): boolean {
-  return lastOutputChar(buffer) === NEWLINE_CHAR
-}
-
-// The last character of a list marker: `-`/`*`/`+`, or the `.`/`)` closing an
-// ordered one. Rejects ordinary prose before the backward walk starts.
-export function isListMarkerTail(code: number): boolean {
-  return code === 45 || code === 42 || code === 43 || code === 46 || code === 41
-}
-
 /**
  * Whether the list marker ending at `fragmentIndex`/`markerIndex` is all its
  * line holds: optional indent, `-`/`*`/`+` or `N.`/`N)`, and nothing else.
@@ -306,27 +296,6 @@ export function listMarkerLineStart(buffer: readonly string[], fragmentIndex: nu
 // digits, so anything wider stops being a list marker at all.
 const MAX_ORDERED_START = 999_999_999
 
-// `start`'s shape, matching Rust's `str::parse::<u32>()`: optional leading `+`,
-// digits only, no partial parse — `Number.parseInt` would read "10foo" as 10.
-function parseOrderedStart(raw: string): number | undefined {
-  let begin = 0
-  let end = raw.length
-  while (begin < end && isHtmlAsciiWhitespace(raw.charCodeAt(begin)))
-    begin++
-  while (end > begin && isHtmlAsciiWhitespace(raw.charCodeAt(end - 1)))
-    end--
-  if (begin < end && raw.charCodeAt(begin) === 43) // '+'
-    begin++
-  if (begin === end)
-    return undefined
-  for (let index = begin; index < end; index++) {
-    const code = raw.charCodeAt(index)
-    if (code < 48 || code > 57)
-      return undefined
-  }
-  return Number.parseInt(raw.slice(begin, end), 10)
-}
-
 // The rendered number of an ordered list item, honoring `<ol start>`. A `start`
 // too wide for an ordered marker is not one, so it falls back to the default
 // numbering, and the running number stops at the same width.
@@ -334,7 +303,7 @@ export function orderedItemNumber(list: ElementNode | null | undefined, index: n
   const raw = list?.attributes?.start
   if (raw === undefined)
     return index + 1
-  const start = parseOrderedStart(raw)
+  const start = parseUnsignedInteger(raw)
   if (start === undefined || start > MAX_ORDERED_START)
     return Math.min(1 + index, MAX_ORDERED_START)
   return Math.min(start + index, MAX_ORDERED_START)

--- a/packages/js/src/utils.ts
+++ b/packages/js/src/utils.ts
@@ -220,10 +220,30 @@ export function blockOpenPrefix(
   prefix: string | undefined,
 ): string | undefined {
   switch (lastOutputChar(buffer)) {
-    // Empty output, or a pending list marker already at the content column.
+    // Empty output.
     case -1:
-    case SPACE_CHAR:
       return undefined
+    case SPACE_CHAR: {
+      // A trailing space can be a pending list marker already at the content
+      // column, or ordinary text (`"item "`) that still has to break as a
+      // paragraph. Only the former needs no separator.
+      let fragment = buffer.length - 1
+      let index = buffer[fragment]!.length
+      for (;;) {
+        if (index === 0) {
+          if (--fragment < 0)
+            return undefined
+          index = buffer[fragment]!.length
+          continue
+        }
+        const code = buffer[fragment]!.charCodeAt(--index)
+        if (code !== SPACE_CHAR) {
+          return code === NEWLINE_CHAR || listMarkerLineStart(buffer, fragment, index)
+            ? undefined
+            : `\n\n${prefix ?? ''}`
+        }
+      }
+    }
     case NEWLINE_CHAR:
       return prefix || undefined
     // Directly under text the block reads as a setext underline or a lazy
@@ -248,7 +268,7 @@ export function isListMarkerTail(code: number): boolean {
  * Whether the list marker ending at `fragmentIndex`/`markerIndex` is all its
  * line holds: optional indent, `-`/`*`/`+` or `N.`/`N)`, and nothing else.
  */
-export function listMarkerLineStart(buffer: string[], fragmentIndex: number, markerIndex: number): boolean {
+export function listMarkerLineStart(buffer: readonly string[], fragmentIndex: number, markerIndex: number): boolean {
   const marker = buffer[fragmentIndex]!.charCodeAt(markerIndex)
   const ordered = marker === 46 || marker === 41 // . )
   if (!ordered && marker !== 45 && marker !== 42 && marker !== 43) // - * +
@@ -286,16 +306,38 @@ export function listMarkerLineStart(buffer: string[], fragmentIndex: number, mar
 // digits, so anything wider stops being a list marker at all.
 const MAX_ORDERED_START = 999_999_999
 
-// The rendered number of an ordered list item, honouring `<ol start>`. A `start`
+// `start`'s shape, matching Rust's `str::parse::<u32>()`: optional leading `+`,
+// digits only, no partial parse — `Number.parseInt` would read "10foo" as 10.
+function parseOrderedStart(raw: string): number | undefined {
+  let begin = 0
+  let end = raw.length
+  while (begin < end && isHtmlAsciiWhitespace(raw.charCodeAt(begin)))
+    begin++
+  while (end > begin && isHtmlAsciiWhitespace(raw.charCodeAt(end - 1)))
+    end--
+  if (begin < end && raw.charCodeAt(begin) === 43) // '+'
+    begin++
+  if (begin === end)
+    return undefined
+  for (let index = begin; index < end; index++) {
+    const code = raw.charCodeAt(index)
+    if (code < 48 || code > 57)
+      return undefined
+  }
+  return Number.parseInt(raw.slice(begin, end), 10)
+}
+
+// The rendered number of an ordered list item, honoring `<ol start>`. A `start`
 // too wide for an ordered marker is not one, so it falls back to the default
 // numbering, and the running number stops at the same width.
 export function orderedItemNumber(list: ElementNode | null | undefined, index: number): number {
   const raw = list?.attributes?.start
   if (raw === undefined)
     return index + 1
-  const start = Number.parseInt(raw, 10)
-  const valid = start >= 0 && start <= MAX_ORDERED_START
-  return Math.min((valid ? start : 1) + index, MAX_ORDERED_START)
+  const start = parseOrderedStart(raw)
+  if (start === undefined || start > MAX_ORDERED_START)
+    return Math.min(1 + index, MAX_ORDERED_START)
+  return Math.min(start + index, MAX_ORDERED_START)
 }
 
 function numericReplacement(codePoint: number): string {

--- a/packages/js/src/utils.ts
+++ b/packages/js/src/utils.ts
@@ -190,19 +190,6 @@ export function getLanguageFromClass(className: string | undefined): string {
   return ''
 }
 
-// Fence info string for a <pre>/<code>: `class="language-x"` first, then
-// `lang="x"`, the form cmark-gfm itself emits. A `lang` carrying a subtag
-// (`en-US`) or spaces is a human language, never an info string.
-export function fenceLanguage(attributes: Record<string, string> | undefined): string {
-  const fromClass = getLanguageFromClass(attributes?.class)
-  if (fromClass)
-    return fromClass
-
-  const lang = attributes?.lang
-  // eslint-disable-next-line no-control-regex
-  return lang && !/[-\x00-\x20\x7F"'&<>`~]/.test(lang) ? lang : ''
-}
-
 // Strict unsigned integer parsing shared by numeric HTML attributes. Partial
 // reads such as `2x` must not disagree with Rust's full-string parse.
 export function parseUnsignedInteger(raw: string | undefined): number | undefined {

--- a/packages/js/test/unit/gfm-text-escaping.test.ts
+++ b/packages/js/test/unit/gfm-text-escaping.test.ts
@@ -39,7 +39,7 @@ describe('gfm text escaping', () => {
 
   it('only escapes syntax where plain text could activate it', () => {
     expect(htmlToMarkdown('<h2># Heading #</h2><p>#hashtag</p><p>Just a - dash</p>'))
-      .toBe('## # Heading #\n\n#hashtag\n\nJust a - dash')
+      .toBe('## # Heading \\#\n\n#hashtag\n\nJust a - dash')
   })
 
   it('escapes syntax introduced by entity decoding', () => {

--- a/packages/js/test/unit/gfm-text-escaping.test.ts
+++ b/packages/js/test/unit/gfm-text-escaping.test.ts
@@ -108,6 +108,11 @@ describe('gfm text escaping', () => {
       .toBe('| a\\|b |\n| --- |')
   })
 
+  it('rejects a partially numeric colspan', () => {
+    expect(htmlToMarkdown('<table><tr><th colspan="2x">h</th></tr><tr><td>a</td><td>b</td></tr></table>'))
+      .toBe('| h |\n| --- |\n| a b |')
+  })
+
   it('serializes decoded text for its output context', () => {
     expect(htmlToMarkdown('<a href="/safe">x&#93;(/evil) [y</a>'))
       .toBe('[x\\](/evil) \\[y](/safe)')

--- a/packages/js/test/unit/gfm-text-escaping.test.ts
+++ b/packages/js/test/unit/gfm-text-escaping.test.ts
@@ -108,8 +108,10 @@ describe('gfm text escaping', () => {
       .toBe('| a\\|b |\n| --- |')
   })
 
-  it('rejects a partially numeric colspan', () => {
+  it('rejects malformed or out-of-range colspan', () => {
     expect(htmlToMarkdown('<table><tr><th colspan="2x">h</th></tr><tr><td>a</td><td>b</td></tr></table>'))
+      .toBe('| h |\n| --- |\n| a b |')
+    expect(htmlToMarkdown('<table><tr><th colspan="300">h</th></tr><tr><td>a</td><td>b</td></tr></table>'))
       .toBe('| h |\n| --- |\n| a b |')
   })
 

--- a/packages/js/test/unit/streaming-parity.test.ts
+++ b/packages/js/test/unit/streaming-parity.test.ts
@@ -111,6 +111,8 @@ describe('streaming parity with the Rust core', () => {
     '<dl><dt>MPN:</dt><dd>D100</dd><dt>Availability:</dt><dd>Ships</dd></dl>',
     '<details><summary>Title</summary><p>Body</p></details>',
     '<address><p>One</p><p>Two</p></address>',
+    '<details><p>a</p>\n\n<p>b</p></details><dl><dd>~tilde~</dd></dl>',
+    '<details><p>a</p>\n\n<p>b</p></details><dl>a<span>b</span>~tilde~</dl>',
   ])('keeps raw HTML block closes stable for %s', async (html) => {
     await expectStreamingParity(html)
   })

--- a/packages/mdream/test/unit/fixture-parity.test.ts
+++ b/packages/mdream/test/unit/fixture-parity.test.ts
@@ -591,6 +591,46 @@ describe('cross-engine parity', () => {
     }
   })
 
+  it('gfm block-structure escaping produces identical output', async () => {
+    const [jsEngine, rustEngine] = await Promise.all([
+      resolveEngine(engines[0].engine),
+      resolveEngine(engines[1].engine),
+    ])
+    const cases = [
+      '<details><p>a</p>\n\n<p>b_c</p></details>',
+      '<table><tr><td><p>a<td>b</tr><tr><td>c</td></tr></table>',
+      '<table><tr><th>h1</th><th colspan="2">h2</th></tr><tr><td>a</td><td>b</td><td>c</td></tr></table>',
+      '<ul><li># h</li><li>- x</li><li>1. y</li></ul>',
+      '<ul><li>x<table><tr><th>h</th></tr><tr><td>c</td></tr></table></li></ul>',
+      '<table><tr><th>h</th></tr><tr><td><code>a|b</code></td></tr></table>',
+      '<h2># Heading #</h2>',
+      '<table><tr><th>h</th></tr><tr><td><h3>Ends with #</h3></td></tr></table>',
+      '<table><tr><th>h</th></tr><tr><td><h3>H</h3></td></tr></table>',
+      '<pre><b>a</b> <i>c</i></pre>',
+      '<ul><li>a<hr></li></ul>',
+      '<ul><li><hr></li><li>b</li></ul>',
+      '<ul><li><p>a</p><hr><p>b</p></li></ul>',
+      '<ul><li>a<ul><li></li></ul></li></ul>',
+      '<p>a</p><ul><li></li><li>b</li></ul>',
+      '<ul><li>a</li><li></li><li>b</li></ul>',
+      '<ul><li>a<ul><li><pre><code>x</code></pre></li></ul></li></ul>',
+      '<ol start="9"><li>Nine</li><li>Ten</li></ol>',
+      '<pre lang="rust">fn main(){}</pre>',
+      '<ul><li><pre><code>a\nb</code></pre></li></ul>',
+      '<ul><li>text<pre><code>x</code></pre></li></ul>',
+      '<dl><dt>BASH_VERSINFO</dt><dd>x</dd>\n\n<dt>A_B</dt><dd>y</dd></dl>',
+      '<pre><code>a</code> [-o option]</pre>',
+      '<ul><li><pre>code</pre><p>after</p></li></ul>',
+      '<table><caption>Cap</caption><tr><th>h</th></tr><tr><td>c</td></tr></table>',
+      '<ul><li><p>Intro:</p><table><caption>Cap</caption><tr><th>h</th></tr><tr><td>c</td></tr></table></li></ul>',
+    ]
+    for (const html of cases) {
+      const jsResult = jsEngine.htmlToMarkdown(html).trimEnd()
+      const rustResult = rustEngine.htmlToMarkdown(html).trimEnd()
+      expect(rustResult, `GFM mismatch for: ${html}`).toBe(jsResult)
+    }
+  })
+
   it('text entity decoding in content produces identical output', async () => {
     const [jsEngine, rustEngine] = await Promise.all([
       resolveEngine(engines[0].engine),

--- a/packages/mdream/test/unit/fixture-parity.test.ts
+++ b/packages/mdream/test/unit/fixture-parity.test.ts
@@ -637,8 +637,18 @@ describe('cross-engine parity', () => {
       '<ol start="-5"><li>a</li></ol>',
       '<ol start="1000000000"><li>a</li></ol>',
       '<ol start="999999998"><li>a</li><li>b</li><li>c</li></ol>',
+      // A `start` with trailing garbage is not a number at all — full-string
+      // parse like Rust's, not `parseInt`'s partial read.
+      '<ol start="10foo"><li>a</li></ol>',
+      '<ol start="0x10"><li>a</li></ol>',
+      '<ol start="+5"><li>a</li></ol>',
       // A space ends the fence info string, so the rest would leak onto the fence.
       '<pre lang="en US">x</pre>',
+      // Text's own trailing space is not a pending list marker at the content
+      // column; it still needs a paragraph break before the next block.
+      '<ul><li>text <hr></li></ul>',
+      '<ul><li>text <hr>after</li></ul>',
+      '<ul><li><blockquote>text <hr></blockquote></li></ul>',
     ]
     for (const html of cases) {
       const jsResult = jsEngine.htmlToMarkdown(html).trimEnd()

--- a/packages/mdream/test/unit/fixture-parity.test.ts
+++ b/packages/mdream/test/unit/fixture-parity.test.ts
@@ -601,6 +601,7 @@ describe('cross-engine parity', () => {
       '<table><tr><td><p>a<td>b</tr><tr><td>c</td></tr></table>',
       '<table><tr><th>h1</th><th colspan="2">h2</th></tr><tr><td>a</td><td>b</td><td>c</td></tr></table>',
       '<table><tr><th colspan="2x">h</th></tr><tr><td>a</td><td>b</td></tr></table>',
+      '<table><tr><th colspan="300">h</th></tr><tr><td>a</td><td>b</td></tr></table>',
       '<ul><li># h</li><li>- x</li><li>1. y</li></ul>',
       '<ul><li>x<table><tr><th>h</th></tr><tr><td>c</td></tr></table></li></ul>',
       '<table><tr><th>h</th></tr><tr><td><code>a|b</code></td></tr></table>',

--- a/packages/mdream/test/unit/fixture-parity.test.ts
+++ b/packages/mdream/test/unit/fixture-parity.test.ts
@@ -623,6 +623,22 @@ describe('cross-engine parity', () => {
       '<ul><li><pre>code</pre><p>after</p></li></ul>',
       '<table><caption>Cap</caption><tr><th>h</th></tr><tr><td>c</td></tr></table>',
       '<ul><li><p>Intro:</p><table><caption>Cap</caption><tr><th>h</th></tr><tr><td>c</td></tr></table></li></ul>',
+      // A raw block's own opening tag writes the blank line that ends it, so the
+      // text after it is Markdown and needs escaping even with no `<summary>`.
+      '<details><p>* one</p></details>',
+      '<details><p># one</p></details>',
+      // An implied `<tr>` end has to close content left open in the cell.
+      '<table><tr><td>a<x-widget><tr><td>b</table>',
+      '<table><tr><td>a<span>y<tr><td>b</table>',
+      '<table><thead><tr><th>V<th>C<tbody><tr><td>a<td><p>x<tr><td>b<td><p>y</table>',
+      '<table><tr><td><table><tr><td>inner<tr><td>b</table><tr><td>outer</table>',
+      // A `start` too wide for an ordered marker is not one.
+      '<ol start="0"><li>a</li><li>b</li></ol>',
+      '<ol start="-5"><li>a</li></ol>',
+      '<ol start="1000000000"><li>a</li></ol>',
+      '<ol start="999999998"><li>a</li><li>b</li><li>c</li></ol>',
+      // A space ends the fence info string, so the rest would leak onto the fence.
+      '<pre lang="en US">x</pre>',
     ]
     for (const html of cases) {
       const jsResult = jsEngine.htmlToMarkdown(html).trimEnd()

--- a/packages/mdream/test/unit/fixture-parity.test.ts
+++ b/packages/mdream/test/unit/fixture-parity.test.ts
@@ -600,6 +600,7 @@ describe('cross-engine parity', () => {
       '<details><p>a</p>\n\n<p>b_c</p></details>',
       '<table><tr><td><p>a<td>b</tr><tr><td>c</td></tr></table>',
       '<table><tr><th>h1</th><th colspan="2">h2</th></tr><tr><td>a</td><td>b</td><td>c</td></tr></table>',
+      '<table><tr><th colspan="2x">h</th></tr><tr><td>a</td><td>b</td></tr></table>',
       '<ul><li># h</li><li>- x</li><li>1. y</li></ul>',
       '<ul><li>x<table><tr><th>h</th></tr><tr><td>c</td></tr></table></li></ul>',
       '<table><tr><th>h</th></tr><tr><td><code>a|b</code></td></tr></table>',

--- a/packages/mdream/test/unit/nodes/html-to-markdown-parity.test.ts
+++ b/packages/mdream/test/unit/nodes/html-to-markdown-parity.test.ts
@@ -88,7 +88,7 @@ describe.each(engines)('html-to-markdown parity $name', (engineConfig) => {
       <li>Nested</li>
     </ul>
   </li>
-</ol>`, { engine })).toBe('1. Nine\n2. Ten\n3. Eleven\n   - Nested')
+</ol>`, { engine })).toBe('9. Nine\n10. Ten\n11. Eleven\n    - Nested')
   })
   it('blockquote: Blockquotes can include other elements, with seamless support for nested quotes.', async () => {
     const engine = await resolveEngine(engineConfig.engine)
@@ -148,7 +148,9 @@ describe.each(engines)('html-to-markdown parity $name', (engineConfig) => {
   })
   it('smart Escaping: Escapes special characters only when necessary, to avoid accidental Markdown rendering.', async () => {
     const engine = await resolveEngine(engineConfig.engine)
-    expect(htmlToMarkdown(`<h2># Heading #</h2>`, { engine })).toBe('## # Heading #')
+    // The trailing `#` is escaped: unescaped it is an ATX closing sequence and
+    // the heading renders as `# Heading`.
+    expect(htmlToMarkdown(`<h2># Heading #</h2>`, { engine })).toBe('## # Heading \\#')
     expect(htmlToMarkdown(`<p># Heading</p>`, { engine })).toBe('\\# Heading')
     expect(htmlToMarkdown(`<p>#hashtag</p>`, { engine })).toBe('#hashtag')
     expect(htmlToMarkdown(`<p>- List Item</p>`, { engine })).toBe('\\- List Item')

--- a/packages/mdream/test/unit/nodes/table.test.ts
+++ b/packages/mdream/test/unit/nodes/table.test.ts
@@ -155,9 +155,11 @@ describe.each(engines)('tables $name', (engineConfig) => {
       </table>
     `
     const markdown = htmlToMarkdown(html, { engine })
+    // The spanned header contributes an empty trailing cell so the delimiter
+    // row is as wide as the body; a narrower delimiter drops the third column.
     expect(markdown).toBe(
-      '| Header 1 | Header 2-3 |\n'
-      + '| --- | --- |\n'
+      '| Header 1 | Header 2-3 | |\n'
+      + '| --- | --- | --- |\n'
       + '| Value 1 | Value 2 | Value 3 |',
     )
   })


### PR DESCRIPTION
I rendered mdream's output for a 2531-page corpus back through `cmark-gfm` and compared the constructs it built against the constructs mdream meant to emit. This fixes the 21 distinct defects that sweep surfaced.

Each repro below is `html -> markdown`, then what `cmark-gfm` builds from that markdown. All of them are in the test suite.

I also re-rendered every repro through `marked` and `remark-gfm`. All three renderers agree on all 37 cases: the same 29 change, the same 8 are deliberately left alone, and none of the fixes is specific to cmark's reading. The only cross-renderer differences are serialization policy — cmark writes the info string as `<pre lang="rust">` where the others write `<code class="language-rust">`, and marked drops the space after a hard break — neither of which changes block structure.

## Escaping

**A raw-HTML region stops being raw at the first blank line.** CommonMark ends an HTML block there and reads what follows as Markdown, so text past one needs escaping. mdream escaped nothing inside `<details>`, `<dl>` and friends:

```
<details><summary>S</summary><p>* text</p></details>

before  …\n\n* text\n\n</details>      cmark: <ul><li>text</li></ul>
after   …\n\n\* text\n\n</details>     cmark: <p>* text</p>
```

A line that *opens* a fresh HTML block suspends Markdown again, so text on that line must stay unescaped — that is why `<dl><dt><code>A_B</code></dt>` keeps its underscore instead of emitting `A\_B`.

The blank-line state lives on `ConvertState` and the scan resumes where the last one stopped, so a region costs one pass however many text nodes it holds. The line scan runs last in the escape condition, so only text that would be escaped anyway pays for it.

**A list marker's content column opens a fresh block context**, exactly like a line start, so block markers there need the same escaping:

```
<ul><li># text</li></ul>

before  - # text        cmark: <ul><li><h1>text</h1></li></ul>
after   - \# text       cmark: <ul><li># text</li></ul>
```

`markdown_line_indent` already located the escape position for a line start; it now also accepts a line holding nothing but a list marker, so `- # h` escapes exactly as `# h` would.

**A heading's trailing `#` run is an ATX closing sequence.** GFM drops it *and the text it was attached to*:

```
<h2>Ends with #</h2>

before  ## Ends with #        cmark: <h2>Ends with</h2>      <- text lost
after   ## Ends with \#       cmark: <h2>Ends with #</h2>
```

Only a run preceded by whitespace closes a heading, so `<h2>C#</h2>` is left alone. A heading rendered as raw `<hN>` in a table cell, or stripped of its markup in plain-text mode, writes no ATX prefix and so has no closing sequence to protect — those keep the `#` unescaped.

## Tables

**`colspan` has no GFM equivalent.** The delimiter row fixes the column count and cells past it are discarded, so a spanned cell has to occupy its whole width:

```
<table><tr><td colspan="2">wide</td></tr><tr><td>a</td><td>b</td></tr></table>

before  | wide |\n| --- |\n| a | b |           cmark: <tr><td>a</td></tr>            <- b dropped
after   | wide | |\n| --- | --- |\n| a | b |   cmark: <tr><td>a</td><td>b</td></tr>
```

Filler cells allocate only when `colspan > 1`; the span remains capped at 64.

**A ragged row is wider than the header promised.** GFM would drop the tail, so it folds into the last cell instead:

```
<table><tr><th>h</th><th>i</th></tr><tr><td>a</td><td>b</td><td>c</td></tr></table>

before  | a | b | c |     cmark: <td>a</td><td>b</td>        <- c dropped
after   | a | b c |       cmark: <td>a</td><td>b c</td>
```

**Content left open in a cell trapped the next row.** `<td><p>x` with no `</p>` left the paragraph on the stack, so `<tr>` could not close the row:

```
<table><thead><tr><th>V<th>C<tbody><tr><td>a<td><p>x<tr><td>b<td><p>y</table>

before  | a | x<tr>b | y</tr> |     cmark: one row, with the literal tag inside the cell
after   | a | x |\n| b | y |        cmark: two rows
```

`close_table_context` now walks past content left open inside the cell to reach the row, in one reverse pass over the stack rather than re-deciding after each close.

**A pipe splits a row even inside a code span.** `\|` is GFM's escape and is honoured there:

```
<table><tr><th>h</th></tr><tr><td><code>a|b</code></td></tr></table>

before  | `a|b` |      cmark: <td>`a</td>               <- row split, span broken
after   | `a\|b` |     cmark: <td><code>a|b</code></td>
```

Outside a table the pipe is ordinary content, so `<p><code>a|b</code></p>` is untouched.

**A heading in a cell needs its own line, which a GFM row cannot give it**, so it stays in the row as raw HTML:

```
<table><tr><th>h</th></tr><tr><td><h3>H</h3></td></tr></table>

before  | ### H\n\n |       cmark: <td>### H</td>, plus a stray <p>|</p>
after   | <h3>H</h3> |      cmark: <td><h3>H</h3></td>
```

**A table inside a list item needs the item's content column.** At column 0 its rows are lazy continuation text:

```
<ul><li><p>intro</p><table><tr><th>h</th></tr><tr><td>c</td></tr></table></li></ul>

before  - intro | h |\n| --- | | c |
        cmark: <li>intro | h | | --- | | c |</li>
after   - intro\n\n  | h |\n  | --- |\n  | c |
        cmark: <li><p>intro</p><table>…</table></li>
```

`<caption>` had the same problem and no handler of its own: glued to preceding text it swallowed the header row, and at column 0 it took the table out of the item.

## Lists, rules and fences

**A rule or a lone marker directly under text is a setext underline.** The `-` run promotes the text above to a heading and the construct itself disappears:

```
<ul><li>a<hr></li></ul>

before  - a ---            cmark: <li>a ---</li>
after   - a\n\n  ---       cmark: <li><p>a</p><hr /></li>
```

```
<ul><li>a<ul><li></li></ul></li></ul>

before  - a\n  -           cmark: <li><h2>a</h2></li>       <- nested item gone
after   - a\n\n  -         cmark: <li><p>a</p><ul><li></li></ul></li>
```

The marker case only arises for a list's first item, since any later sibling's marker already opens its own block. The guard is armed on `<li>` enter and resolved on exit, and the streaming drain holds the two bytes before the marker line so a chunk boundary reads the same line one-shot does.

**`- ---` is dashes and spaces only, so the whole line is a thematic break** and the item is lost with it. A rule sharing the marker's line is written with `*`, which cannot collide:

```
<ul><li><hr></li><li>b</li></ul>

before  - ---\n- b         cmark: <hr /><ul><li>b</li></ul>      <- first item gone
after   - ***\n- b         cmark: <li><hr /></li><li>b</li>
```

**A blank line between a marker and a fence ends the item.** CommonMark allows an item to begin with at most one blank line, so the code block became a sibling of the list:

```
<ul><li><pre><code>a\nb</code></pre></li></ul>

before  - \n\n  ```\n  a\n  b\n  ```
        cmark: <ul><li></li></ul><pre><code>a b</code></pre>
after   - ```\n  a\n  b\n  ```
        cmark: <li><pre><code>a b</code></pre></li>
```

Both fence-emitting paths now ask the same helper for their separator, so a pending marker takes none while content already on the line still gets its own block.

**`<ol start>` was ignored**, for the marker and for the content column it implies:

```
<ol start="9"><li><p>a</p><p>b</p></li></ol>

before  1. a\n\n   b       cmark: <ol><li>…                 <- renumbered from 1
after   9. a\n\n   b       cmark: <ol start="9"><li>…
```

**`</pre>` owns the closing fence.** The `</code>` exit was emitting it, so a trailing sibling landed on the fence line as an opener that never closes:

```
<pre><code>compopt</code> [-o option]</pre><p>after</p>

before  ```\ncompopt\n``` [-o option]\n\nafter
        cmark: <pre><code>compopt ``` [-o option]  after</code></pre>   <- swallows the rest
after   ```\ncompopt [-o option]\n```\n\nafter
        cmark: <pre><code>compopt [-o option]</code></pre><p>after</p>
```

Several `<code>` children now share the one fence the `<pre>` closes instead of each opening its own.

**Inline markup inside `<pre>` renders literally**, so those elements contribute their text only:

```
<pre>a <em>b</em> <strong>c</strong>\n</pre>

before  ```\na *b* **c**\n\n```      cmark: <code>a *b* **c**</code>
after   ```\na b c\n\n```            cmark: <code>a b c</code>
```

`<code>` and `<br>` are excluded — both already have `<pre>`-aware handling. The delimiters were characters the source never contained: `<pre>a <a href="/x">l</a></pre>` used to put a literal `[l](/x)` into the code sample. Markdown code blocks cannot carry emphasis, so the choice is the styling or the block; this keeps the block, as pandoc does.

**`<pre lang>` is read for the info string** when no class carries one, the form cmark-gfm itself emits: `<pre lang="rust">` -> ` ```rust `. A `lang` holding a subtag or spaces (`en-US`) is a human language rather than an info string, and `class="language-…"` still wins.

## Corpus result

Re-running the sweep against the previous behaviour, `cmark-gfm` now builds **1172 more tables, 3607 more rows, 7541 more list items, 19115 more links and 2497 more images** from the same pages. On the ~85 pages where it builds fewer of something, the output matches what mdream intended exactly — those counts were the spurious headings and split items above.

## Take what you want from this

The fixes are independent of each other and each has its own test, so please drop or redo any of them without worrying about the rest. The ones that are judgement calls rather than forced:

- **A ragged row folds into the last cell** (`| a | b c |`). The text survives, the cell boundary does not. Widening the delimiter row instead is strictly better output and is what pandoc and node-html-markdown do, but both buffer the whole table first; mdream writes the delimiter row before it has seen the body. It is doable without a table model — track the running max width and patch the header and delimiter rows in the buffer, adding the table to the existing drain-hold list — but that holds every table in the buffer while it is open, which changes streaming's memory profile on table-heavy pages. Happy to do it as a follow-up with bench numbers. Across 152 tables in the repo's own fixtures, zero have a body row wider than the header once `colspan` is accounted for, so this path only fires on malformed input.
- **A rule sharing a marker's line becomes `- ***`.** Any thematic-break character works; `*` is picked only because it cannot collide with the `-` bullet. turndown has this same bug in mirror image, since it pairs `*` bullets with `* * *` rules.
- **Headings, rules and `<pre>` inside a table cell fall back to raw HTML.** node-html-markdown instead drops the markup and keeps the text; pandoc drops the entire table to HTML. Any of the three round-trips.
- **Inline markup inside `<pre>` contributes text only.** turndown and node-html-markdown make the opposite call — they do not treat a `<code>`-less `<pre>` as a code block at all, keeping the emphasis and losing the block.
- **`<pre lang>` for the info string is an enhancement, not a defect fix.** The old output was valid Markdown, just without the language. Easiest one to cut if you want this PR to be strictly regressions.

## Scope

- **Both engines are fixed**, pinned against each other by 27 new cases in `fixture-parity`.
- **Streaming agrees with one-shot.** Every buffer-indexed offset the new state holds is rebased by the drain, and the marker guard holds the drain while the construct is still open.
- `colspan` and `start` now use the normal filtered attribute path. Both engines parse their numeric values strictly, and plugins still receive the original strings through `ATTR_ALL`.
- The per-byte GFM hazard test becomes a `[u8; 256]` table, and `escape_gfm_text` skips runs of bytes that cannot start or end anything, which is most prose.

## Tests

`crates/core/tests/conversion.rs` gains a test per defect, each named for the rule it pins (`a_heading_keeps_a_trailing_hash`, `cells_past_the_delimiter_row_merge_instead_of_vanishing`, `a_fence_opening_a_list_item_shares_the_marker_line`, …), and `fixture-parity` gains the same inputs as cross-engine cases.

The before/after markdown in every repro above was generated by running each input through a worktree at `main` and through this branch, then reparsing both with `cmark-gfm`, `marked` and `remark-gfm`.

Local verification: `cargo test --release` (519 passed), `pnpm test` (1566 passed), `pnpm typecheck`, host and WASM clippy, `cargo fmt --check` on every file touched. CI green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved GFM table rendering with accurate `colspan`, wider delimiter/header behavior, and better handling of complex/nested layouts.
  * Enhanced ordered-list `start` handling and support for `lang` on code/pre fences.
  * Added an alternate thematic-break marker (`***`).

* **Bug Fixes**
  * Fixed escaping/parsing edge cases, including trailing ATX heading `#`, safer recovery around tables and raw HTML, and more robust streamed output around empty list items and `<pre>/<code>` fence interactions.
  * Prevented table/code-span formatting issues (notably `|`).

* **Tests**
  * Expanded streaming and cross-engine parity regression coverage for the above scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
