### PR TITLE
chore(ci): make the fuzz job run, and make it explore HTML

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -27,6 +27,9 @@ jobs:
 
       - name: Install Rust nightly toolchain
         uses: dtolnay/rust-toolchain@nightly
+        with:
+          # cargo-fuzz can pass -Zbuild-std, which needs the std source
+          components: rust-src
 
       - name: Install cargo-fuzz
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
@@ -37,9 +40,22 @@ jobs:
         with:
           workspaces: crates/core/fuzz -> target
 
+      # corpus/ is gitignored, so without this every weekly run starts cold and
+      # rediscovers the same shallow inputs for 300s
+      - name: Restore corpus
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: crates/core/fuzz/corpus/${{ matrix.target }}
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
+          restore-keys: fuzz-corpus-${{ matrix.target }}-
+
+      # --target is pinned because cargo-fuzz defaults it to its own build
+      # triple: install-action dropped cargo-fuzz, so binstall now fetches the
+      # musl build, and a musl target cannot link the sanitizer
+      # ("sanitizer is incompatible with statically linked libc").
       - name: Run fuzzer
         working-directory: crates/core
-        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=300
+        run: cargo +nightly fuzz run --target x86_64-unknown-linux-gnu ${{ matrix.target }} -- -max_total_time=300
 
       - name: Upload crash artifacts
         if: failure()

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         target:
           - fuzz_html_to_markdown
+          - fuzz_html_grammar
           - fuzz_options
           - fuzz_splitter
           - fuzz_streaming
@@ -55,7 +56,7 @@ jobs:
       # ("sanitizer is incompatible with statically linked libc").
       - name: Run fuzzer
         working-directory: crates/core
-        run: cargo +nightly fuzz run --target x86_64-unknown-linux-gnu ${{ matrix.target }} -- -max_total_time=300
+        run: cargo +nightly fuzz run --target x86_64-unknown-linux-gnu ${{ matrix.target }} -- -dict=fuzz/html.dict -max_total_time=300
 
       - name: Upload crash artifacts
         if: failure()

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -44,10 +44,10 @@ jobs:
       # corpus/ is gitignored, so without this every weekly run starts cold and
       # rediscovers the same shallow inputs for 300s
       - name: Restore corpus
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: crates/core/fuzz/corpus/${{ matrix.target }}
-          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: fuzz-corpus-${{ matrix.target }}-
 
       # --target is pinned because cargo-fuzz defaults it to its own build
@@ -65,3 +65,12 @@ jobs:
           name: fuzz-artifacts-${{ matrix.target }}
           path: crates/core/fuzz/artifacts/
           if-no-files-found: ignore
+
+      # a run that crashed is the one whose corpus is worth keeping, and a
+      # plain actions/cache step only saves when the job succeeded
+      - name: Save corpus
+        if: always()
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: crates/core/fuzz/corpus/${{ matrix.target }}
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/crates/core/fuzz/Cargo.toml
+++ b/crates/core/fuzz/Cargo.toml
@@ -38,6 +38,13 @@ doc = false
 bench = false
 
 [[bin]]
+name = "fuzz_html_grammar"
+path = "fuzz_targets/fuzz_html_grammar.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "fuzz_splitter"
 path = "fuzz_targets/fuzz_splitter.rs"
 test = false

