### PR TITLE
fix(edge): report WASM panics as catchable errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,9 @@ jobs:
 
       - name: Build WASM for Workers
         run: |
-          node scripts/build-wasm-edge.mjs --target web --out-dir crates/edge/test-worker/wasm
+          # the test worker's own artifact carries the panic probe (#195); the
+          # packaged artifact stays exactly what we release
+          node scripts/build-wasm-edge.mjs --target web --out-dir crates/edge/test-worker/wasm --features panic-probe
           node scripts/build-wasm-edge.mjs --target web --out-dir packages/mdream/wasm
 
       - run: pnpm install

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -50,6 +50,9 @@ opt-level = 3
 lto = true
 strip = true
 codegen-units = 1
+# napi catches unwinds and turns them into JS exceptions. wasm32-unknown-unknown
+# ignores this: rustup ships `panic_unwind` built with abort for that target, so
+# the edge crate always aborts and reports panics through its panic hook instead.
 panic = "unwind"
 
 [profile.wasm]

--- a/crates/edge/Cargo.toml
+++ b/crates/edge/Cargo.toml
@@ -15,6 +15,11 @@ wasm-opt = false # wasm-pack's bundled wasm-opt is too old; run wasm-opt manuall
 [lib]
 crate-type = [ "cdylib" ]
 
+[features]
+# Test-only: makes `origin: "__mdream_panic_probe__"` panic so the Workers test
+# can assert panic reporting against a real abort. Never enabled for releases.
+panic-probe = [ ]
+
 [dependencies]
 mdream = { path = "../core" }
 wasm-bindgen = "0.2.123"

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::Cell;
 
 use wasm_bindgen::prelude::*;
 
@@ -16,21 +16,24 @@ use wasm_bindgen::prelude::*;
 // is the message: capture it in a panic hook and let the JS glue re-throw it as
 // a real `Error`. Every panic runs the hook, unlike a hook that throws (that
 // leaves std's panic counter raised, so later panics abort before the hook).
+//
+// `Cell` rather than `RefCell`: a hook running inside a panic must not be able
+// to panic itself on a conflicting borrow.
 thread_local! {
-  static PANIC_MESSAGE: RefCell<Option<String>> = const { RefCell::new(None) };
+  static PANIC_MESSAGE: Cell<Option<String>> = const { Cell::new(None) };
 }
 
 #[wasm_bindgen(start)]
 pub fn install_panic_hook() {
   std::panic::set_hook(Box::new(|info| {
-    PANIC_MESSAGE.with_borrow_mut(|slot| *slot = Some(info.to_string()));
+    PANIC_MESSAGE.with(|slot| slot.set(Some(info.to_string())));
   }));
 }
 
 /// Consumes the message of the panic that aborted the last export call.
 #[wasm_bindgen(js_name = "__mdreamTakePanicMessage")]
 pub fn take_panic_message() -> Option<String> {
-  PANIC_MESSAGE.with_borrow_mut(Option::take)
+  PANIC_MESSAGE.with(Cell::take)
 }
 
 // ── Manual JsValue helpers (replaces serde) ──

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -1,4 +1,37 @@
+use std::cell::RefCell;
+
 use wasm_bindgen::prelude::*;
