### PR TITLE
fix(core): resume an unfinished start tag's scan across chunks

### DIFF
--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -1,6 +1,9 @@
 use crate::consts::*;
 use crate::entities::{decode_html_entities, decode_html_entities_for_markdown};
-use crate::scan::{is_whitespace, process_comment_or_doctype, process_tag_attributes};
+use crate::scan::{
+  PendingTagScan, is_whitespace, process_comment_or_doctype, process_tag_attributes,
+  tag_is_complete,
+};
 use crate::selector::{ParsedSelectorList, matches_selector_list, parse_css_selector_list};
 use crate::tags::get_tag_handler;
 use crate::tailwind::process_tailwind_classes;
@@ -389,6 +392,9 @@ pub struct ConvertState {
   first_block_parent_index: Option<usize>,
   block_parent_indices: Vec<usize>,
   parse_text_buffer: String,
+  /// Set while a start tag is known to span chunks, holding how far its `>`
+  /// search reached so the next chunk resumes instead of restarting it.
+  pending_tag: Option<PendingTagScan>,
   script_text_buffer: String,
   pub stack: Vec<ElementNode>,
   node_pool: Vec<ElementNode>,
@@ -577,6 +583,7 @@ impl ConvertState {
       first_block_parent_index: None,
       block_parent_indices: Vec::with_capacity(16),
       parse_text_buffer: String::new(),
+      pending_tag: None,
       script_text_buffer: String::new(),
       stack: Vec::with_capacity(32),
       node_pool: Vec::with_capacity(32),
@@ -771,7 +778,10 @@ impl ConvertState {
     }
   }
 
-  pub fn process_html(&mut self, chunk: &str) -> String {
+  /// Consumes what it can of `chunk` and returns how many bytes that was. The
+  /// caller keeps the rest; returning an owned tail instead would copy a token
+  /// that spans many chunks once per chunk, which is quadratic.
+  pub fn process_html(&mut self, chunk: &str) -> usize {
     // Non-empty only when the previous chunk ended mid-text: that run continues
     // here instead of being re-fed as raw input. Every flush leaves it empty.
     let mut text_buffer = std::mem::take(&mut self.parse_text_buffer);
@@ -1128,6 +1138,17 @@ impl ConvertState {
           run_start = i;
         }
 
+        // `process_opening_tag` throws away everything it parsed when the tag
+        // is incomplete, so resume the `>` search instead of re-parsing it.
+        if let Some(mut pending) = self.pending_tag {
+          if !tag_is_complete(chunk, i2, &mut pending) {
+            self.pending_tag = Some(pending);
+            carry = true;
+            break;
+          }
+          self.pending_tag = None;
+        }
+
         let result =
           self.process_opening_tag(&tag_name, tag_id, builtin_tag_id.is_some(), chunk, i2);
         if result.skip {
@@ -1153,24 +1174,22 @@ impl ConvertState {
             }
           }
         } else {
-          // Incomplete opening tag: re-parse from '<' in the next chunk.
+          // Incomplete opening tag. The next chunk resumes the `>` search from
+          // here rather than re-parsing the tag from '<'.
+          self.pending_tag = Some(PendingTagScan::new());
           carry = true;
           break;
         }
       }
     }
 
-    // Carry only an unfinished token, RAW from `run_start`, never the parsed
-    // `text_buffer` (re-processing would re-derive it). A trailing text run is
-    // kept in `text_buffer` instead, so it is parsed once however many chunks
-    // it spans.
-    let leftover = if carry {
-      chunk[run_start..].to_string()
-    } else {
-      String::new()
-    };
+    // An unfinished token stays with the caller RAW from `run_start`, never the
+    // parsed `text_buffer` (re-processing would re-derive it). A trailing text
+    // run is kept in `text_buffer` instead, so it is parsed once however many
+    // chunks it spans.
+    let consumed = if carry { run_start } else { chunk_length };
     self.parse_text_buffer = text_buffer;