--- a/crates/core/fuzz/fuzz_targets/fuzz_html_grammar.rs
+++ b/crates/core/fuzz/fuzz_targets/fuzz_html_grammar.rs
@@ -1,0 +1,256 @@
+#![no_main]
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use mdream::types::*;
+use mdream::{MarkdownStreamProcessor, html_to_format_result};
+
+// The byte-oriented targets have to rediscover HTML from random bytes, so most
+// of their budget is spent on inputs the parser rejects in its first branch.
+// This one emits a token stream instead: every mutation lands on something the
+// parser walks deep into, and because the tokens are emitted flat rather than
+// as a tree, unbalanced and mismatched markup falls out on its own.
+//
+// Keep the byte-oriented targets. A grammar only produces what it knows about,
+// so it cannot replace random bytes, only spend more time past the tokenizer.
+
+// Tags picked for the handlers that behave differently: raw-text elements,
+// void elements, table and list structure, and elements with no handler at all.
+const TAGS: [&str; 40] = [
+  "html", "head", "body", "main", "article", "section", "nav", "footer", "header", "aside", "div",
+  "p", "span", "h1", "h2", "h3", "h4", "h5", "h6", "strong", "em", "code", "pre", "blockquote",
+  "ul", "ol", "li", "dl", "dt", "dd", "table", "thead", "tbody", "tr", "th", "td", "a", "img",
+  "script", "style",
+];
+
+const VOID_TAGS: [&str; 6] = ["br", "hr", "meta", "link", "input", "source"];
+
+// Unknown and case-varied names: the tag lookup is a perfect hash on lowercase
+// bytes, so these drive the fallback and the case-folding path.
+const ODD_TAGS: [&str; 6] = ["my-widget", "DIV", "TaBlE", "svg", "template", "textarea"];
+
+const ATTR_NAMES: [&str; 12] = [
+  "href",
+  "src",
+  "class",
+  "id",
+  "alt",
+  "title",
+  "colspan",
+  "rowspan",
+  "style",
+  "hidden",
+  "aria-hidden",
+  "data-x",
+];
+
+const ATTR_VALUES: [&str; 14] = [
+  "",
+  "/rel",
+  "https://example.com/a b",
+  "//cdn.example.com/x",
+  "#frag",
+  "javascript:alert(1)",
+  "data:text/html,<b>",
+  "9999",
+  "-1",
+  "text-red-500 font-bold line-through",
+  "sr-only",
+  "\"quoted\"",
+  "a'b",
+  "\u{1F600}",
+];
+
+// Text fragments that interact with Markdown escaping, entity decoding and
+// UTF-8 boundary handling.
+const TEXTS: [&str; 20] = [
+  "x",
+  " ",
+  "\n\n",
+  "\r\n",
+  "hello world",
+  "*emphasis* _under_ `tick`",
+  "| pipe | table |",
+  "# not a heading",
+  "> quote",
+  "[link] (paren)",
+  "&amp;",
+  "&#x1F600;",
+  "&#xZZ;",
+  "&notanentity;",
+  "&",
+  "\u{1F600}\u{1F1E6}\u{1F1FA}",
+  "e\u{0301}\u{0301}\u{0301}",
+  "\u{202E}rtl",
+  "\0",
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+];
+
+#[derive(Arbitrary, Debug)]
+enum Token {
+  Open { tag: u8, attrs: Vec<(u8, u8, Quote)> },
+  Close { tag: u8 },
+  SelfClosing { tag: u8 },
+  Void { tag: u8 },
+  Odd { tag: u8, close: bool },
+  Text { which: u8 },
+  Comment { unterminated: bool },
+  Doctype,
+  // Deliberately broken syntax the tokenizer has to resynchronise from.
+  StrayLt,
+  StrayGt,
+  UnclosedOpen { tag: u8 },
+  AttrNoValue { tag: u8, attr: u8 },
+}
+
+#[derive(Arbitrary, Debug)]
+enum Quote {
+  Double,
+  Single,
+  None,
+}
+
+#[derive(Arbitrary, Debug)]
+struct Input {
+  tokens: Vec<Token>,
+  chunk_width: u8,
+  wrap_width: u8,
+  plain_text: bool,
+  clean_all: bool,
+  minimal_plugins: bool,
+}
+
+fn pick<T: Copy>(table: &[T], i: u8) -> T {
+  table[i as usize % table.len()]
+}
+
+fn push_attrs(out: &mut String, attrs: &[(u8, u8, Quote)]) {
+  for (name, value, quote) in attrs {
+    out.push(' ');
+    out.push_str(pick(&ATTR_NAMES, *name));
+    out.push('=');
+    let value = pick(&ATTR_VALUES, *value);
+    match quote {
+      Quote::Double => {
+        out.push('"');
+        out.push_str(value);
+        out.push('"');
+      }
+      Quote::Single => {
+        out.push('\'');
+        out.push_str(value);
+        out.push('\'');
+      }
+      // Unquoted values run to the next space, so a value containing one leaks
+      // into the following attribute name.
+      Quote::None => out.push_str(value),
+    }
+  }
+}
+
+fn render(tokens: &[Token]) -> String {
+  let mut out = String::new();
+  for token in tokens {
+    match token {
+      Token::Open { tag, attrs } => {
+        out.push('<');
+        out.push_str(pick(&TAGS, *tag));
+        push_attrs(&mut out, attrs);
+        out.push('>');
+      }
+      Token::Close { tag } => {
+        out.push_str("</");
+        out.push_str(pick(&TAGS, *tag));
+        out.push('>');
+      }
+      Token::SelfClosing { tag } => {
+        out.push('<');
+        out.push_str(pick(&TAGS, *tag));
+        out.push_str("/>");
+      }
+      Token::Void { tag } => {
+        out.push('<');
+        out.push_str(pick(&VOID_TAGS, *tag));
+        out.push('>');
+      }
+      Token::Odd { tag, close } => {
+        out.push('<');
+        if *close {
+          out.push('/');
+        }
+        out.push_str(pick(&ODD_TAGS, *tag));
+        out.push('>');
+      }
+      Token::Text { which } => out.push_str(pick(&TEXTS, *which)),
+      Token::Comment { unterminated } => {
+        out.push_str("<!-- c ");
+        if !*unterminated {
+          out.push_str("-->");
+        }
+      }
+      Token::Doctype => out.push_str("<!DOCTYPE html>"),
+      Token::StrayLt => out.push_str("a < b"),
+      Token::StrayGt => out.push('>'),
+      Token::UnclosedOpen { tag } => {
+        out.push('<');
+        out.push_str(pick(&TAGS, *tag));
+        out.push_str(" class=\"x");
+      }
+      Token::AttrNoValue { tag, attr } => {
+        out.push('<');
+        out.push_str(pick(&TAGS, *tag));
+        out.push(' ');
+        out.push_str(pick(&ATTR_NAMES, *attr));
+        out.push_str("=>");
+      }
+    }
+  }
+  out
+}
+
+fuzz_target!(|input: Input| {
+  let html = render(&input.tokens);
+
+  let plugins = input.minimal_plugins.then(|| PluginConfig {
+    filter: Some(FilterConfig {
+      include: None,
+      exclude: Some(vec!["nav".to_string(), "footer".to_string()]),
+      process_children: None,
+    }),
+    isolate_main: Some(IsolateMainConfig),
+    frontmatter: Some(FrontmatterConfig::default()),
+    tailwind: Some(TailwindConfig),
+    extraction: Some(ExtractionConfig {
+      selectors: vec!["h1".to_string(), "img[alt]".to_string()],
+    }),
+    tag_overrides: None,
+  });
+
+  let options = HTMLToMarkdownOptions {
+    origin: Some("https://example.com/base/".to_string()),
+    clean_urls: input.clean_all,
+    clean: input.clean_all.then(CleanConfig::all),
+    plugins,
+    wrap_width: input.wrap_width as usize,
+  };
+
+  let format = if input.plain_text {
+    OutputFormat::Text
+  } else {
+    OutputFormat::Markdown
+  };
+
+  let _ = html_to_format_result(&html, options.clone(), format);
+
+  let width = (input.chunk_width as usize).max(1);
+  let mut processor = MarkdownStreamProcessor::new_with_format(options, format);
+  let mut start = 0;
+  while start < html.len() {
+    let mut end = (start + width).min(html.len());
+    while end < html.len() && !html.is_char_boundary(end) {
+      end += 1;
+    }
+    let _ = processor.process_chunk(&html[start..end]);
+    start = end;
+  }
+  let _ = processor.finish();
+});