+
+// ── Panic reporting ──
+//
+// wasm32-unknown-unknown always aborts on panic: the std shipped by rustup
+// builds `panic_unwind` with the abort strategy, so `-Cpanic=unwind` fails to
+// link (`the crate panic_unwind does not have the panic strategy unwind`) and
+// the workspace `panic = "unwind"` profile setting is ignored for this target.
+// Unwinding needs a nightly `-Zbuild-std` rebuild plus wasm exception handling,
+// which measured +8.8% wasm and 6-7% slower conversions.
+//
+// An abort reaches JS as a bare `RuntimeError: unreachable` trap. The trap is
+// catchable and leaves the instance usable, so the only thing actually missing
+// is the message: capture it in a panic hook and let the JS glue re-throw it as
+// a real `Error`. Every panic runs the hook, unlike a hook that throws (that
+// leaves std's panic counter raised, so later panics abort before the hook).
+thread_local! {
+  static PANIC_MESSAGE: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+#[wasm_bindgen(start)]
+pub fn install_panic_hook() {
+  std::panic::set_hook(Box::new(|info| {
+    PANIC_MESSAGE.with_borrow_mut(|slot| *slot = Some(info.to_string()));
+  }));
+}
+
+/// Consumes the message of the panic that aborted the last export call.
+#[wasm_bindgen(js_name = "__mdreamTakePanicMessage")]
+pub fn take_panic_message() -> Option<String> {
+  PANIC_MESSAGE.with_borrow_mut(Option::take)
+}
 
 // ── Manual JsValue helpers (replaces serde) ──
 
@@ -100,6 +133,14 @@ fn parse_options(
   }
 
   let origin = as_string(&get_prop(options, "origin"));
+
+  // Test-only trigger for the panic reporting regression test (#195); compiled
+  // out of every released artifact.
+  #[cfg(feature = "panic-probe")]
+  if origin.as_deref() == Some("__mdream_panic_probe__") {
+    panic!("panic probe: intentional panic");
+  }
+
   let clean_urls = as_bool(&get_prop(options, "cleanUrls")).unwrap_or(false);
   let clean = parse_clean(&get_prop(options, "clean"));
 

--- a/crates/edge/test-worker/src/index.ts
+++ b/crates/edge/test-worker/src/index.ts
@@ -1,6 +1,7 @@
 import type { MdreamOptions } from 'mdream'
 import { htmlToMarkdown as pkgHtmlToMarkdown, streamHtmlToMarkdown as pkgStreamHtmlToMarkdown } from 'mdream'
-import init, { htmlToMarkdown, htmlToMarkdownResult, MarkdownStream } from '../wasm/mdream_edge.js'
+import { wasmPanicError } from '../../../../packages/mdream/src/wasm-panic.js'
+import init, { __mdreamTakePanicMessage, htmlToMarkdown, htmlToMarkdownResult, MarkdownStream } from '../wasm/mdream_edge.js'
 // @ts-expect-error wasm module import
 import wasmModule from '../wasm/mdream_edge_bg.wasm'
 
@@ -68,6 +69,27 @@ export default {
         },
       })
       return Response.json({ markdown, frontmatter, heading })
