### PR TITLE
fix(core): floor the streaming hold-back offsets to a char boundary

### DIFF
--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -1324,28 +1324,16 @@ impl ConvertState {
     // dropped (empty element) and a block boundary then trims that trailing space, a yielded
     // space would be silently removed and shift every later byte. Hold those spaces back too.
     if let Some(&(_, p, _)) = self.open_markers.first() {
-      stable_end = stable_end.min(self.buffer[..p].trim_end_matches(['\n', ' ']).len());
+      stable_end = stable_end.min(hold_before(&self.buffer, p));
     }
     if let Some(span) = self.code_spans.first() {
-      stable_end = stable_end.min(
-        self.buffer[..span.output_start]
-          .trim_end_matches(['\n', ' '])
-          .len(),
-      );
+      stable_end = stable_end.min(hold_before(&self.buffer, span.output_start));
     }
     if let Some(fence) = &self.code_fence {
-      stable_end = stable_end.min(
-        self.buffer[..fence.output_start]
-          .trim_end_matches(['\n', ' '])
-          .len(),
-      );
+      stable_end = stable_end.min(hold_before(&self.buffer, fence.output_start));
     }
     if let Some(frame) = self.blockquotes.first() {
-      stable_end = stable_end.min(
-        self.buffer[..frame.content_start]
-          .trim_end_matches(['\n', ' '])
-          .len(),
-      );
+      stable_end = stable_end.min(hold_before(&self.buffer, frame.content_start));
     }
     // An open `<a>`'s close can rewrite the buffer back to `link_bracket_pos`
     // (emptyLinkText drop, selfLinkHeadings, redundantLinks, GFM autolink). Hold the
@@ -1355,11 +1343,7 @@ impl ConvertState {
     // so hold them back too or a yielded space would be silently removed.
     // Mirrors the same guard in `drain_streamed_prefix`.
     if self.depth_map[TAG_A as usize] > 0 {
-      stable_end = stable_end.min(
-        self.buffer[..self.link_bracket_pos]
-          .trim_end_matches(['\n', ' '])
-          .len(),
-      );
+      stable_end = stable_end.min(hold_before(&self.buffer, self.link_bracket_pos));
     }
     // A marker still alone on its line has its separating newline inserted at
     // the line start when the item resolves, so the line stays mutable.
@@ -1534,6 +1518,17 @@ impl ConvertState {
     self.line_start = self.line_start.saturating_sub(drain_end);
     self.line_start_scanned_to = self.line_start_scanned_to.saturating_sub(drain_end);
   }
+}
+
+/// Highest offset that holds back everything from `at`, plus the blank run just
+/// before it that a rewrite reaching back there can trim. Floored like
+/// `keep_two_before`, so a drifted `at` never slices mid-codepoint.
+fn hold_before(buf: &str, at: usize) -> usize {
+  let mut i = at.min(buf.len());
+  while !buf.is_char_boundary(i) {
+    i -= 1;
+  }
+  buf[..i].trim_end_matches(['\n', ' ']).len()
 }
 
 /// Highest offset that still keeps the two bytes before `at` in the buffer, for

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -447,6 +447,9 @@ fn streaming_multibyte_never_panics() {
     "<blockquote>”<br>\n</><p>🎉",
     "<a href=\"/x\">link</a>“<strong></strong>—漢字",
     "<ul><li>é<a href=\"/x\"></a>…</li></ul>🎉&mdash;",
+    // Inline element still open at yield: the hold-back offsets are read
+    // before the yield bounds are floored, so a drifted one sliced mid-char.
+    "><li><br>é<a><td><li><li>",
   ];
   for &html in CASES {
     for max_bytes in [1usize, 2, 3, 4, 5, 7, 11] {


### PR DESCRIPTION
`get_markdown_chunk` narrows its yield boundary using five offsets a later rewrite can reach back to (open inline marker, code span, code fence, blockquote, open link), and sliced each one raw. Those offsets drift when a rewrite truncates and rebuilds the buffer, so one can land inside a multibyte codepoint and panic:

```
end byte index 165 is not a char boundary; it is inside 'é'
```

`drain_streamed_prefix` already routes the same five offsets through `keep_two_before`, which floors to a boundary for exactly this reason. The clamps from #155 sit *after* these slices, so they never covered them. This adds `hold_before` with the same guarantee and uses it at all five sites, which also removes the duplicated slice/trim at each.

No behaviour change beyond not panicking: flooring only moves the boundary down, so a chunk may hold a partial codepoint back slightly longer. It can never yield unstable bytes.

Reproducer (added to `streaming_multibyte_never_panics`; panics on `main` at every chunk width):

```
"><li><br>é<a><td><li><li>"
```

Found by `fuzz_streaming_chunks`, then reduced by delta debugging. It needs an inline element still *open* when a chunk is yielded — the existing cases miss that because their `<a>` is already closed by then.

The sixth buffer slice, `&self.buffer[..drain_end]` in the drain, is deliberately left alone: its bounds are already floored, and 600k+ instrumented executions under `fuzz_streaming_options` never produced a non-boundary `drain_end`.

Post-fix: 2.2M runs of `fuzz_streaming_chunks` and 4.0M of `fuzz_streaming_options`, both clean; full `cargo test -p mdream` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming output handling around spaces, newlines, and UTF-8 text.
  * Prevented potential errors when streaming pauses near multibyte characters.
  * Preserved formatting across open inline elements, code, blockquotes, and links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->