--- a/crates/core/fuzz/html.dict
+++ b/crates/core/fuzz/html.dict
@@ -1,0 +1,146 @@
+# libFuzzer dictionary for the byte-oriented HTML targets.
+#
+# Without it a mutator spends most of its budget rediscovering that input has
+# to start with '<' to reach anything past the tokenizer. Tokens are inserted
+# and spliced into the raw input, so this also feeds the Arbitrary-derived
+# targets through their String fields.
+#
+# Pass with: cargo fuzz run <target> -- -dict=fuzz/html.dict
+
+# ── structure ──
+"<html>"
+"<head>"
+"<body>"
+"<main>"
+"<article>"
+"<section>"
+"<nav>"
+"<footer>"
+"<header>"
+"<div>"
+"</div>"
+"<span>"
+"</span>"
+"<p>"
+"</p>"
+
+# ── headings, where slug and buffer offsets are recorded ──
+"<h1>"
+"</h1>"
+"<h2>"
+"<h4>"
+"</h4>"
+"<h6>"
+
+# ── inline formatting ──
+"<strong>"
+"</strong>"
+"<em>"
+"<b>"
+"<i>"
+"<del>"
+"<sup>"
+"<sub>"
+"<code>"
+"</code>"
+"<pre>"
+"</pre>"
+"<blockquote>"
+"</blockquote>"
+
+# ── lists ──
+"<ul>"
+"<ol>"
+"<li>"
+"</li>"
+"<dl>"
+"<dt>"
+"<dd>"
+
+# ── tables ──
+"<table>"
+"<thead>"
+"<tbody>"
+"<tr>"
+"<th>"
+"<td>"
+"</td>"
+"colspan=\"2\""
+"rowspan=\"9999\""
+
+# ── links and media ──
+"<a href=\"/rel\">"
+"<a href=\"https://example.com\">"
+"<a href=\"#frag\">"
+"</a>"
+"<img src=\"/x.png\" alt=\"a\">"
+"<picture>"
+"<source>"
+"<svg>"
+
+# ── raw text and void elements, which suspend normal tokenizing ──
+"<script>"
+"</script>"
+"<style>"
+"</style>"
+"<textarea>"
+"<template>"
+"<title>"
+"<br>"
+"<hr>"
+"<meta charset=\"utf-8\">"
+"<link rel=\"canonical\">"
+
+# ── attributes ──
+" class=\""
+" id=\""
+" hidden"
+" aria-hidden=\"true\""
+"class=\"sr-only\""
+"class=\"line-through font-bold\""
+"style=\"display:none\""
+
+# ── malformed markup the tokenizer has to resynchronise from ──
+"<"
+">"
+"</"
+"< "
+"<>"
+"</>"
+"<!--"
+"-->"
+"<!-- unterminated"
+"<!DOCTYPE html>"
+"<![CDATA["
+"<div class=\"x"
+"<div =>"
+"<DIV>"
+"<my-widget>"
+"< div>"
+"</ div>"
+
+# ── entities ──
+"&amp;"
+"&lt;"
+"&gt;"
+"&quot;"
+"&nbsp;"
+"&#x1F600;"
+"&#65;"
+"&#xZZ;"
+"&notanentity;"
+"&"
+"&#"
+
+# ── text that interacts with Markdown escaping ──
+"\x0a\x0a"
+"\x0d\x0a"
+"*"
+"_"
+"`"
+"|"
+"# "
+"> "
+"- "
+"[]("
+"\x00"