+    }
+
+    // Regression for #195: a Rust panic aborts the WASM instance, so it must
+    // still reach Workers code as a catchable error carrying the panic message,
+    // and the instance must keep converting afterwards. Needs the wasm built
+    // with `--features panic-probe`.
+    if (url.pathname === '/panic' && request.method === 'POST') {
+      const html = await request.text()
+      let reported: { name: string, message: string, cause: string } | undefined
+      try {
+        htmlToMarkdown(html, { origin: '__mdream_panic_probe__' })
+      }
+      catch (error) {
+        const panic = wasmPanicError(error, __mdreamTakePanicMessage) as Error
+        reported = {
+          name: panic.name,
+          message: panic.message,
+          cause: String((panic as { cause?: unknown }).cause),
+        }
+      }
+      return Response.json({ reported, afterPanic: htmlToMarkdown(html) })
     }
 
     if (url.pathname === '/convert' && request.method === 'POST') {

--- a/crates/edge/test-worker/test/worker.test.ts
+++ b/crates/edge/test-worker/test/worker.test.ts
@@ -143,6 +143,33 @@ describe('mdream WASM in Workers runtime', () => {
     expect(md).toContain('& < > "')
   })
 
+  it('reports Rust panics as catchable errors and keeps converting (#195)', async () => {
+    const first = await SELF.fetch('http://localhost/panic', {
+      method: 'POST',
+      body: '<h1>Alive</h1>',
+    })
+    const data = await first.json() as {
+      reported?: { name: string, message: string, cause: string }
+      afterPanic: string
+    }
+    expect(data.reported).toBeDefined()
+    expect(data.reported!.name).toBe('Error')
+    expect(data.reported!.message).toContain('panic probe: intentional panic')
+    expect(data.reported!.message).toContain('mdream WASM panic')
+    // the raw trap is kept as the cause
+    expect(data.reported!.cause).toContain('unreachable')
+    // the aborted instance still converts
+    expect(data.afterPanic).toBe('# Alive')
+
+    // and a second panic is reported just as well: the hook is not one-shot
+    const second = await SELF.fetch('http://localhost/panic', {
+      method: 'POST',
+      body: '<h1>Alive</h1>',
+    })
+    const secondData = await second.json() as { reported?: { message: string } }
+    expect(secondData.reported?.message).toContain('panic probe: intentional panic')
+  })
+
   it('returns 404 for unknown routes', async () => {
     const res = await SELF.fetch('http://localhost/unknown')
     expect(res.status).toBe(404)

--- a/packages/mdream/README.md
+++ b/packages/mdream/README.md
@@ -931,6 +931,19 @@ for await (const chunk of streamHtmlToMarkdown(response.body)) {
 }
 ```
 
+Conversion errors are catchable. WASM has no unwinding, so an internal Rust panic aborts the call, but the message is preserved and re-thrown as a normal `Error` (with the raw WASM trap as `cause`), and the instance keeps working for later requests:
+
+```ts
+try {
+  return new Response(htmlToMarkdown(html))
+}
+catch (error) {
+  // "mdream WASM panic, please report this at ...\npanicked at ..."
+  console.error(error)
+  return new Response('conversion failed', { status: 500 })
+}
+```
+
 If your toolchain doesn't resolve the export conditions, the raw wasm-bindgen build (web target) is exposed at `mdream/wasm` for manual initialization:
 
 ```ts

--- a/packages/mdream/build.config.ts
+++ b/packages/mdream/build.config.ts
@@ -69,7 +69,7 @@ ${bindingsCode}
 // Auto-init with inlined WASM
 initSync({module:_decodeBase64(_wasmBase64)});
 // Public API
-function htmlToMarkdown(html,options){return htmlToMarkdownResult(html,options||{})}
+function htmlToMarkdown(html,options){try{return htmlToMarkdownResult(html,options||{})}catch(e){var p=__mdreamTakePanicMessage();if(p)throw new Error("mdream WASM panic, please report this at https://github.com/harlan-zw/mdream/issues\\n"+p,{cause:e});throw e}}
 if(typeof window!=='undefined'){window.mdream={htmlToMarkdown:htmlToMarkdown}}
 })();`
 

--- a/packages/mdream/src/browser.ts
+++ b/packages/mdream/src/browser.ts
@@ -68,7 +68,8 @@ export async function* streamHtmlToMarkdown(
   if (!htmlStream)
     throw new Error('Invalid HTML stream provided')
   await ensureInit()
-  const stream = new MarkdownStream(options || {})
+  // the raw binding, wrapped once below rather than once per chunk
+  const stream = new _MarkdownStream(options || {})
   const reader = htmlStream.getReader()
   const decoder = new TextDecoder()
   try {
@@ -92,6 +93,9 @@ export async function* streamHtmlToMarkdown(
     const final_ = stream.finish()
     if (final_)
       yield final_
+  }
+  catch (error) {
+    throw wasmPanicError(error)
   }
   finally {
     reader.releaseLock()

--- a/packages/mdream/src/browser.ts
+++ b/packages/mdream/src/browser.ts
@@ -1,5 +1,6 @@
 import type { HtmlToMarkdownOptions, MdreamNapiResult } from '../napi/index.js'
 import init, { htmlToMarkdownResult as _htmlToMarkdownResult, MarkdownStream as _MarkdownStream } from '../wasm/mdream_edge.js'
+import { wasmPanicError } from './wasm-panic.js'
 
 let _initPromise: Promise<unknown>
 
@@ -15,7 +16,13 @@ ensureInit()
 
 export async function htmlToMarkdown(html: string, options?: HtmlToMarkdownOptions): Promise<MdreamNapiResult> {
   await ensureInit()
-  return _htmlToMarkdownResult(html, options || {})
+  try {
+    return _htmlToMarkdownResult(html, options || {})
+  }
+  catch (error) {
+    // A Rust panic aborts the WASM instance; surface its message (#195).
+    throw wasmPanicError(error)
+  }
 }
 
 export async function createMarkdownStream(options?: HtmlToMarkdownOptions): Promise<MarkdownStream> {
@@ -27,15 +34,30 @@ export class MarkdownStream {
   private _inner: _MarkdownStream
 
   constructor(options?: HtmlToMarkdownOptions) {
-    this._inner = new _MarkdownStream(options || {})
+    try {
+      this._inner = new _MarkdownStream(options || {})
+    }
+    catch (error) {
+      throw wasmPanicError(error)
+    }
   }
 
   processChunk(chunk: string): string {
-    return this._inner.processChunk(chunk)
+    try {
+      return this._inner.processChunk(chunk)
+    }
+    catch (error) {
+      throw wasmPanicError(error)
+    }
   }
 
   finish(): string {
-    return this._inner.finish()
+    try {
+      return this._inner.finish()
+    }
+    catch (error) {
+      throw wasmPanicError(error)
+    }
   }
 }
 
@@ -46,7 +68,7 @@ export async function* streamHtmlToMarkdown(
   if (!htmlStream)
     throw new Error('Invalid HTML stream provided')
   await ensureInit()
-  const stream = new _MarkdownStream(options || {})
+  const stream = new MarkdownStream(options || {})
   const reader = htmlStream.getReader()
   const decoder = new TextDecoder()
   try {

--- a/packages/mdream/src/edge.ts
+++ b/packages/mdream/src/edge.ts
@@ -70,7 +70,8 @@ export async function* streamHtmlToMarkdown(
 ): AsyncIterable<string> {
   if (!htmlStream)
     throw new Error('Invalid HTML stream provided')
-  const stream = new MarkdownStream(options ? resolveOptions(options).napiOpts : undefined)
+  // the raw binding, wrapped once below rather than once per chunk
+  const stream = new _MarkdownStream(options ? resolveOptions(options).napiOpts : undefined)
   const reader = htmlStream.getReader()
   const decoder = new TextDecoder()
   try {
@@ -94,6 +95,9 @@ export async function* streamHtmlToMarkdown(
     const final_ = stream.finish()
     if (final_)
       yield final_
+  }
+  catch (error) {
+    throw wasmPanicError(error)
   }
   finally {
     reader.releaseLock()

--- a/packages/mdream/src/edge.ts
+++ b/packages/mdream/src/edge.ts
@@ -2,17 +2,28 @@ import type { HtmlToMarkdownOptions } from '../napi/index.js'
 import { htmlToMarkdownResult as _htmlToMarkdownResult, MarkdownStream as _MarkdownStream, initSync } from '../wasm/mdream_edge.js'
 import wasmModule from '../wasm/mdream_edge_bg.wasm'
 import { resolveOptions } from './resolve-options.js'
+import { wasmPanicError } from './wasm-panic.js'
 
 // Edge runtimes (workerd, edge-light) resolve `.wasm` imports to a compiled
 // WebAssembly.Module that must be instantiated manually (#119).
 initSync({ module: wasmModule })
 
+function convert(html: string, napiOpts: HtmlToMarkdownOptions | undefined) {
+  try {
+    return _htmlToMarkdownResult(html, napiOpts)
+  }
+  catch (error) {
+    // A Rust panic aborts the WASM instance; surface its message (#195).
+    throw wasmPanicError(error)
+  }
+}
+
 export function htmlToMarkdown(html: string, options?: HtmlToMarkdownOptions): string {
   if (!options)
-    return _htmlToMarkdownResult(html, undefined).markdown || ''
+    return convert(html, undefined).markdown || ''
 
   const { napiOpts, extractionHandlers, frontmatterCallback } = resolveOptions(options)
-  const result = _htmlToMarkdownResult(html, napiOpts)
+  const result = convert(html, napiOpts)
   if (result.frontmatter && frontmatterCallback)
     frontmatterCallback(result.frontmatter)
   if (result.extracted?.length && extractionHandlers) {
@@ -26,15 +37,30 @@ export class MarkdownStream {
   private _inner: _MarkdownStream
 
   constructor(options?: HtmlToMarkdownOptions) {
-    this._inner = new _MarkdownStream(options)
+    try {
+      this._inner = new _MarkdownStream(options)
+    }
+    catch (error) {
+      throw wasmPanicError(error)
+    }
   }
 
   processChunk(chunk: string): string {
-    return this._inner.processChunk(chunk)
+    try {
+      return this._inner.processChunk(chunk)
+    }
+    catch (error) {
+      throw wasmPanicError(error)
+    }
   }
 
   finish(): string {
-    return this._inner.finish()
+    try {
+      return this._inner.finish()
+    }
+    catch (error) {
+      throw wasmPanicError(error)
+    }
   }
 }
 
@@ -44,7 +70,7 @@ export async function* streamHtmlToMarkdown(
 ): AsyncIterable<string> {
   if (!htmlStream)
     throw new Error('Invalid HTML stream provided')
-  const stream = new _MarkdownStream(options ? resolveOptions(options).napiOpts : undefined)
+  const stream = new MarkdownStream(options ? resolveOptions(options).napiOpts : undefined)
   const reader = htmlStream.getReader()
   const decoder = new TextDecoder()
   try {

--- a/packages/mdream/src/wasm-panic.ts
+++ b/packages/mdream/src/wasm-panic.ts
@@ -12,6 +12,12 @@ import { __mdreamTakePanicMessage } from '../wasm/mdream_edge.js'
  * probe build can be checked against the same reporting path.
  */
 export function wasmPanicError(error: unknown, takeMessage: () => string | undefined = __mdreamTakePanicMessage): unknown {
+  // An abort always surfaces as a trap. Anything else (a TypeError from the
+  // bindings, a rejected stream read) must not be labelled with a message left
+  // behind by a panic someone else caught.
+  if (!(error instanceof WebAssembly.RuntimeError))
+    return error
+
   let message: string | undefined
   try {
     message = takeMessage()

--- a/packages/mdream/src/wasm-panic.ts
+++ b/packages/mdream/src/wasm-panic.ts
@@ -1,0 +1,26 @@
+import { __mdreamTakePanicMessage } from '../wasm/mdream_edge.js'
+
+/**
+ * WASM aborts on panic (wasm32-unknown-unknown has no unwinding), so a Rust
+ * panic reaches JS as a bare `RuntimeError: unreachable` with no message. The
+ * Rust panic hook stashes the message before aborting: pick it up here and
+ * re-throw something actionable, keeping the trap as `cause`.
+ *
+ * The instance stays usable after an abort, so callers may keep converting.
+ *
+ * `takeMessage` defaults to the bundled instance; tests pass their own so a
+ * probe build can be checked against the same reporting path.
+ */
+export function wasmPanicError(error: unknown, takeMessage: () => string | undefined = __mdreamTakePanicMessage): unknown {
+  let message: string | undefined
+  try {
+    message = takeMessage()
+  }
+  catch {
+    // WASM never initialized, or the instance is gone: nothing to add.
+    return error
+  }
+  if (!message)
+    return error
+  return new Error(`mdream WASM panic, please report this at https://github.com/harlan-zw/mdream/issues\n${message}`, { cause: error })
+}