-    leftover
+    consumed
   }
 
   pub fn get_markdown(&mut self) -> String {

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -3131,11 +3131,8 @@ mod tests {
   fn safe_prose_skips_the_gfm_escape_slow_path() {
     let mut state = ConvertState::new(HTMLToMarkdownOptions::default(), 64, OutputFormat::Markdown);
 
-    assert!(
-      state
-        .process_html("<p>ordinary prose with 123 numbers and punctuation.</p>")
-        .is_empty()
-    );
+    let html = "<p>ordinary prose with 123 numbers and punctuation.</p>";
+    assert_eq!(state.process_html(html), html.len());
 
     assert_eq!(state.gfm_escape_slow_path_calls, 0);
     assert_eq!(
@@ -3148,11 +3145,8 @@ mod tests {
   fn syntax_and_entities_use_the_gfm_escape_slow_path() {
     let mut state = ConvertState::new(HTMLToMarkdownOptions::default(), 64, OutputFormat::Markdown);
 
-    assert!(
-      state
-        .process_html("<p>* literal</p><p>&#42; decoded</p>")
-        .is_empty()
-    );
+    let html = "<p>* literal</p><p>&#42; decoded</p>";
+    assert_eq!(state.process_html(html), html.len());
 
     assert_eq!(state.gfm_escape_slow_path_calls, 2);
     assert_eq!(state.get_markdown(), "\\* literal\n\n\\* decoded");

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -56,8 +56,8 @@ pub fn html_to_format_result(
 ) -> MdreamResult {
   let capacity = (html.len() / 3).clamp(1024, 256 * 1024);
   let mut state = ConvertState::new(options, capacity, format);
-  let leftover = state.process_html(html);
-  state.finalize(&leftover);
+  let consumed = state.process_html(html);
+  state.finalize(&html[consumed..]);
 
   let extracted = if state.has_extraction {
     let results = std::mem::take(&mut state.extraction_results);
@@ -110,23 +110,26 @@ impl MarkdownStreamProcessor {
 
   pub fn process_chunk(&mut self, chunk: &str) -> String {
     if self.buffer.is_empty() {
-      self.buffer = self.state.process_html(chunk);
+      let consumed = self.state.process_html(chunk);
+      self.buffer.push_str(&chunk[consumed..]);
     } else {
       self.buffer.push_str(chunk);
-      let full = std::mem::take(&mut self.buffer);
-      self.buffer = self.state.process_html(&full);
+      // Draining only what was consumed leaves a token still waiting for its
+      // terminator in place, rather than recopying it every chunk.
+      let consumed = self.state.process_html(&self.buffer);
+      self.buffer.drain(..consumed);
     }
     self.state.get_markdown_chunk()
   }
 
   pub fn finish(&mut self) -> String {
-    let leftover = if self.buffer.is_empty() {
-      String::new()
+    let buffer = std::mem::take(&mut self.buffer);
+    let consumed = if buffer.is_empty() {
+      0
     } else {
-      let chunk = std::mem::take(&mut self.buffer);
-      self.state.process_html(&chunk)
+      self.state.process_html(&buffer)
     };
-    self.state.finalize(&leftover);
+    self.state.finalize(&buffer[consumed..]);
     self.state.get_markdown_chunk()
   }
 }

--- a/crates/core/src/scan.rs
+++ b/crates/core/src/scan.rs
@@ -93,6 +93,69 @@ pub(crate) fn process_comment_or_doctype(html_chunk: &str, position: usize) -> C
   }
 }
 
+/// How far a start tag spanning several chunks has been searched for its `>`,
+/// so the next chunk resumes instead of restarting. Without this a tag longer
+/// than the chunk is re-scanned from `<` every chunk, which is quadratic.
+#[derive(Clone, Copy)]
+pub(crate) struct PendingTagScan {
+  /// Bytes of the attribute region already examined.
+  scanned: usize,
+  state: State,
+  /// The quote still open at `scanned`, or 0 outside a quoted value.
+  quote_char: u8,
+}
+
+impl PendingTagScan {
+  #[inline]
+  pub(crate) fn new() -> Self {
+    Self {
+      scanned: 0,
+      state: State::Gap,
+      quote_char: 0,
+    }
+  }
+}
+
+/// Resume the search for a start tag's `>`, reporting whether the tag is now
+/// complete. Runs the same tokenizer as [`scan_tag`] so the two always agree on
+/// where a tag ends; `process_tag_attributes` still does the single real parse.
+pub(crate) fn tag_is_complete(
+  html_chunk: &str,
+  attrs_start: usize,
+  pending: &mut PendingTagScan,
+) -> bool {
+  let bytes = html_chunk.as_bytes();
+  let mut i = attrs_start + pending.scanned;
+
+  while i < bytes.len() {
+    let c = bytes[i];
+
+    if pending.quote_char != 0 {
+      if c == pending.quote_char {
+        pending.quote_char = 0;
+        pending.state = State::Gap;
+      }
+      i += 1;
+      continue;
+    }
+
+    // `/>` is reached through its own `>`, so one test covers both endings.
+    if c == GT_CHAR {
+      return true;
+    }
+
+    if pending.state == State::BeforeValue && (c == QUOTE_CHAR || c == APOS_CHAR) {
+      pending.quote_char = c;
+    } else {
+      pending.state = pending.state.step_without_extraction(c);
+    }
+    i += 1;
+  }
+
+  pending.scanned = i - attrs_start;
+  false
+}
+
 /// Scan a start tag's attribute region to its `>`, storing only the attributes
 /// `attr_mask` selects.
 pub(crate) fn process_tag_attributes(

--- a/crates/core/tests/streaming_scaling.rs
+++ b/crates/core/tests/streaming_scaling.rs
@@ -89,12 +89,17 @@ fn repeat_to(prefix: &str, unit: &str, target: usize, suffix: &str) -> String {
 }
 
 /// Each body is one run longer than the chunk, so none of them offers the tag
-/// boundary that flushes the text buffer.
-fn cases() -> [(&'static str, String); 4] {
+/// boundary that flushes the text buffer. `start tag` withholds that boundary a
+/// different way: the tag is the run, so it is the terminator that never comes.
+fn cases() -> [(&'static str, String); 5] {
   [
     (
       "text run",
       repeat_to("<p>", "lorem ipsum dolor sit amet ", SIZE, "</p>"),
+    ),
+    (
+      "start tag",
+      repeat_to("<a href=\"/", "aaaaaaaaaaaaaaaa", SIZE, "\">link</a>"),
     ),
     (
       "style body",


### PR DESCRIPTION
A start tag longer than the streaming chunk was re-parsed from its `<` on every chunk. `process_opening_tag` throws away everything it parsed when the tag turns out incomplete, so that work repeated and grew with the tag: a 4 MiB tag allocated 774x the document and streamed in 367 ms against 4 ms one-shot.

`PendingTagScan` now records how far the `>` search reached, so the next chunk resumes there instead of restarting. It runs the same tokenizer as `scan_tag` (a `>` inside a quoted value does not end a tag; only `State::BeforeValue` opens a quote), so the two cannot disagree about where a tag ends.

`process_html` also now reports how many bytes it consumed instead of returning an owned leftover `String`. The old signature copied a token spanning many chunks once per chunk, which was the same quadratic on the caller's side. `MarkdownStreamProcessor` drains only what was consumed.

Reproducer: a new `start tag` case in `streaming_scaling.rs`, a single tag longer than the chunk. On `main` it fails the existing linearity assertion at 774.50x.

|  | before | after |
|---|---|---|
| allocation | 774.50x | 9.00x |
| streamed | 367.4 ms | 8.3 ms |
| vs one-shot | 90.2x | 2.0x |

Output is unchanged; the streaming/one-shot equivalence and drain tests cover that.

Verified with the full `cargo test -p mdream`, plus 2.2M runs of `fuzz_streaming_chunks` and 1.5M of `fuzz_streaming_options`. Those fuzz runs had #204 applied, because `main` has an unrelated mid-codepoint panic that the fuzzer reaches first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming HTML conversion for tags split across input chunks.
  - Correctly handles quoted attribute values and resumes scanning without reprocessing earlier content.
  - Preserves incomplete input safely until additional data arrives.

- **Performance**
  - Reduced temporary allocations during streaming conversion.
  - Improved handling of very long start tags and attributes.

- **Tests**
  - Expanded coverage for split tags, entities, escaped output, and oversized attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->