### PR DESCRIPTION
### 🔗 Linked issue

Related to #195, related to #200

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Two parts: the weekly job never ran, and once it runs it should spend its 300s inside the parser rather than outside it.

#### 1. The job has never passed

Added in #126 on 2026-07-15, three scheduled runs (07-20, 07-27, 08-03), all five targets failing in every one, before fuzzing starts:

```
info: install-action does not support cargo-fuzz (updating install-action might resolve this); fallback to cargo-binstall
error: sanitizer is incompatible with statically linked libc, disable it using `-C target-feature=-crt-static`
error[E0463]: can't find crate for `std`
Error: failed to build fuzz script: ... "cargo" "build" ... "--target" "x86_64-unknown-linux-musl" ...
```

install-action dropped cargo-fuzz, so it falls back to cargo-binstall, which fetches the musl-linked build. cargo-fuzz defaults `--target` to its own build triple, so the fuzzers were being built for `x86_64-unknown-linux-musl`, where the sanitizer cannot link against a static libc.

- pin `--target x86_64-unknown-linux-gnu`, which holds regardless of how cargo-fuzz was installed
- add `rust-src` to the nightly toolchain, in case cargo-fuzz passes `-Zbuild-std`
- cache `corpus/` per target. It is gitignored, so every weekly run was starting cold

