### PR TITLE
fix: preserve cmark list structure

### DIFF
--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -506,6 +506,8 @@ pub struct ConvertState {
   empty_item_hazard: bool,
   empty_item_line_start: usize,
   empty_item_len: usize,
+  /// A list item rule waiting to see whether visible content follows it.
+  list_rule_pending: bool,
   #[cfg(test)]
   gfm_escape_slow_path_calls: usize,
 }
@@ -626,6 +628,7 @@ impl ConvertState {
       empty_item_hazard: false,
       empty_item_line_start: 0,
       empty_item_len: 0,
+      list_rule_pending: false,
       #[cfg(test)]
       gfm_escape_slow_path_calls: 0,
     };

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -404,6 +404,10 @@ impl ConvertState {
       return;
     }
 
+    if self.list_rule_pending && !self.stack[stack_len - 1].excludes_text_nodes {
+      self.flush_list_rule();
+    }
+
     // Deferred <pre> code fence (issue #97): open a bare <pre>'s fence right
     // before its first non-whitespace child. A direct <code> child keeps
     // fence ownership; a deeper/other first child opens the <pre>'s own fence.
@@ -668,6 +672,9 @@ impl ConvertState {
     }
 
     let tag_id = node.tag_id;
+    if tag_id == Some(TAG_LI) {
+      self.list_rule_pending = false;
+    }
     let closes_own_pre_fence = tag_id == Some(TAG_PRE) && self.pre_fence_open;
 
     // Check override
@@ -762,6 +769,15 @@ impl ConvertState {
     } else {
       node.spacing
     };
+
+    if !has_override
+      && !self.plain_text
+      && tag_id == Some(TAG_HR)
+      && !self.in_table_cell()
+      && self.depth_map[TAG_LI as usize] > 0
+    {
+      self.list_rule_pending = true;
+    }
 
     if !self.plain_text && tag_id == Some(TAG_BLOCKQUOTE) && !self.blockquotes.is_empty() {
       self.finalize_blockquote();
@@ -1118,6 +1134,13 @@ impl ConvertState {
     let has_inline_gfm_hazard = std::mem::take(&mut self.text_buffer_has_inline_gfm_hazard);
     if text.is_empty() {
       return;
+    }
+
+    if self.list_rule_pending {
+      if text.as_bytes().iter().all(|&byte| is_whitespace(byte)) {
+        return;
+      }
+      self.flush_list_rule();
     }
 
     if self.pending_inline_whitespace {
@@ -1919,6 +1942,15 @@ impl ConvertState {
       }
     }
     p
+  }
+
+  fn flush_list_rule(&mut self) {
+    let prefix = self.continuation_prefix();
+    self.buffer.reserve(2 + prefix.len());
+    self.buffer.push_str("\n\n");
+    self.buffer.push_str(&prefix);
+    self.last_content_cache_len = 2 + prefix.len();
+    self.list_rule_pending = false;
   }
 
   /// Push `text` into the buffer, hard-wrapping on spaces so no output line
@@ -2804,8 +2836,9 @@ impl ConvertState {
       return NO_SPACING;
     }
     if self.collapse_span_depth > 0 {
-      let is_block =
-        tag_id.is_some_and(|id| (TAG_H1..=TAG_H6).contains(&id) || id == TAG_P || id == TAG_DIV);
+      let is_block = tag_id.is_some_and(|id| {
+        (TAG_H1..=TAG_H6).contains(&id) || matches!(id, TAG_P | TAG_DIV | TAG_LI)
+      });
       if !is_block {
         return NO_SPACING;
       }

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -52,6 +52,10 @@ fn plain_text_output_preserves_readable_separators() {
     ),
     "Line\nBreak\n\nName\tRole\nAda\tAdmin\n\nDiagram"
   );
+  assert_eq!(
+    convert_text("<ul><li>text<hr>after</li></ul>"),
+    "text after"
+  );
 }
 
 #[test]
@@ -1081,6 +1085,14 @@ fn mixed_nested_lists() {
 }
 
 #[test]
