### PR TITLE
fix(rust): make streaming output match one-shot

### DIFF
--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -441,6 +441,10 @@ pub struct ConvertState {
   /// newlines at the document start. When a later rewrite trims the buffer
   /// empty, spacing and newline counts still see the one-shot context.
   flushed_tail: [u8; 2],
+  /// Whether `flushed_tail` describes real removed bytes. Output can be yielded
+  /// without the buffer being cut, and until a cut happens `flushed_tail` is
+  /// still the document-start sentinel, which no consumer may read as context.
+  flushed_tail_valid: bool,
   /// First non-blank byte of the current line when draining has removed that
   /// line's start, so line-leading questions survive the cut. `None` means the
   /// retained buffer still holds the whole line (or its lead is still blank).
@@ -606,6 +610,7 @@ impl ConvertState {
       last_yielded_length: 0,
       has_streamed_output: false,
       flushed_tail: [b'\n'; 2],
+      flushed_tail_valid: false,
       cut_line_lead: None,
       buffer_start_column: 0,
       #[cfg(test)]
@@ -1450,6 +1455,7 @@ impl ConvertState {
       };
     }
     let bytes = self.buffer.as_bytes();
+    self.flushed_tail_valid = true;
     self.flushed_tail = if drain_end >= 2 {
       [bytes[drain_end - 2], bytes[drain_end - 1]]
     } else {

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -122,6 +122,16 @@ fn trailing_spaces(bytes: &[u8]) -> usize {
       .map_or(0, |i| i + 1)
 }
 
+#[inline]
+fn trim_ascii_whitespace_end(value: &str) -> usize {
+  let bytes = value.as_bytes();
+  let mut len = bytes.len();
+  while len > 0 && bytes[len - 1].is_ascii_whitespace() {
+    len -= 1;
+  }
+  len
+}
+
 /// What the current output line holds where a table row is about to be written.
 enum LineBeforeRow {
   /// Nothing but block prefix, or a pending list marker.
@@ -129,6 +139,16 @@ enum LineBeforeRow {
   /// A row left open mid-line.
   Row,
   /// Other content, so the row needs a block break to become a table.
+  Content,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+#[repr(u8)]
+enum CutLineLead {
+  Uncut,
+  Blank,
+  RawHtml,
+  Row,
   Content,
 }
 
@@ -441,16 +461,6 @@ pub struct ConvertState {
   /// newlines at the document start. When a later rewrite trims the buffer
   /// empty, spacing and newline counts still see the one-shot context.
   flushed_tail: [u8; 2],
-  /// Whether `flushed_tail` describes real removed bytes. Output can be yielded
-  /// without the buffer being cut, and until a cut happens `flushed_tail` is
-  /// still the document-start sentinel, which no consumer may read as context.
-  flushed_tail_valid: bool,
-  /// First non-blank byte of the current line when draining has removed that
-  /// line's start, so line-leading questions survive the cut. `None` means the
-  /// retained buffer still holds the whole line (or its lead is still blank).
-  /// Rescanning `buffer` for a line start is wrong once a drain has happened;
-  /// this is the same trick as `flushed_tail`, one step further back.
-  cut_line_lead: Option<u8>,
   /// Output column immediately before `buffer[0]`. Draining may remove the
   /// beginning of the current line, but wrapping still needs its full column.
   buffer_start_column: usize,
@@ -518,6 +528,12 @@ pub struct ConvertState {
   empty_item_len: usize,
   /// A list item rule waiting to see whether visible content follows it.
   list_rule_pending: bool,
+  /// What leads the current line when draining has removed that line's start.
+  /// `Uncut` also says `flushed_tail` still holds its document-start sentinel;
+  /// yielding alone does not make that context valid.
+  /// Rescanning `buffer` for a line start is wrong once a drain has happened;
+  /// this is the same trick as `flushed_tail`, one step further back.
+  cut_line_lead: CutLineLead,
   #[cfg(test)]
   gfm_escape_slow_path_calls: usize,
 }
@@ -610,8 +626,7 @@ impl ConvertState {
       last_yielded_length: 0,
       has_streamed_output: false,
       flushed_tail: [b'\n'; 2],
-      flushed_tail_valid: false,
-      cut_line_lead: None,
+      cut_line_lead: CutLineLead::Uncut,
       buffer_start_column: 0,
       #[cfg(test)]
       disable_drain: false,
@@ -1161,10 +1176,7 @@ impl ConvertState {
   pub fn get_markdown(&mut self) -> String {
     // ASCII whitespace only, as everywhere else: U+00A0 is content, and the
     // streaming path cannot un-send a nbsp it has already yielded.
-    let trimmed_end_len = self
-      .buffer
-      .trim_end_matches(|c: char| c.is_ascii_whitespace())
-      .len();
+    let trimmed_end_len = trim_ascii_whitespace_end(&self.buffer);
     self.buffer.truncate(trimmed_end_len);
     let start = if self.preserve_leading_whitespace {
       0
@@ -1284,10 +1296,7 @@ impl ConvertState {
         // until its inline/code element closes. That close trims ASCII
         // whitespace, so hold the whole run rather than yielding bytes it may
         // retract later.
-        stable_end = self
-          .buffer
-          .trim_end_matches(|c: char| c.is_ascii_whitespace())
-          .len();
+        stable_end = trim_ascii_whitespace_end(&self.buffer);
       } else if stable_end < buf_len {
         // Other trailing spaces inside <pre> are significant code. A
         // line-leading run is the exception: list continuation indentation is
@@ -1410,11 +1419,13 @@ impl ConvertState {
     // Keep the tail a late rewrite may still touch, and never drop the `[` of an
     // open link (its close can rewrite from that offset).
     // Formatting also inspects the last two bytes to count existing newlines.
-    // Keep both, moving to a UTF-8 boundary if the tail starts in a code point.
+    // Keep enough for the widest GFM list marker too: up to three spaces, nine
+    // digits, a delimiter, and a trailing space. Row separation can then still
+    // recognize a marker after earlier output has drained.
     let mut retained_tail_start = self
       .buffer
       .len()
-      .saturating_sub(self.last_content_cache_len.max(2));
+      .saturating_sub(self.last_content_cache_len.max(14));
     while !self.buffer.is_char_boundary(retained_tail_start) {
       retained_tail_start -= 1;
     }
@@ -1459,8 +1470,13 @@ impl ConvertState {
           .saturating_add(drained.chars().count())
       };
     }
+    // The blank line that ends a raw-HTML region may sit in the bytes about to
+    // leave; dropped unscanned, the region never closes and keeps suspending the
+    // escapes one-shot writes.
+    if self.raw_html_scanned_to < drain_end && !self.raw_html_markdown && self.in_raw_html_block() {
+      self.track_raw_html_markdown_context(drain_end);
+    }
     let bytes = self.buffer.as_bytes();
-    self.flushed_tail_valid = true;
     self.flushed_tail = if drain_end >= 2 {
       [bytes[drain_end - 2], bytes[drain_end - 1]]
     } else {
@@ -1469,20 +1485,29 @@ impl ConvertState {
     // Remember what the line being cut leads with; a line opened before an
     // earlier drain keeps that answer across successive cuts.
     self.cut_line_lead = if bytes[drain_end - 1] == b'\n' {
-      None
+      CutLineLead::Blank
     } else {
       let (line, inherited) = match bytes[..drain_end].iter().rposition(|b| *b == b'\n') {
-        Some(at) => (&bytes[at + 1..drain_end], None),
+        Some(at) => (&bytes[at + 1..drain_end], CutLineLead::Blank),
         None => (&bytes[..drain_end], self.cut_line_lead),
       };
-      inherited.or_else(|| line.iter().copied().find(|b| !matches!(b, b' ' | b'\t')))
+      if matches!(
+        inherited,
+        CutLineLead::RawHtml | CutLineLead::Row | CutLineLead::Content
+      ) {
+        inherited
+      } else {
+        line
+          .iter()
+          .copied()
+          .find(|b| !matches!(b, b' ' | b'\t'))
+          .map_or(CutLineLead::Blank, |byte| match byte {
+            b'<' => CutLineLead::RawHtml,
+            b'|' => CutLineLead::Row,
+            _ => CutLineLead::Content,
+          })
+      }
     };
-    // The blank line that ends a raw-HTML region may sit in the bytes about to
-    // leave; dropped unscanned, the region never closes and keeps suspending the
-    // escapes one-shot writes.
-    if self.raw_html_scanned_to < drain_end && !self.raw_html_markdown && self.in_raw_html_block() {
-      self.track_raw_html_markdown_context();
-    }
     self.buffer.drain(..drain_end);
     self.last_yielded_length -= drain_end;
     self.link_bracket_pos = self.link_bracket_pos.saturating_sub(drain_end);

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -1466,6 +1466,12 @@ impl ConvertState {
       };
       inherited.or_else(|| line.iter().copied().find(|b| !matches!(b, b' ' | b'\t')))
     };
+    // The blank line that ends a raw-HTML region may sit in the bytes about to
+    // leave; dropped unscanned, the region never closes and keeps suspending the
+    // escapes one-shot writes.
+    if self.raw_html_scanned_to < drain_end && !self.raw_html_markdown && self.in_raw_html_block() {
+      self.track_raw_html_markdown_context();
+    }
     self.buffer.drain(..drain_end);
     self.last_yielded_length -= drain_end;
     self.link_bracket_pos = self.link_bracket_pos.saturating_sub(drain_end);

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -441,6 +441,12 @@ pub struct ConvertState {
   /// newlines at the document start. When a later rewrite trims the buffer
   /// empty, spacing and newline counts still see the one-shot context.
   flushed_tail: [u8; 2],
+  /// First non-blank byte of the current line when draining has removed that
+  /// line's start, so line-leading questions survive the cut. `None` means the
+  /// retained buffer still holds the whole line (or its lead is still blank).
+  /// Rescanning `buffer` for a line start is wrong once a drain has happened;
+  /// this is the same trick as `flushed_tail`, one step further back.
+  cut_line_lead: Option<u8>,
   /// Output column immediately before `buffer[0]`. Draining may remove the
   /// beginning of the current line, but wrapping still needs its full column.
   buffer_start_column: usize,
@@ -600,6 +606,7 @@ impl ConvertState {
       last_yielded_length: 0,
       has_streamed_output: false,
       flushed_tail: [b'\n'; 2],
+      cut_line_lead: None,
       buffer_start_column: 0,
       #[cfg(test)]
       disable_drain: false,
@@ -1447,6 +1454,17 @@ impl ConvertState {
       [bytes[drain_end - 2], bytes[drain_end - 1]]
     } else {
       [self.flushed_tail[1], bytes[0]]
+    };
+    // Remember what the line being cut leads with; a line opened before an
+    // earlier drain keeps that answer across successive cuts.
+    self.cut_line_lead = if bytes[drain_end - 1] == b'\n' {
+      None
+    } else {
+      let (line, inherited) = match bytes[..drain_end].iter().rposition(|b| *b == b'\n') {
+        Some(at) => (&bytes[at + 1..drain_end], None),
+        None => (&bytes[..drain_end], self.cut_line_lead),
+      };
+      inherited.or_else(|| line.iter().copied().find(|b| !matches!(b, b' ' | b'\t')))
     };
     self.buffer.drain(..drain_end);
     self.last_yielded_length -= drain_end;

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -1159,7 +1159,12 @@ impl ConvertState {
   }
 
   pub fn get_markdown(&mut self) -> String {
-    let trimmed_end_len = self.buffer.trim_end().len();
+    // ASCII whitespace only, as everywhere else: U+00A0 is content, and the
+    // streaming path cannot un-send a nbsp it has already yielded.
+    let trimmed_end_len = self
+      .buffer
+      .trim_end_matches(|c: char| c.is_ascii_whitespace())
+      .len();
     self.buffer.truncate(trimmed_end_len);
     let start = if self.preserve_leading_whitespace {
       0

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -2887,9 +2887,13 @@ impl ConvertState {
 
   fn line_state_before_row(&self) -> LineBeforeRow {
     let bytes = self.buffer.as_bytes();
+    // An empty buffer is a fresh line only while no drain has taken this line's
+    // beginning: afterwards `flushed_tail` is what the row follows, so the
+    // emptied buffer has to fall through to the drain-aware scan below.
+    let line_lead_drained = self.has_streamed_output && self.flushed_tail[1] != b'\n';
     // Rows end their line, so the row after a row decides on one byte and never
     // rescans the line it just wrote.
-    if matches!(bytes.last(), None | Some(b'\n')) {
+    if matches!(bytes.last(), Some(b'\n')) || (bytes.is_empty() && !line_lead_drained) {
       return LineBeforeRow::Open;
     }
     let mut index = bytes.len();
@@ -2901,12 +2905,26 @@ impl ConvertState {
       .iter()
       .position(|byte| !matches!(byte, b' ' | b'\t'))
       .unwrap_or(line.len());
-    match line.get(start) {
+    // `index == 0` means the scan ran out of buffer, not that the line starts
+    // here: a drain may have taken the beginning of this line away. Trusting the
+    // fragment reads an open row as content and separates it with a blank line,
+    // which ends the GFM table and ejects every row after it.
+    let cut_lead = if index == 0 && line_lead_drained {
+      self.cut_line_lead
+    } else {
+      None
+    };
+    match cut_lead.as_ref().or_else(|| line.get(start)) {
       Some(b'|') => LineBeforeRow::Row,
       None => LineBeforeRow::Open,
       // A pending list marker is block prefix, not content: a table's first row
       // belongs on it.
-      Some(_) if self.list_marker_line_start(bytes, bytes.len() - trailing_spaces(bytes)) => {
+      // A drain can empty the buffer entirely; the marker scan needs a byte to
+      // start from, and a fully drained line has none to offer.
+      Some(_)
+        if !bytes.is_empty()
+          && self.list_marker_line_start(bytes, bytes.len() - trailing_spaces(bytes)) =>
+      {
         LineBeforeRow::Open
       }
       Some(_) => LineBeforeRow::Content,

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -1598,6 +1598,20 @@ impl ConvertState {
     if tail.is_empty() && !at_exit {
       return;
     }
+    // An open inline marker, and an open `<a>`'s `[`, are rewritten away if the
+    // element closes empty, so neither is content the item can be decided on —
+    // only its exit is. It must open exactly at the item's content start;
+    // anything earlier is content that already settles the question.
+    let opens_the_item = |position: usize| position == end;
+    if !at_exit
+      && (self
+        .open_markers
+        .first()
+        .is_some_and(|&(_, position, _)| opens_the_item(position))
+        || (self.depth_map[TAG_A as usize] > 0 && opens_the_item(self.link_bracket_pos)))
+    {
+      return;
+    }
     self.empty_item_hazard = false;
     if !tail.is_empty() && !tail.starts_with('\n') {
       return;

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -1921,14 +1921,27 @@ impl ConvertState {
   /// or `None` when the buffer already sits there.
   fn block_open_prefix(&self, prefix: &str) -> Option<Cow<'static, str>> {
     let bytes = self.buffer.as_bytes();
+    // An emptied buffer is the start of the output only while no drain has taken
+    // this line away; afterwards `flushed_tail` holds what the block would be
+    // glued to. A space there is the ambiguous case the `Some(b' ')` arm below
+    // resolves by scanning, which a drained line no longer offers, so leave it to
+    // the arm's conservative answer rather than guess a separator.
+    let drained_onto_content =
+      self.flushed_tail_valid && !matches!(self.flushed_tail[1], b'\n' | b' ');
     match bytes.last() {
+      None if drained_onto_content => Some(Cow::Owned(format!("\n\n{prefix}"))),
       None => None,
       Some(b' ') => {
         // A trailing space can be a pending list marker already at the content
         // column, or ordinary text (`"item "`) that still has to break as a
         // paragraph. Only the former needs no separator.
         let end = bytes.len() - trailing_spaces(bytes);
-        if end > 0 && bytes[end - 1] != b'\n' && !self.list_marker_line_start(bytes, end) {
+        if end == 0 {
+          // Every retained byte is a space, so the line's content — and the
+          // marker scan's starting point — left with the drain.
+          return drained_onto_content.then(|| Cow::Owned(format!("\n\n{prefix}")));
+        }
+        if bytes[end - 1] != b'\n' && !self.list_marker_line_start(bytes, end) {
           Some(Cow::Owned(format!("\n\n{prefix}")))
         } else {
           None

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -106,6 +106,11 @@ fn parse_bounded_u32(value: &str, max: u32) -> Option<u32> {
 
 impl ConvertState {
   #[inline]
+  fn has_flushed_tail(&self) -> bool {
+    self.cut_line_lead != CutLineLead::Uncut
+  }
+
+  #[inline]
   fn inline_marker_type(tag_id: u8) -> Option<u8> {
     // The kind is the delimiter identity: one value per distinct delimiter
     // string, so tags sharing a delimiter share a kind.
@@ -255,10 +260,7 @@ impl ConvertState {
     let Some(frame) = self.blockquotes.pop() else {
       return;
     };
-    let content_end = self
-      .buffer
-      .trim_end_matches(|c: char| c.is_ascii_whitespace())
-      .len();
+    let content_end = trim_ascii_whitespace_end(&self.buffer);
     // An empty range means "no content" only while none of it has left the
     // buffer. `has_streamed_output` is global, so reading it here drops the `>`
     // of a genuinely empty blockquote that one-shot emits.
@@ -1203,7 +1205,7 @@ impl ConvertState {
     let buf_len = buf_bytes.len();
     let last_char = if buf_len > 0 {
       buf_bytes[buf_len - 1]
-    } else if self.flushed_tail_valid {
+    } else if self.has_flushed_tail() {
       // The buffer was drained (and possibly trimmed) empty, but earlier output
       // ended with this byte. Spacing must be decided against it, not `0`, so a
       // word separator that one-shot keeps is not dropped across the boundary.
@@ -1279,7 +1281,7 @@ impl ConvertState {
 
     let inside_raw_html_block = self.in_raw_html_block();
     if inside_raw_html_block {
-      self.track_raw_html_markdown_context();
+      self.track_raw_html_markdown_context(self.buffer.len());
     } else {
       self.raw_html_markdown = false;
       self.raw_html_scanned_to = self.buffer.len();
@@ -1559,7 +1561,7 @@ impl ConvertState {
       spaces += 1;
     }
     if index == 0 {
-      return !self.flushed_tail_valid || self.flushed_tail[1] == b'\n';
+      return !self.has_flushed_tail() || self.flushed_tail[1] == b'\n';
     }
     bytes[index - 1] == b'\n'
   }
@@ -1586,7 +1588,7 @@ impl ConvertState {
     let before = |offset: usize| -> u8 {
       match line_start.checked_sub(offset) {
         Some(at) => bytes[at],
-        None if self.flushed_tail_valid => self.flushed_tail[2 - (offset - line_start)],
+        None if self.has_flushed_tail() => self.flushed_tail[2 - (offset - line_start)],
         None => 0,
       }
     };
@@ -1864,7 +1866,7 @@ impl ConvertState {
   fn last_output_byte(&self) -> Option<u8> {
     match self.buffer.as_bytes().last().copied() {
       Some(byte) => Some(byte),
-      None if self.flushed_tail_valid => Some(self.flushed_tail[1]),
+      None if self.has_flushed_tail() => Some(self.flushed_tail[1]),
       None => None,
     }
   }
@@ -1880,14 +1882,22 @@ impl ConvertState {
 
   #[inline]
   /// Note whether the open raw-HTML region has been broken by a blank line.
-  pub(super) fn track_raw_html_markdown_context(&mut self) {
+  pub(super) fn track_raw_html_markdown_context(&mut self, end: usize) {
     if self.raw_html_markdown {
       return;
     }
-    let len = self.buffer.len();
+    let len = end.min(self.buffer.len());
+    if self.raw_html_scanned_to == 0
+      && self.has_flushed_tail()
+      && self.flushed_tail[1] == b'\n'
+      && self.buffer.as_bytes().first() == Some(&b'\n')
+    {
+      self.raw_html_markdown = true;
+      return;
+    }
     // Byte scanning, so a resume point inside a multi-byte character is fine.
     let from = self.raw_html_scanned_to.min(len).saturating_sub(1);
-    if self.buffer.as_bytes()[from..]
+    if self.buffer.as_bytes()[from..len]
       .windows(2)
       .any(|pair| pair == b"\n\n")
     {
@@ -1920,8 +1930,8 @@ impl ConvertState {
     // a drain has taken this line's beginning: the fragment left behind can open
     // with a tag the real line only continues, which suspends Markdown and drops
     // the escapes a one-shot conversion writes.
-    if self.line_start == 0 && self.flushed_tail_valid && self.flushed_tail[1] != b'\n' {
-      return self.cut_line_lead == Some(b'<');
+    if self.line_start == 0 && self.has_flushed_tail() && self.flushed_tail[1] != b'\n' {
+      return self.cut_line_lead == CutLineLead::RawHtml;
     }
     let line = &bytes[self.line_start..len];
     let indent = line
@@ -1953,7 +1963,12 @@ impl ConvertState {
   }
 
   pub(crate) fn in_raw_html_block(&self) -> bool {
-    self.raw_html_block_depth() > 0
+    self.depth_map[TAG_DETAILS as usize] > 0
+      || self.depth_map[TAG_SUMMARY as usize] > 0
+      || self.depth_map[TAG_ADDRESS as usize] > 0
+      || self.depth_map[TAG_DL as usize] > 0
+      || self.depth_map[TAG_DT as usize] > 0
+      || self.depth_map[TAG_DD as usize] > 0
   }
 
   /// Character count of the current (unterminated) buffer line, i.e. since the
@@ -1984,7 +1999,7 @@ impl ConvertState {
     // resolves by scanning, which a drained line no longer offers, so leave it to
     // the arm's conservative answer rather than guess a separator.
     let drained_onto_content =
-      self.flushed_tail_valid && !matches!(self.flushed_tail[1], b'\n' | b' ');
+      self.has_flushed_tail() && !matches!(self.flushed_tail[1], b'\n' | b' ');
     match bytes.last() {
       None if drained_onto_content => Some(Cow::Owned(format!("\n\n{prefix}"))),
       None => None,
@@ -2706,7 +2721,7 @@ impl ConvertState {
     // anything precedes `buffer[0]`: until a drain actually cuts, `flushed_tail`
     // still holds its document-start sentinel and reading it invents a newline
     // that suppresses half of a block separator.
-    let tail_known = self.flushed_tail_valid;
+    let tail_known = self.has_flushed_tail();
     let last_char = if buf_len > 0 {
       buf_bytes[buf_len - 1]
     } else if tail_known {
@@ -2822,9 +2837,7 @@ impl ConvertState {
             // set: a trailing U+00A0 (`&nbsp;`) is meaningful content, and once
             // streaming has yielded it the truncation can't un-send its bytes,
             // so the reach-back would drop the next text's leading char.
-            let trimmed_len = frag
-              .trim_end_matches(|c: char| c.is_ascii_whitespace())
-              .len();
+            let trimmed_len = trim_ascii_whitespace_end(frag);
             if start + trimmed_len < buf_len {
               self.buffer.truncate(start + trimmed_len);
               if !is_enter && is_inline {
@@ -2986,7 +2999,7 @@ impl ConvertState {
     // An empty buffer is a fresh line only while no drain has taken this line's
     // beginning: afterwards `flushed_tail` is what the row follows, so the
     // emptied buffer has to fall through to the drain-aware scan below.
-    let line_lead_drained = self.flushed_tail_valid && self.flushed_tail[1] != b'\n';
+    let line_lead_drained = self.has_flushed_tail() && self.flushed_tail[1] != b'\n';
     // Rows end their line, so the row after a row decides on one byte and never
     // rescans the line it just wrote.
     if matches!(bytes.last(), Some(b'\n')) || (bytes.is_empty() && !line_lead_drained) {
@@ -3005,12 +3018,14 @@ impl ConvertState {
     // here: a drain may have taken the beginning of this line away. Trusting the
     // fragment reads an open row as content and separates it with a blank line,
     // which ends the GFM table and ejects every row after it.
-    let cut_lead = if index == 0 && line_lead_drained {
-      self.cut_line_lead
-    } else {
-      None
-    };
-    match cut_lead.as_ref().or_else(|| line.get(start)) {
+    if index == 0 && line_lead_drained {
+      match self.cut_line_lead {
+        CutLineLead::Row => return LineBeforeRow::Row,
+        CutLineLead::RawHtml | CutLineLead::Content => return LineBeforeRow::Content,
+        CutLineLead::Uncut | CutLineLead::Blank => {}
+      }
+    }
+    match line.get(start) {
       Some(b'|') => LineBeforeRow::Row,
       None => LineBeforeRow::Open,
       // A pending list marker is block prefix, not content: a table's first row
@@ -3063,7 +3078,7 @@ impl ConvertState {
 
 #[cfg(test)]
 mod tests {
-  use super::ConvertState;
+  use super::{ConvertState, CutLineLead};
   use crate::types::{HTMLToMarkdownOptions, OutputFormat};
 
   #[test]
@@ -3072,7 +3087,7 @@ mod tests {
     state.has_streamed_output = true;
     // A drain is what puts bytes behind `buffer[0]`; yielding alone does not, and
     // the counting below may only read `flushed_tail` once one has happened.
-    state.flushed_tail_valid = true;
+    state.cut_line_lead = CutLineLead::Blank;
     state.flushed_tail = [b'\n', b'\n'];
 
     state.write_output(true, false, 2, Some("next"), false);
@@ -3104,7 +3119,7 @@ mod tests {
 
     state.has_streamed_output = true;
     // A drain is what puts bytes behind `buffer[0]`; yielding alone does not.
-    state.flushed_tail_valid = true;
+    state.cut_line_lead = CutLineLead::Content;
     state.flushed_tail = *b"xy";
     assert_eq!(state.last_output_byte(), Some(b'y'));
 

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -1838,7 +1838,7 @@ impl ConvertState {
 
   #[inline]
   /// Note whether the open raw-HTML region has been broken by a blank line.
-  fn track_raw_html_markdown_context(&mut self) {
+  pub(super) fn track_raw_html_markdown_context(&mut self) {
     if self.raw_html_markdown {
       return;
     }
@@ -1874,6 +1874,13 @@ impl ConvertState {
     }
     self.line_start_scanned_to = len;
 
+    // A `line_start` of zero is the drained buffer's front, not the line's, once
+    // a drain has taken this line's beginning: the fragment left behind can open
+    // with a tag the real line only continues, which suspends Markdown and drops
+    // the escapes a one-shot conversion writes.
+    if self.line_start == 0 && self.has_streamed_output && self.flushed_tail[1] != b'\n' {
+      return self.cut_line_lead == Some(b'<');
+    }
     let line = &bytes[self.line_start..len];
     let indent = line
       .iter()

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -259,8 +259,12 @@ impl ConvertState {
       .buffer
       .trim_end_matches(|c: char| c.is_ascii_whitespace())
       .len();
+    // An empty range means "no content" only while none of it has left the
+    // buffer. `has_streamed_output` is global, so reading it here drops the `>`
+    // of a genuinely empty blockquote that one-shot emits.
+    let content_left_buffer = self.last_yielded_length > frame.content_start;
     if content_end < frame.content_start
-      || (content_end == frame.content_start && self.has_streamed_output)
+      || (content_end == frame.content_start && content_left_buffer)
     {
       return;
     }

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -1186,7 +1186,7 @@ impl ConvertState {
     let buf_len = buf_bytes.len();
     let last_char = if buf_len > 0 {
       buf_bytes[buf_len - 1]
-    } else if self.has_streamed_output {
+    } else if self.flushed_tail_valid {
       // The buffer was drained (and possibly trimmed) empty, but earlier output
       // ended with this byte. Spacing must be decided against it, not `0`, so a
       // word separator that one-shot keeps is not dropped across the boundary.
@@ -1542,7 +1542,7 @@ impl ConvertState {
       spaces += 1;
     }
     if index == 0 {
-      return !self.has_streamed_output || self.flushed_tail[1] == b'\n';
+      return !self.flushed_tail_valid || self.flushed_tail[1] == b'\n';
     }
     bytes[index - 1] == b'\n'
   }
@@ -1569,7 +1569,7 @@ impl ConvertState {
     let before = |offset: usize| -> u8 {
       match line_start.checked_sub(offset) {
         Some(at) => bytes[at],
-        None if self.has_streamed_output => self.flushed_tail[2 - (offset - line_start)],
+        None if self.flushed_tail_valid => self.flushed_tail[2 - (offset - line_start)],
         None => 0,
       }
     };
@@ -1822,7 +1822,7 @@ impl ConvertState {
   fn last_output_byte(&self) -> Option<u8> {
     match self.buffer.as_bytes().last().copied() {
       Some(byte) => Some(byte),
-      None if self.has_streamed_output => Some(self.flushed_tail[1]),
+      None if self.flushed_tail_valid => Some(self.flushed_tail[1]),
       None => None,
     }
   }
@@ -1878,7 +1878,7 @@ impl ConvertState {
     // a drain has taken this line's beginning: the fragment left behind can open
     // with a tag the real line only continues, which suspends Markdown and drops
     // the escapes a one-shot conversion writes.
-    if self.line_start == 0 && self.has_streamed_output && self.flushed_tail[1] != b'\n' {
+    if self.line_start == 0 && self.flushed_tail_valid && self.flushed_tail[1] != b'\n' {
       return self.cut_line_lead == Some(b'<');
     }
     let line = &bytes[self.line_start..len];
@@ -2632,18 +2632,23 @@ impl ConvertState {
     // `flushed_tail` contains the two bytes immediately before `buffer[0]`.
     // Without that context a separator that one-shot trims to one newline can
     // be emitted as two in streaming (e.g. a lone `-` at the buffer start).
+    // Yielding does not remove bytes, so `has_streamed_output` is no evidence that
+    // anything precedes `buffer[0]`: until a drain actually cuts, `flushed_tail`
+    // still holds its document-start sentinel and reading it invents a newline
+    // that suppresses half of a block separator.
+    let tail_known = self.flushed_tail_valid;
     let last_char = if buf_len > 0 {
       buf_bytes[buf_len - 1]
-    } else if self.has_streamed_output {
+    } else if tail_known {
       self.flushed_tail[1]
     } else {
       0
     };
     let second_last_char = if buf_len > 1 {
       buf_bytes[buf_len - 2]
-    } else if buf_len == 1 && self.has_streamed_output {
+    } else if buf_len == 1 && tail_known {
       self.flushed_tail[1]
-    } else if self.has_streamed_output {
+    } else if tail_known {
       self.flushed_tail[0]
     } else {
       0
@@ -2911,7 +2916,7 @@ impl ConvertState {
     // An empty buffer is a fresh line only while no drain has taken this line's
     // beginning: afterwards `flushed_tail` is what the row follows, so the
     // emptied buffer has to fall through to the drain-aware scan below.
-    let line_lead_drained = self.has_streamed_output && self.flushed_tail[1] != b'\n';
+    let line_lead_drained = self.flushed_tail_valid && self.flushed_tail[1] != b'\n';
     // Rows end their line, so the row after a row decides on one byte and never
     // rescans the line it just wrote.
     if matches!(bytes.last(), Some(b'\n')) || (bytes.is_empty() && !line_lead_drained) {
@@ -2995,11 +3000,28 @@ mod tests {
   fn empty_drained_buffer_counts_two_flushed_newlines() {
     let mut state = ConvertState::new(HTMLToMarkdownOptions::default(), 64, OutputFormat::Markdown);
     state.has_streamed_output = true;
+    // A drain is what puts bytes behind `buffer[0]`; yielding alone does not, and
+    // the counting below may only read `flushed_tail` once one has happened.
+    state.flushed_tail_valid = true;
     state.flushed_tail = [b'\n', b'\n'];
 
     state.write_output(true, false, 2, Some("next"), false);
 
     assert_eq!(state.buffer, "next");
+  }
+
+  // Yielded output that never drained leaves `buffer[0]` at the document start,
+  // where one-shot counts no preceding newlines. Reading the sentinel there
+  // suppresses half of every following block separator.
+  #[test]
+  fn undrained_buffer_counts_no_flushed_newlines() {
+    let mut state = ConvertState::new(HTMLToMarkdownOptions::default(), 64, OutputFormat::Markdown);
+    state.has_streamed_output = true;
+    state.buffer.push('c');
+
+    state.write_output(true, false, 2, Some("next"), false);
+
+    assert_eq!(state.buffer, "c\n\nnext");
   }
 
   // Draining, and then a rewrite trimming what draining retained, leaves the
@@ -3011,6 +3033,8 @@ mod tests {
     assert_eq!(state.last_output_byte(), None);
 
     state.has_streamed_output = true;
+    // A drain is what puts bytes behind `buffer[0]`; yielding alone does not.
+    state.flushed_tail_valid = true;
     state.flushed_tail = *b"xy";
     assert_eq!(state.last_output_byte(), Some(b'y'));
 

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -575,6 +575,19 @@ impl ConvertState {
       self.record_item_marker(self.stack[stack_len - 1].index, output_start);
     }
 
+    // The blank line that re-enables Markdown must be looked for *inside* the
+    // region. `raw_html_scanned_to` only moves on text nodes, so it still points
+    // before the region began and earlier block spacing is read as if inside,
+    // escaping text that is passed through verbatim: `\*` reaches the reader as a
+    // literal backslash.
+    if !self.plain_text
+      && tag_id.is_some_and(Self::is_raw_html_block_tag)
+      && self.raw_html_block_depth() == 1
+    {
+      self.raw_html_markdown = false;
+      self.raw_html_scanned_to = self.buffer.len();
+    }
+
     if !self.plain_text && !enter_is_literal && tag_id == Some(TAG_BLOCKQUOTE) {
       if !self.blockquotes.is_empty() && self.buffer.ends_with("\n\n") {
         self.buffer.pop();
@@ -1919,13 +1932,28 @@ impl ConvertState {
     line.get(indent) == Some(&b'<')
   }
 
+  /// Tags whose content is emitted as raw HTML, suspending Markdown until a
+  /// blank line inside the region re-enables it.
+  #[inline]
+  pub(crate) fn is_raw_html_block_tag(id: u8) -> bool {
+    matches!(
+      id,
+      TAG_DETAILS | TAG_SUMMARY | TAG_ADDRESS | TAG_DL | TAG_DT | TAG_DD
+    )
+  }
+
+  /// `1` at an enter means this tag begins the region.
+  fn raw_html_block_depth(&self) -> u32 {
+    u32::from(self.depth_map[TAG_DETAILS as usize])
+      + u32::from(self.depth_map[TAG_SUMMARY as usize])
+      + u32::from(self.depth_map[TAG_ADDRESS as usize])
+      + u32::from(self.depth_map[TAG_DL as usize])
+      + u32::from(self.depth_map[TAG_DT as usize])
+      + u32::from(self.depth_map[TAG_DD as usize])
+  }
+
   pub(crate) fn in_raw_html_block(&self) -> bool {
-    self.depth_map[TAG_DETAILS as usize] > 0
-      || self.depth_map[TAG_SUMMARY as usize] > 0
-      || self.depth_map[TAG_ADDRESS as usize] > 0
-      || self.depth_map[TAG_DL as usize] > 0
-      || self.depth_map[TAG_DT as usize] > 0
-      || self.depth_map[TAG_DD as usize] > 0
+    self.raw_html_block_depth() > 0
   }
 
   /// Character count of the current (unterminated) buffer line, i.e. since the

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -1616,10 +1616,18 @@ impl ConvertState {
     {
       return;
     }
-    self.empty_item_hazard = false;
+    // Content on the marker's own line settles it: no blank line is owed.
     if !tail.is_empty() && !tail.starts_with('\n') {
+      self.empty_item_hazard = false;
       return;
     }
+    // Otherwise only the item's own exit may act. A following `<li>` records a new
+    // marker and drops this pending one, which is how one-shot leaves `<li><li>`
+    // tight; the drain calling in early must not insert on its behalf.
+    if !at_exit {
+      return;
+    }
+    self.empty_item_hazard = false;
     self.buffer.insert(self.empty_item_line_start, '\n');
     // The insertion moves cached offsets at or past the line: an inline marker
     // still open across it measures emptiness from `content_start`, so left

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -1617,9 +1617,26 @@ impl ConvertState {
       return;
     }
     self.buffer.insert(self.empty_item_line_start, '\n');
-    // The insertion moves every cached buffer offset at or past the line.
+    // The insertion moves cached offsets at or past the line: an inline marker
+    // still open across it measures emptiness from `content_start`, so left
+    // unshifted it stops looking empty and streaming leaks markers one-shot drops.
+    //
+    // Not the blockquote frames. Their `content_start` marks where quote
+    // prefixing begins, which belongs *before* this newline; shifting it turns
+    // `- \n  >\n  > -` into `- \n\n  > -`, which GFM reads as the list's sibling
+    // rather than its child. `link_bracket_pos` needs no shift either — a pending
+    // `[` is the tail this function has already returned on.
+    let at = self.empty_item_line_start;
+    for (_, output_start, content_start) in &mut self.open_markers {
+      if *output_start >= at {
+        *output_start += 1;
+      }
+      if *content_start >= at {
+        *content_start += 1;
+      }
+    }
     self.line_start_scanned_to = usize::MAX;
-    self.raw_html_scanned_to = self.raw_html_scanned_to.min(self.empty_item_line_start);
+    self.raw_html_scanned_to = self.raw_html_scanned_to.min(at);
   }
 
   #[inline]

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -1141,3 +1141,19 @@ fn streaming_empty_blockquote_marker_matches_one_shot() {
     "*>*"
   );
 }
+
+// Draining resolves a pending marker guard early so it can release its hold. It
+// must not insert on the item's behalf: the very next `<li>` drops the pending
+// guard, which is how one-shot leaves `<li><li>` tight.
+#[test]
+fn streaming_marker_guard_defers_to_item_exit_matches_one_shot() {
+  for html in [
+    "<li><li><br /><ul><li>",
+    "<ul><li><ul><li><br /><ul><li>",
+    "<tr><li><br /><ul><li>",
+    "<td>d</td><li><br /><ul><li>",
+  ] {
+    assert_stream_matches(html, HTMLToMarkdownOptions::default());
+    assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
+  }
+}

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -1157,3 +1157,25 @@ fn streaming_marker_guard_defers_to_item_exit_matches_one_shot() {
     assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
   }
 }
+
+// Raw HTML is passed through verbatim, so a GFM escape written inside a raw
+// region is not an escape: the backslash reaches the reader. The blank line that
+// re-enables Markdown must be looked for inside the region, not before it.
+#[test]
+fn raw_html_region_text_is_not_gfm_escaped() {
+  for (html, expected) in [
+    (".<ul><li><dd>*", ".\n\n- <dd>*</dd>"),
+    ("<p>x</p><li><dd>_", "x\n\n- <dd>_</dd>"),
+    ("<caption>c</caption><tr><dd>*", "c\n\n| <dd>*</dd>\n |\n|"),
+    // Only inside the region: the leading `*` is still escaped.
+    ("*<ul><li><dd>_", "\\*\n\n- <dd>_</dd>"),
+  ] {
+    assert_eq!(
+      html_to_markdown(html, HTMLToMarkdownOptions::default()),
+      expected,
+      "one-shot for {html:?}"
+    );
+    assert_stream_matches(html, HTMLToMarkdownOptions::default());
+    assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
+  }
+}

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -952,6 +952,11 @@ fn streaming_table_row_after_drained_line_matches_one_shot() {
     // holds the drain boundary far enough to reach that state.
     "<i><div>.<br />\n<table><tr>",
     "<span><div>.<br />\n<table><tr>",
+    // The drained prefix is a complete list marker, not paragraph content.
+    "<i><li><br><li><tr>",
+    // Ordered markers remain recognizable when their leading digit would
+    // otherwise be the first byte drained.
+    "<ol><li><table><i></table><tr>",
   ] {
     assert_stream_matches(html, HTMLToMarkdownOptions::default());
     assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
@@ -989,6 +994,20 @@ fn streaming_raw_html_blank_line_drained_matches_one_shot() {
     assert_stream_matches(html, HTMLToMarkdownOptions::default());
     assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
   }
+}
+
+#[test]
+fn streaming_raw_html_ignores_rewritable_blockquote_separator() {
+  let html = "<dd>*<blockquote><blockquote>_";
+  assert_stream_matches(html, HTMLToMarkdownOptions::default());
+  assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
+}
+
+#[test]
+fn streaming_raw_html_keeps_stable_blank_line_context() {
+  let html = "<dd><ol><i><ol>_";
+  assert_stream_matches(html, HTMLToMarkdownOptions::default());
+  assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
 }
 
 // Every item's marker is immediately followed by a link and an emphasis, the

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -934,3 +934,18 @@ fn streaming_empty_item_with_open_marker_matches_one_shot() {
     assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
   }
 }
+
+// Past a blank line a raw-HTML region is Markdown again, tracked by scanning the
+// buffer for that blank line. A drain can carry those bytes away before the scan
+// reaches them, leaving the region suspended forever: streaming then omits every
+// escape one-shot writes there.
+#[test]
+fn streaming_raw_html_blank_line_drained_matches_one_shot() {
+  for html in [
+    "<dd><p>.<br />*<Foo/Bar>",
+    "<dd><tr><a href=\"u\" title=\"t\">_</html>",
+  ] {
+    assert_stream_matches(html, HTMLToMarkdownOptions::default());
+    assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
+  }
+}

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -967,3 +967,19 @@ fn streaming_block_separator_after_undrained_yield_matches_one_shot() {
     assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
   }
 }
+
+// A block opening inside a list item asks what its line already holds. An emptied
+// buffer is the start of the output only until a drain takes that line away;
+// afterwards the block is glued to text it should have broken away from.
+#[test]
+fn streaming_block_open_after_drained_line_matches_one_shot() {
+  for html in [
+    "<ul><li>.<br />\n<table><caption>c</caption><tr><td>d</td></tr></table>",
+    "<ol><li>.<br />\n<table><caption>c</caption><tr><td>d</td></tr></table>",
+    "<i><ul><li>.<br />\n<table><caption>c</caption><tr><td>d</td></tr></table>",
+    "<ul><li>t<ul><li>.<br />\n<table><caption>c</caption><tr><td>d</td></tr></table>",
+  ] {
+    assert_stream_matches(html, HTMLToMarkdownOptions::default());
+    assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
+  }
+}

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -895,3 +895,24 @@ fn streaming_empty_nested_item_marker_matches_one_shot() {
     assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
   }
 }
+
+// A table row's separator depends on what its line already holds, read by
+// scanning the buffer back to the last newline. A drain can take that line's
+// beginning — or the whole line — so the scan runs out of buffer and reads the
+// fragment as a fresh line: an open row is classified as content and separated
+// with a blank line, which ends the GFM table and ejects every row after it.
+#[test]
+fn streaming_table_row_after_drained_line_matches_one_shot() {
+  for html in [
+    // The line's beginning is drained, leaving a fragment of the open row.
+    "<ul><li><table><tr><td></td></tr><tr><td>d</td></tr><tr><td></td></tr></table></li></ul>",
+    // The line is drained entirely, so the buffer is empty where one-shot still
+    // sees the content the row must be separated from. An open inline element
+    // holds the drain boundary far enough to reach that state.
+    "<i><div>.<br />\n<table><tr>",
+    "<span><div>.<br />\n<table><tr>",
+  ] {
+    assert_stream_matches(html, HTMLToMarkdownOptions::default());
+    assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
+  }
+}

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -2,7 +2,7 @@
 #![allow(unsafe_code)]
 
 use std::alloc::{GlobalAlloc, Layout, System};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::cell::Cell;
 
 use mdream::MarkdownStreamProcessor;
 use mdream::html_to_markdown;
@@ -14,26 +14,79 @@ use mdream::types::{CleanConfig, HTMLToMarkdownOptions, PluginConfig, TagOverrid
 
 struct Tracking;
 
-static LIVE: AtomicUsize = AtomicUsize::new(0);
-static PEAK: AtomicUsize = AtomicUsize::new(0);
+/// Accounting is per-thread. Process-wide counters measure whatever else the
+/// harness is doing: tests run in parallel, and one building a multi-megabyte
+/// fixture lands in another's peak, so the bound has to be either loose enough
+/// to be meaningless or flaky. A thread only sees its own allocations, so two
+/// measurements can run at once.
+#[derive(Clone, Copy)]
+struct Acct {
+  on: bool,
+  live: isize,
+  peak: isize,
+}
+
+thread_local! {
+  static ACCT: Cell<Acct> = const {
+    Cell::new(Acct { on: false, live: 0, peak: 0 })
+  };
+}
+
+/// `try_with` because TLS is already gone late in thread teardown, and a `Cell`
+/// with a const initialiser never allocates, so this cannot recurse back into
+/// the allocator.
+fn account(delta: isize) {
+  let _ = ACCT.try_with(|cell| {
+    let mut acct = cell.get();
+    if !acct.on {
+      return;
+    }
+    acct.live += delta;
+    if acct.live > acct.peak {
+      acct.peak = acct.live;
+    }
+    cell.set(acct);
+  });
+}
 
 unsafe impl GlobalAlloc for Tracking {
   unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
     let p = unsafe { System.alloc(layout) };
     if !p.is_null() {
-      let live = LIVE.fetch_add(layout.size(), Ordering::Relaxed) + layout.size();
-      PEAK.fetch_max(live, Ordering::Relaxed);
+      account(layout.size() as isize);
     }
     p
   }
   unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-    LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+    account(-(layout.size() as isize));
     unsafe { System.dealloc(ptr, layout) };
   }
 }
 
 #[global_allocator]
 static ALLOC: Tracking = Tracking;
+
+/// Peak live bytes while `feed` runs, and the total output it produced. The
+/// output is dropped as it arrives, the way a wire consumer would.
+fn measure_peak(html: &str, chunk: usize, opts: HTMLToMarkdownOptions) -> (u64, u64) {
+  ACCT.set(Acct {
+    on: true,
+    live: 0,
+    peak: 0,
+  });
+  let mut p = MarkdownStreamProcessor::new(opts);
+  let mut total_out: u64 = 0;
+  for c in html.as_bytes().chunks(chunk) {
+    total_out += p.process_chunk(std::str::from_utf8(c).unwrap()).len() as u64;
+  }
+  total_out += p.finish().len() as u64;
+  let mut acct = ACCT.get();
+  acct.on = false;
+  ACCT.set(acct);
+  // Freeing something allocated before the measurement can drive `live`
+  // negative; the peak is what matters and it can only be >= 0.
+  (acct.peak.max(0) as u64, total_out)
+}
 
 fn safe_clean() -> CleanConfig {
   // Everything except `fragments`, which needs the whole buffer.
@@ -503,19 +556,7 @@ fn streaming_memory_is_bounded_not_document_sized() {
     html.push_str("<p>x</p>");
   }
 
-  let mut p = MarkdownStreamProcessor::new(HTMLToMarkdownOptions::default());
-  let mut total_out: u64 = 0;
-
-  // Keep LIVE as the allocator's true process-wide total. Resetting it here
-  // would make later deallocations for pre-existing allocations underflow.
-  let baseline = LIVE.load(Ordering::Relaxed);
-  PEAK.store(baseline, Ordering::Relaxed);
-  for c in html.as_bytes().chunks(8 * 1024) {
-    let out = p.process_chunk(std::str::from_utf8(c).unwrap());
-    total_out += out.len() as u64; // wire would send + drop this
-  }
-  total_out += p.finish().len() as u64;
-  let peak = PEAK.load(Ordering::Relaxed).saturating_sub(baseline) as u64;
+  let (peak, total_out) = measure_peak(&html, 8 * 1024, HTMLToMarkdownOptions::default());
 
   // Amplification really happened...
   assert!(
@@ -950,6 +991,69 @@ fn streaming_raw_html_blank_line_drained_matches_one_shot() {
   }
 }
 
+// Every item's marker is immediately followed by a link and an emphasis, the
+// shape that holds the empty-item decision open across a chunk boundary. That
+// hold pins the drain at the marker's line, so one that outlived its item would
+// retain the document instead of a window.
+#[test]
+fn streaming_memory_bounded_with_empty_item_marker_holds() {
+  let mut html = String::with_capacity(8 * 1024 * 1024 + 64);
+  html.push_str("<ul>");
+  while html.len() < 8 * 1024 * 1024 {
+    html.push_str("<li><li><a href=\"/u\">t</a><em>e</em>x</li>");
+  }
+  html.push_str("</ul>");
+
+  let (peak, total_out) = measure_peak(&html, 8 * 1024, HTMLToMarkdownOptions::default());
+
+  // The conversion really ran...
+  assert!(
+    total_out > 1024 * 1024,
+    "expected >1MB output, got {total_out}"
+  );
+  // ...and the hold released every item, so memory stayed a window. Measures
+  // ~9KB against an 8MB input; the bound is loose enough to absorb allocator
+  // and scheduling noise while still failing if the hold ever pins the document.
+  assert!(
+    peak < 1024 * 1024,
+    "peak {peak} should be a bounded window, not ~{} input",
+    html.len()
+  );
+}
+
+// The measurement must ignore other threads: tests run in parallel, and one
+// building a multi-megabyte fixture would otherwise land in another's peak.
+// Joining the allocating thread while this thread's window is still open is
+// what makes the overlap a fact rather than a matter of timing.
+#[test]
+fn memory_measurement_ignores_other_threads() {
+  ACCT.set(Acct {
+    on: true,
+    live: 0,
+    peak: 0,
+  });
+  let allocated = std::thread::spawn(|| {
+    let fixture = vec![7u8; 8 * 1024 * 1024];
+    std::hint::black_box(fixture.len())
+  })
+  .join()
+  .unwrap();
+  let mut acct = ACCT.get();
+  acct.on = false;
+  ACCT.set(acct);
+
+  assert_eq!(
+    allocated,
+    8 * 1024 * 1024,
+    "the other thread did not allocate"
+  );
+  assert!(
+    acct.peak < 64 * 1024,
+    "peak {} includes another thread's 8MB",
+    acct.peak
+  );
+}
+
 // Yielding does not remove bytes, but `has_streamed_output` is set as soon as any
 // are yielded. `flushed_tail` only describes real removed bytes, so reading it on
 // the strength of that flag invents a newline before `buffer[0]` and suppresses
@@ -982,4 +1086,35 @@ fn streaming_block_open_after_drained_line_matches_one_shot() {
     assert_stream_matches(html, HTMLToMarkdownOptions::default());
     assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
   }
+}
+
+// The newline an empty item inserts at its marker line moves every buffer offset
+// at or past it. An inline element still open across the insertion measures its
+// own emptiness from one of them, so leaving it unshifted stops an empty element
+// from looking empty and leaks the markers one-shot drops.
+#[test]
+fn streaming_open_marker_across_item_newline_matches_one_shot() {
+  for html in [
+    "<li><li><br /><i>",
+    "<li><li><br /><em>",
+    "<ul><li><ul><li><br /><i>",
+    "<tr><li><br /><i>",
+    ".<li><br /><i>",
+    "<ul><li><blockquote><ul><li>",
+  ] {
+    assert_stream_matches(html, HTMLToMarkdownOptions::default());
+    assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
+  }
+
+  // The blockquote frames must NOT be shifted with the rest: their
+  // `content_start` belongs before the inserted newline. Shifting it moves the
+  // quote out of the list item, and because that moves one-shot too, parity
+  // cannot see it — so pin the bytes a GFM parser reads back as `li > blockquote`.
+  assert_eq!(
+    html_to_markdown(
+      "<ul><li><blockquote><ul><li>",
+      HTMLToMarkdownOptions::default()
+    ),
+    "- \n  >\n  > -"
+  );
 }

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -916,3 +916,21 @@ fn streaming_table_row_after_drained_line_matches_one_shot() {
     assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
   }
 }
+
+// An empty `<li>`'s marker needs a newline inserted at its line start, decided
+// at the item's exit. An open inline marker, and an open `<a>`'s `[`, are both
+// dropped if their element closes empty, so neither is item content — but a
+// chunk boundary materialises them into the buffer, where the item read them as
+// content and resolved without the newline one-shot inserts.
+#[test]
+fn streaming_empty_item_with_open_marker_matches_one_shot() {
+  for html in [
+    "<li><li><i></li>",
+    "<li><li><a href=\"x\"></li>",
+    "<li><li><em></li>",
+    "<ul><li><li><i></li></ul>",
+  ] {
+    assert_stream_matches(html, HTMLToMarkdownOptions::default());
+    assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
+  }
+}

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -1179,3 +1179,24 @@ fn raw_html_region_text_is_not_gfm_escaped() {
     assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
   }
 }
+
+// The one-shot finaliser trimmed the buffer with `str::trim_end`, whose Unicode
+// set includes U+00A0. Everywhere else nbsp is content, and streaming cannot
+// un-send a nbsp it has already yielded, so one-shot deleted a trailing one that
+// streaming kept -- silently dropping content in the last case below.
+#[test]
+fn trailing_nbsp_is_content_and_matches_one_shot() {
+  for (html, expected) in [
+    ("<p>x</p><p>&nbsp;</p>", "x\n\n\u{a0}"),
+    ("<p>x</p><p>a&nbsp;</p>", "x\n\na\u{a0}"),
+    ("<p>hello&nbsp;world&nbsp;</p>", "hello\u{a0}world\u{a0}"),
+  ] {
+    assert_eq!(
+      html_to_markdown(html, HTMLToMarkdownOptions::default()),
+      expected,
+      "one-shot for {html:?}"
+    );
+    assert_stream_matches(html, HTMLToMarkdownOptions::default());
+    assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
+  }
+}

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -1118,3 +1118,26 @@ fn streaming_open_marker_across_item_newline_matches_one_shot() {
     "- \n  >\n  > -"
   );
 }
+
+// An empty blockquote's `>` was dropped for the rest of the document once
+// anything had been yielded, because the emptiness test read the global
+// `has_streamed_output` instead of asking about the frame's own range.
+#[test]
+fn streaming_empty_blockquote_marker_matches_one_shot() {
+  for html in [
+    "<i><blockquote>",
+    "<i>><blockquote>",
+    "<em>-<blockquote>",
+    "<table><dt><blockquote>",
+    "<tr><a href=\"u\"><blockquote>",
+  ] {
+    assert_stream_matches(html, HTMLToMarkdownOptions::default());
+    assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
+  }
+  // Parity alone cannot see this: both sides agreeing on a dropped `>` would
+  // pass. Pin the marker itself.
+  assert_eq!(
+    html_to_markdown("<i><blockquote>", HTMLToMarkdownOptions::default()),
+    "*>*"
+  );
+}

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -949,3 +949,21 @@ fn streaming_raw_html_blank_line_drained_matches_one_shot() {
     assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
   }
 }
+
+// Yielding does not remove bytes, but `has_streamed_output` is set as soon as any
+// are yielded. `flushed_tail` only describes real removed bytes, so reading it on
+// the strength of that flag invents a newline before `buffer[0]` and suppresses
+// half of the following block separator.
+#[test]
+fn streaming_block_separator_after_undrained_yield_matches_one_shot() {
+  for html in [
+    "<table><caption>c</caption>.",
+    "<table><p>x</p>.",
+    "<table><caption>c</caption><tr>",
+    "<td>d</td><table><tr>",
+    "<table><p>x</p><dd>",
+  ] {
+    assert_stream_matches(html, HTMLToMarkdownOptions::default());
+    assert_stream_matches_every_split(html, HTMLToMarkdownOptions::default());
+  }
+}


### PR DESCRIPTION
# fix(convert): make streaming output match one-shot

Streaming (`get_markdown_chunk`) and one-shot (`html_to_markdown`) can disagree on the same
input. This fixes every divergence I can find, and adds a helper that asserts parity at *every*
chunk boundary so they can't drift again.

## What I measured

I enumerated all HTML strings over two hand-picked token sets — 65,536 of length 4 and 17,576
of length 3, **83,112** total — and compared streaming against one-shot at several chunk sizes:

| | divergent inputs |
| --- | --- |
| `main` (9372e52) | **10,270** |
| this branch | **0** |

Also 0 divergences across ~2,200 real pages at chunk sizes 64 / 512 / 4096.

## Root causes

Ten are streaming-side bugs. Most trace back to the lookback window in #193 — the drain frees
buffered bytes, and several call sites still read state that only exists in the freed region
(`flushed_tail`, `line_state_before_row`, `block_open_prefix`, the item-marker guard,
`has_streamed_output` used as a proxy for a *frame's* own output, and open-marker offsets that
don't shift when an empty item inserts a newline). One is older than #193: the phantom-newline
bug in `flushed_tail` originates in #159.

Reading `flushed_tail` is only legal once a drain has cut bytes away, so that commit adds the
predicate saying so and moves **every** reader onto it, not just the one that provably diverged —
the others were latent copies of the same mistake. Those extra sites change no output, verified by
the probe and a one-shot dump.

**Two commits change one-shot output**, because one-shot was the wrong side. I checked each
against a GFM round-trip oracle (comrak + pulldown-cmark) rather than assuming one-shot is right:

- `db60685` — one-shot GFM-escapes text *inside* a raw HTML region, so `*` became `\*` in a
  region that is passed through verbatim. **46 of the 65,536** synthetic inputs change; every
  one *removes* a backslash (54 → 8 across those cases) and none adds one; **0 real pages**
  change.
- `afdbeec` — `get_markdown()` finalised with `str::trim_end`, which is Unicode-aware and so
  silently deleted a trailing U+00A0. Now ASCII-only. Changes 2 real pages, +4 bytes each.

Happy to drop those two if you'd rather take the parity fixes alone — they're the last two
commits, and `afdbeec` is independent of everything else.

## Checks

Rebased on `main` (9372e52); the one overlapping change (#200's heading-slug guard) doesn't touch
these paths.

- 541 tests pass (528 on `main`, +13 here); every commit is green on its own.
- `cargo clippy --workspace --exclude mdream-edge -- -D warnings -A clippy::pedantic
  -A clippy::nursery` (CI's invocation) is clean; with `--all-targets` the finding count is
  identical to `main`.
- `cargo fmt --check` reports the same pre-existing files as `main`, none of them mine.
- No memory regression: the bounded window holds at a 4,369-byte peak for an 8.4 MB document,
  byte-identical to `main`, and there are tests pinning it.
- 515 insertions / 42 deletions across 3 files.

One test-only change is not a fix: the peak-allocation tracker now accounts **per-thread** instead
of in process-wide atomics. With a second measuring test, tests running in parallel charge each
other's multi-megabyte fixtures to whichever measurement is in flight — that failed here on Linux
before I fixed it. Per-thread accounting also removes the need for the `MEM_MEASURE` mutex.

The `assert_stream_matches_every_split` helper is the part I'd most like reviewed — it's what
makes these bugs cheap to catch, and why the count is 0 rather than "0 that I tried".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming conversion across buffer boundaries to preserve Markdown formatting and line context.
  * Fixed spacing and separator handling for tables, lists, blockquotes, and empty items.
  * Improved raw HTML detection and Markdown transitions during streaming.
  * Preserved trailing whitespace behavior, including non-breaking spaces, more accurately.
  * Added safeguards for marker handling, links, block openings, and raw HTML escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->