#### 2. An HTML preset for the fuzzers

The byte-oriented targets have to rediscover HTML from random bytes, so most of a run is spent on inputs the tokenizer rejects in its first branch. Two additions:

- **`fuzz/html.dict`**, a libFuzzer dictionary of tags, attributes, entities and malformed fragments (`<div class="x`, `</ div>`, `<!-- unterminated`, `&#xZZ;`). Passed to every target; tokens are spliced into the raw input, so the `Arbitrary`-derived targets get it through their `String` fields too.
- **`fuzz_html_grammar`**, a structure-aware target that emits a flat token stream (open, close, self-closing, void, stray `<`, unclosed attribute, `=` with no value) over a vocabulary chosen for handlers that behave differently: raw-text elements, void elements, table and list structure, unknown tags, case variants. Because tokens are emitted flat rather than as a tree, unbalanced and mismatched markup falls out on its own. It runs each document through both the one-shot and the streaming path at a fuzzer-chosen chunk width.

The byte-oriented targets stay. A grammar only produces what it knows about, so it cannot replace random bytes, only spend more time past the tokenizer.

**Measured on cold corpora, 90s each, same machine:**

| setup | runs | cov (edges) | ft (features) |
|---|---|---|---|
| `fuzz_html_to_markdown`, no dict | 2,498,451 | 3,650 | 15,701 |
| `fuzz_html_to_markdown`, with dict | 1,875,977 | 4,954 (+36%) | 20,514 (+31%) |
| `fuzz_html_grammar` | 935,812 | 5,784 (+58%) | 24,657 (+57%) |

The grammar target reaches the most coverage on a third of the executions.

**It also finds real bugs.** Run against `main` for 420s, `fuzz_html_grammar` independently rediscovered the panic #200 fixes:

```
thread panicked at crates/core/src/convert/output.rs:896:
start byte index 27 is out of bounds of `*emphasis* _under_ `tick``
```

Confirmed clean on #200's branch. No crash input is committed here, since #200 already carries a seed for that bug.

**Merge order:** independent of #200, but both touch `fuzz.yml` and `fuzz/Cargo.toml`, so whichever lands second needs a trivial rebase (the matrix gains both `fuzz_html_grammar` and `fuzz_streaming_options`).

Worth a manual `workflow_dispatch` once this lands rather than waiting for Monday, since the musl half of the failure cannot be reproduced locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added expanded automated fuzz testing for HTML and Markdown conversion.
  * Coverage now includes malformed markup, streaming conversion, sanitization, URL handling, plugins, and edge-case HTML inputs.
  * Added reusable HTML test data to improve detection of parsing and conversion issues.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->