+fn a_nested_list_inside_a_span_keeps_its_structure() {
+  assert_eq!(
+    convert("<ol><li><span>parent<ul><li>child</li><li>child 2</li></ul></span></li></ol>"),
+    "1. parent\n   - child\n   - child 2"
+  );
+}
+
+#[test]
 fn ordered_list_with_code_block_uses_marker_width_indent() {
   // Ordered list continuation must be indented by the marker width
   // (3 columns for "1. ") so the fenced code block parses as part of the
@@ -1410,11 +1422,15 @@ fn a_rule_inside_a_list_item_keeps_its_own_block() {
   assert_eq!(convert("<ul><li>text <hr></li></ul>"), "- text\n\n  ---");
   assert_eq!(
     convert("<ul><li>text <hr>after</li></ul>"),
-    "- text\n\n  --- after"
+    "- text\n\n  ---\n\n  after"
   );
   assert_eq!(
     convert("<ul><li><blockquote>text <hr></blockquote></li></ul>"),
     "- \n  > text\n  >\n  > ---"
+  );
+  assert_eq!(
+    convert("<ul><li><blockquote>text<hr></blockquote>after</li></ul>"),
+    "- \n  > text\n  >\n  > ---\n\n  after"
   );
 }
 

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -279,6 +279,17 @@ fn streaming_gfm_text_escaping_matches_every_split() {
 }
 
 #[test]
+fn streaming_cmark_block_structure_matches_every_split() {
+  for html in [
+    "<ul><li>text <hr>after</li></ul>",
+    "<ul><li><blockquote>text<hr></blockquote>after</li></ul>",
+    "<ol><li><span>parent<ul><li>child</li><li>child 2</li></ul></span></li></ol>",
+  ] {
+    assert_stream_matches(html, HTMLToMarkdownOptions::default());
+  }
+}
+
+#[test]
 fn streaming_gfm_link_and_image_serialization_matches_every_split() {
   for html in [
     r#"<a href="">text</a>"#,

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -108,6 +108,8 @@ export interface MarkdownState {
   bufferedBlockquoteDepth: number
   /** Fragment for a marker line at risk of becoming a setext underline. */
   emptyItemFragment?: number
+  /** A list item rule whose following content still needs its content column. */
+  listRulePending?: true
   /** Whether output should omit Markdown/HTML markup */
   plainText?: boolean
 }
@@ -743,7 +745,7 @@ function calculateNewLineConfig(node: ElementNode, depthMap: Uint16Array, plainT
   // Adjust for inline elements
   // Block elements preserve spacing even inside span elements (presentational containers)
   // because spans shouldn't affect block-level semantics of their children
-  const isBlockElement = tagId !== undefined && ((tagId >= TAG_H1 && tagId <= TAG_H6) || tagId === TAG_P || tagId === TAG_DIV)
+  const isBlockElement = tagId !== undefined && ((tagId >= TAG_H1 && tagId <= TAG_H6) || tagId === TAG_P || tagId === TAG_DIV || tagId === TAG_LI)
   let currParent = node.parent
   while (currParent) {
     if (currParent.tagHandler?.collapsesInnerWhiteSpace) {
@@ -1216,6 +1218,31 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
       : node.parent?.excludedFromMarkdown
     if (inTemplate)
       return
+
+    if (state.listRulePending) {
+      const isVisibleText = node.type === TEXT_NODE
+        && eventType === NodeEventEnter
+        && hasNonWhitespace((node as TextNode).value)
+      const opensVisibleElement = node.type === ELEMENT_NODE
+        && eventType === NodeEventEnter
+        && !node.tagHandler?.excludesTextNodes
+      if (isVisibleText || opensVisibleElement) {
+        const separator = blockOpenPrefix(state.buffer, continuationPrefix(
+          node,
+          state.listIndentWidths || [],
+          !state.bufferedBlockquoteDepth,
+        ))!
+        state.buffer.push(separator)
+        state.lastContentCache = separator
+        state.listRulePending = undefined
+      }
+      else if (node.type === ELEMENT_NODE && eventType === NodeEventExit && (node as ElementNode).tagId === TAG_LI) {
+        state.listRulePending = undefined
+      }
+      else if (node.type === TEXT_NODE) {
+        return
+      }
+    }
 
     const lastNode = state.lastNode
     state.lastNode = event.node as ElementNode | TextNode

--- a/packages/js/src/markdown-processor.ts
+++ b/packages/js/src/markdown-processor.ts
@@ -108,8 +108,8 @@ export interface MarkdownState {
   bufferedBlockquoteDepth: number
   /** Fragment for a marker line at risk of becoming a setext underline. */
   emptyItemFragment?: number
-  /** A list item rule whose following content still needs its content column. */
-  listRulePending?: true
+  /** Content-column prefix deferred after a list item rule. */
+  listRulePending?: string
   /** Whether output should omit Markdown/HTML markup */
   plainText?: boolean
 }
@@ -1219,7 +1219,7 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
     if (inTemplate)
       return
 
-    if (state.listRulePending) {
+    if (state.listRulePending !== undefined) {
       const isVisibleText = node.type === TEXT_NODE
         && eventType === NodeEventEnter
         && hasNonWhitespace((node as TextNode).value)
@@ -1227,11 +1227,7 @@ export function createMarkdownProcessor(options: EngineOptions = {}, resolvedPlu
         && eventType === NodeEventEnter
         && !node.tagHandler?.excludesTextNodes
       if (isVisibleText || opensVisibleElement) {
-        const separator = blockOpenPrefix(state.buffer, continuationPrefix(
-          node,
-          state.listIndentWidths || [],
-          !state.bufferedBlockquoteDepth,
-        ))!
+        const separator = blockOpenPrefix(state.buffer, state.listRulePending)!
         state.buffer.push(separator)
         state.lastContentCache = separator
         state.listRulePending = undefined

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -499,18 +499,14 @@ export const tagHandlers: Record<number, TagHandler> = {
       )
       if (!prefix)
         return MARKDOWN_HORIZONTAL_RULE
+      if (state.depthMap?.[TAG_LI])
+        state.listRulePending = prefix
       const open = blockOpenPrefix(state.buffer, prefix)
       // Sharing the marker's line, where `---` would make the whole line a
       // thematic break and take the item with it.
       return open === undefined
         ? MARKDOWN_HORIZONTAL_RULE_ALT
         : `${open}${MARKDOWN_HORIZONTAL_RULE}`
-    },
-    exit: ({ state }) => {
-      if (isInsideTableCell(state) || !(state.depthMap?.[TAG_LI] || 0))
-        return ''
-      state.listRulePending = true
-      return ''
     },
     isSelfClosing: true,
   },

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -506,6 +506,12 @@ export const tagHandlers: Record<number, TagHandler> = {
         ? MARKDOWN_HORIZONTAL_RULE_ALT
         : `${open}${MARKDOWN_HORIZONTAL_RULE}`
     },
+    exit: ({ state }) => {
+      if (isInsideTableCell(state) || !(state.depthMap?.[TAG_LI] || 0))
+        return ''
+      state.listRulePending = true
+      return ''
+    },
     isSelfClosing: true,
   },
   [TAG_STRONG]: Strong,

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -328,8 +328,8 @@ export interface MdreamRuntimeState extends Partial<MdreamProcessingState> {
   preFenceOpen?: boolean
   /** Number of default blockquotes currently buffered for line prefixing. */
   bufferedBlockquoteDepth?: number
-  /** A list item rule whose following content still needs its content column. */
-  listRulePending?: true
+  /** Content-column prefix deferred after a list item rule. */
+  listRulePending?: string
   /** Whether output should omit Markdown/HTML markup */
   plainText?: boolean
 }

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -328,6 +328,8 @@ export interface MdreamRuntimeState extends Partial<MdreamProcessingState> {
   preFenceOpen?: boolean
   /** Number of default blockquotes currently buffered for line prefixing. */
   bufferedBlockquoteDepth?: number
+  /** A list item rule whose following content still needs its content column. */
+  listRulePending?: true
   /** Whether output should omit Markdown/HTML markup */
   plainText?: boolean
 }

--- a/packages/js/test/unit/gfm-text-escaping.test.ts
+++ b/packages/js/test/unit/gfm-text-escaping.test.ts
@@ -115,6 +115,18 @@ describe('gfm text escaping', () => {
       .toBe('| h |\n| --- |\n| a b |')
   })
 
+  it('keeps content after a list item rule in a separate block', () => {
+    expect(htmlToMarkdown('<ul><li>text <hr>after</li></ul>'))
+      .toBe('- text\n\n  ---\n\n  after')
+    expect(htmlToMarkdown('<ul><li><blockquote>text<hr></blockquote>after</li></ul>'))
+      .toBe('- \n  > text\n  >\n  > ---\n\n  after')
+  })
+
+  it('keeps a nested list structured inside a span', () => {
+    expect(htmlToMarkdown('<ol><li><span>parent<ul><li>child</li><li>child 2</li></ul></span></li></ol>'))
+      .toBe('1. parent\n   - child\n   - child 2')
+  })
+
   it('serializes decoded text for its output context', () => {
     expect(htmlToMarkdown('<a href="/safe">x&#93;(/evil) [y</a>'))
       .toBe('[x\\](/evil) \\[y](/safe)')

--- a/packages/js/test/unit/streaming-parity.test.ts
+++ b/packages/js/test/unit/streaming-parity.test.ts
@@ -68,6 +68,14 @@ describe('streaming parity with the Rust core', () => {
   })
 
   it.each([
+    '<ul><li>text <hr>after</li></ul>',
+    '<ul><li><blockquote>text<hr></blockquote>after</li></ul>',
+    '<ol><li><span>parent<ul><li>child</li><li>child 2</li></ul></span></li></ol>',
+  ])('keeps cmark block structure across every split for %s', async (html) => {
+    await expectStreamingParity(html)
+  })
+
+  it.each([
     '<blockquote><p>intro</p><ul><li>one</li><li>two</li></ul></blockquote>',
     '<blockquote>lead<table><tr><td>a</td></tr></table>tail</blockquote>',
     '<blockquote><ul><li>one<ul><li>sub</li></ul></li></ul></blockquote>',


### PR DESCRIPTION
### 🔗 Linked issue

Follow-up to #193, now rebased onto merged `main`.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

cmark-gfm 0.29.0.gfm.13 flattened nested lists inside spans and parsed content after a list item `<hr>` as part of the rule line. The JS and Rust converters now preserve both structures, including every streaming split.

The JS path keeps the content-column prefix computed while emitting `<hr>`, then reuses it for the deferred separator. This removes a second ancestor walk and cut 16 to 18 B gzip from the first implementation.

The cmark audit used commit `499789b` across 215 focused fixtures plus the complete GitHub Markdown, small Wikipedia, and large Wikipedia corpora. One mismatch remains: a table body row wider than its header. Exact output needs full-table buffering or a second pass, so that work stays out of this bounded-memory streaming PR.

### 📦 Bundle and performance

Measured against `main` at `05f8810` on the same checkout and toolchain:

| Bundle | Raw delta | Gzip delta |
|---|---:|---:|
| JavaScript Core | +371 B | +97 B |
| JavaScript Minimal | +371 B | +97 B |
| JavaScript Stream | +371 B | +96 B |
| Rust Edge WASM | +412 B | +212 B |

Alternating same-process A/B samples canceled local machine drift. CPU deltas were core +2.9%, attribute-heavy -2.2%, minimal -0.5%, and stream +2.3%; every result stayed under the 5% gate. No-opt allocations changed by +0.44%, +0.02%, +0.10%, and +0.49% respectively. WASM peak memory was byte-identical for the wiki and both streaming retention cases.