--- a/packages/mdream/src/worker.ts
+++ b/packages/mdream/src/worker.ts
@@ -17,7 +17,7 @@ const WASM_RE = /\.wasm$/
 
 function getWorkerBlob(wasmUrl: string): Blob {
   const code = `
-import init, { htmlToMarkdownResult } from '${wasmUrl.replace(WASM_RE, '.js')}';
+import init, { __mdreamTakePanicMessage, htmlToMarkdownResult } from '${wasmUrl.replace(WASM_RE, '.js')}';
 
 let ready = false;
 
@@ -42,7 +42,9 @@ self.onmessage = function(e) {
       const result = htmlToMarkdownResult(msg.html, msg.options || {});
       self.postMessage({ id: msg.id, type: 'result', data: result.markdown || '' });
     } catch (err) {
-      self.postMessage({ id: msg.id, type: 'error', message: err.message });
+      // WASM aborts on panic (#195): the message is stashed by the panic hook
+      const panic = __mdreamTakePanicMessage();
+      self.postMessage({ id: msg.id, type: 'error', message: panic || err.message });
     }
   }
 };`

--- a/packages/mdream/src/worker.ts
+++ b/packages/mdream/src/worker.ts
@@ -17,7 +17,9 @@ const WASM_RE = /\.wasm$/
 
 function getWorkerBlob(wasmUrl: string): Blob {
   const code = `
-import init, { __mdreamTakePanicMessage, htmlToMarkdownResult } from '${wasmUrl.replace(WASM_RE, '.js')}';
+// namespace import: the URL is caller-supplied and may point at an older build
+import init, * as engine from '${wasmUrl.replace(WASM_RE, '.js')}';
+const { htmlToMarkdownResult } = engine;
 
 let ready = false;
 
@@ -43,7 +45,7 @@ self.onmessage = function(e) {
       self.postMessage({ id: msg.id, type: 'result', data: result.markdown || '' });
     } catch (err) {
       // WASM aborts on panic (#195): the message is stashed by the panic hook
-      const panic = __mdreamTakePanicMessage();
+      const panic = engine.__mdreamTakePanicMessage?.();
       self.postMessage({ id: msg.id, type: 'error', message: panic || err.message });
     }
   }

--- a/packages/mdream/test/unit/wasm-panic.test.ts
+++ b/packages/mdream/test/unit/wasm-panic.test.ts
@@ -19,6 +19,11 @@ describe('wasmPanicError', () => {
     expect(wasmPanicError(TRAP, () => undefined)).toBe(TRAP)
   })
 
+  it('never labels a non-trap failure with a stale panic message', () => {
+    const failure = new TypeError('expected a string argument')
+    expect(wasmPanicError(failure, () => 'panicked at edge/src/lib.rs:12:5:\nstale')).toBe(failure)
+  })
+
   it('rethrows untouched when the message cannot be read', () => {
     expect(wasmPanicError(TRAP, () => {
       throw new TypeError('wasm is undefined')

--- a/packages/mdream/test/unit/wasm-panic.test.ts
+++ b/packages/mdream/test/unit/wasm-panic.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { wasmPanicError } from '../../src/wasm-panic.js'
+
+// WASM aborts on panic, so the runtime hands JS a bare `RuntimeError:
+// unreachable`. The Rust panic hook stashes the message for us to attach (#195).
+const TRAP = new WebAssembly.RuntimeError('unreachable')
+
+describe('wasmPanicError', () => {
+  it('attaches the captured panic message and keeps the trap as cause', () => {
+    const error = wasmPanicError(TRAP, () => 'panicked at edge/src/lib.rs:12:5:\nboom') as Error
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error.message).toContain('mdream WASM panic')
+    expect(error.message).toContain('panicked at edge/src/lib.rs:12:5:\nboom')
+    expect(error.cause).toBe(TRAP)
+  })
+
+  it('rethrows untouched when the failure was not a panic', () => {
+    expect(wasmPanicError(TRAP, () => undefined)).toBe(TRAP)
+  })
+
+  it('rethrows untouched when the message cannot be read', () => {
+    expect(wasmPanicError(TRAP, () => {
+      throw new TypeError('wasm is undefined')
+    })).toBe(TRAP)
+  })
+})

--- a/scripts/build-wasm-edge.mjs
+++ b/scripts/build-wasm-edge.mjs
@@ -31,9 +31,13 @@ function argValue(name, fallback) {
 const target = argValue('--target')
 const outDir = resolve(argValue('--out-dir'))
 const outName = argValue('--out-name', 'mdream_edge')
+// Test-only cargo features (e.g. panic-probe). Released artifacts pass none.
+const features = argValue('--features', '')
 const edgeDir = resolve(import.meta.dirname, '../crates/edge')
 
-execFileSync('wasm-pack', ['build', '--target', target, '--out-dir', outDir, '--out-name', outName], {
+const cargoArgs = features ? ['--', '--features', features] : []
+
+execFileSync('wasm-pack', ['build', '--target', target, '--out-dir', outDir, '--out-name', outName, ...cargoArgs], {
   cwd: edgeDir,
   stdio: 'inherit',
   env: { ...process.env, CARGO_PROFILE_RELEASE_OPT_LEVEL: 's' },


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #195

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Rust panics reached Workers as `RuntimeError: unreachable` with no message. This keeps the abort but captures the panic message in a hook, so the JS entries can re-throw it as a real `Error`:

```
Error: mdream WASM panic, please report this at https://github.com/harlan-zw/mdream/issues
panicked at edge/src/lib.rs:141:5:
panic probe: intentional panic
  [cause]: RuntimeError: unreachable
```

**Why not `panic = "unwind"` (options 1 and 2 in the issue)**

It does not build on stable. rustup ships `panic_unwind` for `wasm32-unknown-unknown` compiled with the abort strategy, so the workspace `panic = "unwind"` is ignored for this target and forcing it fails:

```console
$ RUSTFLAGS="-Cpanic=unwind -Ctarget-feature=+exception-handling" wasm-pack build
error: the crate `panic_unwind` does not have the panic strategy `unwind`
```

Unwinding therefore needs a nightly `-Zbuild-std` rebuild in release CI, on top of the +8.8% wasm and 6-7% throughput cost measured in the issue.

**The premise is also softer than the issue states.** An abort does not terminate the instance uncatchably. Measured on the current artifact: the trap arrives in JS as a catchable `WebAssembly.RuntimeError`, and the instance kept converting correctly after 2000 consecutive panics (allocations live at panic time leak, since no destructors run). The only thing lost was the message.

**What changed**

- `crates/edge/src/lib.rs`: `#[wasm_bindgen(start)]` installs a panic hook that stashes the message into a thread-local `Cell`, plus `__mdreamTakePanicMessage()` to consume it. Two deliberate choices: the hook does not throw, because throwing from inside it leaves std's panic counter raised and only the first panic per instance would ever be reported; and `Cell` over `RefCell`, so a hook running inside a panic cannot panic again on a conflicting borrow.
- `packages/mdream/src/wasm-panic.ts`: shared `wasmPanicError()` used by `edge.ts`, `browser.ts` and `worker.ts`; same logic inlined into the iife bundle in `build.config.ts`. It only translates `WebAssembly.RuntimeError`, so a message left behind by someone catching a panic from `mdream/wasm` directly can never be attached to an unrelated `TypeError` or stream rejection. `streamHtmlToMarkdown` wraps its whole read loop once rather than routing every chunk through a wrapper's try/catch.
- `packages/mdream/src/worker.ts`: the worker blob namespace-imports the glue and calls `__mdreamTakePanicMessage?.()`. Its wasm URL is caller-supplied, so a named import would break the worker outright against an older hosted build.
- `crates/edge/Cargo.toml`: test-only `panic-probe` feature makes `origin: "__mdream_panic_probe__"` panic, so the Workers test asserts against a real abort. Compiled out of released artifacts; CI builds it only into the test worker's own wasm.

**Cost** (wasm-opt'd `--target web` artifact, before → after)

| | raw | gzip |
|---|---|---|
| baseline | 165,799 B | 72,853 B |
| this PR | 168,281 B | 73,991 B |
| delta | +1.50% | +1.56% |

Building the message by hand from `payload()` and `location()` instead of `PanicHookInfo::to_string()` was tried and came out 1.1 KB *larger*: the `Display` impl is already linked for std's default hook, so the manual version only adds code.

No hot path work was added. Conversion throughput on `wikipedia-largest.html` sits at 10.2-10.9 ms median for both the baseline and this build across interleaved runs, so the difference is inside binary-layout and machine noise, against 6-7% for the unwind route.

**Tests**

- `crates/edge/test-worker/test/worker.test.ts`: in workerd, a panic surfaces as an `Error` carrying the panic message with the trap as `cause`, the instance still converts afterwards, and a second panic is reported just as well.
- `packages/mdream/test/unit/wasm-panic.test.ts`: `wasmPanicError` attaches the message, and passes non-panic failures through untouched.
- Verified end-to-end through the shipped `mdream` package path in workerd with a probe-enabled artifact (temporary route, not committed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved WASM error reporting with descriptive panic messages and preserved underlying errors.
  * Added consistent panic handling for one-time and streaming Markdown conversions across browser, edge, and worker environments.
  * Conversion errors can now be caught and returned as appropriate HTTP responses.

* **Documentation**
  * Added guidance and examples for handling WASM conversion failures.

* **Tests**
  * Added coverage for panic reporting, error causes, repeated requests, and continued conversion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
