### PR TITLE
fix(core): four more streaming/one-shot divergences

### DIFF
--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -510,6 +510,10 @@ pub struct ConvertState {
   code_fence: Option<CodeFenceState>,
   /// Open blockquotes stay buffered until all child line boundaries are known.
   blockquotes: Vec<BlockquoteFrame>,
+  /// Scratch for the quoted rewrite of a blockquote region. Held across calls so
+  /// a flush, which can run once per 8KB and once per open frame, reuses the
+  /// capacity instead of allocating a fresh copy of the region each time.
+  blockquote_scratch: String,
   /// Heading slugs collected during conversion for fragment validation
   heading_slugs: Vec<String>,
   /// Fragment link locations: (bracket_start, link_end)
@@ -667,6 +671,7 @@ impl ConvertState {
       code_spans: Vec::new(),
       code_fence: None,
       blockquotes: Vec::with_capacity(4),
+      blockquote_scratch: String::new(),
       heading_slugs: Vec::new(),
       fragment_links: Vec::new(),
       in_heading: false,

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -360,6 +360,11 @@ impl ConvertState {
       || self.clean_flags & CLEAN_FRAGMENTS != 0
       || self.has_frontmatter
       || self.has_extraction
+      // A code span or fence measures and rewrites itself through buffer offsets
+      // that quoting moves, and the drain already holds at the open one, so
+      // flushing past it releases nothing and only invalidates its offsets.
+      || self.code_fence.is_some()
+      || !self.code_spans.is_empty()
     {
       return;
     }

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -271,9 +271,12 @@ impl ConvertState {
       return;
     }
     let content = &self.buffer[frame.content_start..content_end];
-    let mut quoted = String::with_capacity(
-      content.len() + (frame.list_indent.len() + 2) * (content.matches('\n').count() + 1),
-    );
+    // Borrowed rather than allocated: the capacity outlives the call, so a
+    // document full of quotes pays for this region once.
+    let mut quoted = core::mem::take(&mut self.blockquote_scratch);
+    quoted.clear();
+    quoted
+      .reserve(content.len() + (frame.list_indent.len() + 2) * (content.matches('\n').count() + 1));
 
     for (index, line) in content.split('\n').enumerate() {
       if index > 0 {
@@ -348,6 +351,7 @@ impl ConvertState {
     self.buffer.truncate(frame.content_start);
     self.buffer.push_str(&quoted);
     self.last_content_cache_len = quoted.len();
+    self.blockquote_scratch = quoted;
     // Quoting inserted a `> ` and a newline per line, so a line the scan had
     // already passed is no longer where the cache says the current one begins.
     self.invalidate_line_start();
@@ -397,8 +401,9 @@ impl ConvertState {
       let content = &self.buffer[shared_start..flush_end];
       let quoted_prefix = "> ".repeat(self.blockquotes.len());
       let blank_prefix = quoted_prefix.trim_end();
-      let mut quoted =
-        String::with_capacity(content.len() + quoted_prefix.len() * content.matches('\n').count());
+      let mut quoted = core::mem::take(&mut self.blockquote_scratch);
+      quoted.clear();
+      quoted.reserve(content.len() + quoted_prefix.len() * content.matches('\n').count());
       for line in content.split_inclusive('\n') {
         let line = line.strip_suffix('\n').unwrap_or(line);
         if line.is_empty() {
@@ -411,6 +416,7 @@ impl ConvertState {
       }
       self.buffer.replace_range(shared_start..flush_end, &quoted);
       flush_end = shared_start + quoted.len();
+      self.blockquote_scratch = quoted;
       for frame in &mut self.blockquotes {
         frame.content_start = flush_end;
       }
@@ -420,11 +426,13 @@ impl ConvertState {
     }
 
     let frames = self.blockquotes.clone();
+    // Taken once for the whole walk: every frame rewrites the same region again,
+    // so without this each nesting level allocates its own copy of it per flush.
+    let mut quoted = core::mem::take(&mut self.blockquote_scratch);
     for frame in frames.iter().rev() {
       let content = &self.buffer[frame.content_start..flush_end];
-      let mut quoted = String::with_capacity(
-        content.len() + (frame.list_indent.len() + 2) * content.matches('\n').count(),
-      );
+      quoted.clear();
+      quoted.reserve(content.len() + (frame.list_indent.len() + 2) * content.matches('\n').count());
       for line in content.split_inclusive('\n') {
         let line = line.strip_suffix('\n').unwrap_or(line);
         quoted.push_str(&frame.list_indent);
@@ -445,6 +453,7 @@ impl ConvertState {
         .replace_range(frame.content_start..flush_end, &quoted);
       flush_end = frame.content_start + quoted.len();
     }
+    self.blockquote_scratch = quoted;
 
     for frame in &mut self.blockquotes {
       frame.content_start = flush_end;

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -1970,6 +1970,16 @@ impl ConvertState {
     }
   }
 
+  /// Note that the buffer has been shortened to `len`. A list marker's recorded
+  /// end is a length, and the space a trim takes is the marker's own: left past
+  /// the content it reads the element that opens the item as content.
+  #[inline]
+  fn clamp_item_marker_end(&mut self, len: usize) {
+    if self.empty_item_len > len {
+      self.empty_item_len = len;
+    }
+  }
+
   #[inline]
   fn trim_trailing_spaces(&mut self) {
     let floor = self.trim_floor();
@@ -1982,6 +1992,7 @@ impl ConvertState {
       self.last_content_cache_len = self
         .last_content_cache_len
         .saturating_sub(self.buffer.len() - trimmed_len);
+      self.clamp_item_marker_end(trimmed_len);
       self.buffer.truncate(trimmed_len);
     }
   }
@@ -2964,6 +2975,7 @@ impl ConvertState {
             // so the reach-back would drop the next text's leading char.
             let trimmed_len = trim_ascii_whitespace_end(frag);
             if start + trimmed_len < buf_len {
+              self.clamp_item_marker_end(start + trimmed_len);
               self.buffer.truncate(start + trimmed_len);
               // The run just shrank; a stale length lets the next trim start
               // behind it and reach into spacing no text node wrote.

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -2755,7 +2755,7 @@ impl ConvertState {
         if self.depth_map[TAG_BLOCKQUOTE as usize] > 0
           || (self.depth_map[TAG_LI as usize] > 0 && !self.in_table_cell())
         {
-          let last_char = self.buffer.as_bytes().last().copied().unwrap_or(0);
+          let last_char = self.last_output_byte().unwrap_or(0);
           if last_char != 0 && last_char != b' ' && last_char != b'\n' {
             return Some(Cow::Borrowed("\n\n"));
           }

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -425,11 +425,10 @@ impl ConvertState {
       return;
     }
 
-    let frames = self.blockquotes.clone();
     // Taken once for the whole walk: every frame rewrites the same region again,
     // so without this each nesting level allocates its own copy of it per flush.
     let mut quoted = core::mem::take(&mut self.blockquote_scratch);
-    for frame in frames.iter().rev() {
+    for frame in self.blockquotes.iter().rev() {
       let content = &self.buffer[frame.content_start..flush_end];
       quoted.clear();
       quoted.reserve(content.len() + (frame.list_indent.len() + 2) * content.matches('\n').count());
@@ -634,6 +633,19 @@ impl ConvertState {
       if output.as_deref() == Some("\n") && self.buffer.ends_with("\n\n") {
         output = None;
       }
+    }
+
+    // Finalize completed quote lines before recording a new code offset. A
+    // later flush must stop at that offset, but the prefix before it is safe to
+    // quote and yield now even when both arrive in one large input chunk.
+    if !self.plain_text
+      && !enter_is_literal
+      && tag_id == Some(TAG_CODE)
+      && output.is_some()
+      && ((self.depth_map[TAG_PRE as usize] == 0 && !self.in_raw_html_block())
+        || (self.depth_map[TAG_PRE as usize] > 0 && !self.pre_fence_open && !self.in_table_cell()))
+    {
+      self.flush_streaming_blockquote_lines();
     }
 
     let output_start = self.buffer.len();
@@ -1191,6 +1203,10 @@ impl ConvertState {
       self.pre_fence_pending = false;
       return;
     }
+
+    // Flush before the fence records buffer offsets. Completed quote lines do
+    // not need to stay retained behind a fence that starts later in this chunk.
+    self.flush_streaming_blockquote_lines();
 
     self.pre_fence_pending = false;
     self.pre_fence_open = true;

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -348,6 +348,9 @@ impl ConvertState {
     self.buffer.truncate(frame.content_start);
     self.buffer.push_str(&quoted);
     self.last_content_cache_len = quoted.len();
+    // Quoting inserted a `> ` and a newline per line, so a line the scan had
+    // already passed is no longer where the cache says the current one begins.
+    self.invalidate_line_start();
   }
 
   pub(crate) fn flush_streaming_blockquote_lines(&mut self) {
@@ -407,6 +410,7 @@ impl ConvertState {
         frame.content_start = flush_end;
       }
       self.last_content_cache_len = self.buffer.len() - flush_end;
+      self.invalidate_line_start();
       return;
     }
 
@@ -441,6 +445,7 @@ impl ConvertState {
       frame.content_start = flush_end;
     }
     self.last_content_cache_len = self.buffer.len() - flush_end;
+    self.invalidate_line_start();
   }
 
   /// Emit markdown for entering the element currently on top of self.stack.
@@ -1756,7 +1761,7 @@ impl ConvertState {
         fence.content_start += 1;
       }
     }
-    self.line_start_scanned_to = usize::MAX;
+    self.invalidate_line_start();
     self.raw_html_scanned_to = self.raw_html_scanned_to.min(at);
   }
 
@@ -2005,6 +2010,13 @@ impl ConvertState {
       self.raw_html_markdown = true;
     }
     self.raw_html_scanned_to = len;
+  }
+
+  /// Rebuild the cached line start on the next read: a rewrite has moved or
+  /// inserted newlines behind the incremental scan point.
+  #[inline]
+  fn invalidate_line_start(&mut self) {
+    self.line_start_scanned_to = usize::MAX;
   }
 
   /// Whether the current line opens a raw HTML block, which suspends Markdown

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -4204,3 +4204,15 @@ fn rawtext_eof_residual_is_text_not_a_dropped_tag() {
     assert_eq!(convert(html), "a", "html={html:?}");
   }
 }
+
+// Quoting a closed blockquote rewrites its content in place, inserting a `> `
+// and a newline per line behind the cached line start. Read stale, the "current
+// line" began with the literal `<code>` text, which suspends escaping the way
+// a line that opens a raw HTML block does.
+#[test]
+fn blockquote_quoting_keeps_escaping_a_later_line() {
+  assert_eq!(
+    convert("<dd><h2><li><blockquote>a<p><code><p>>aa<<a><<li>`"),
+    "<dd>\n\n## - \n  > a\n  >\n  > <code></code>\n  >\n  > &gt;aa&lt;&lt; - \\`\n\n</dd>"
+  );
+}

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -1540,3 +1540,11 @@ fn streaming_holds_a_blockquote_blank_line_until_content_follows() {
     }
   }
 }
+
+#[test]
+fn streaming_matches_one_shot_across_blockquote_quoting() {
+  assert_stream_matches_every_split(
+    "<dd><h2><li><blockquote>a<p><code><p>>aa<<a><<li>`",
+    HTMLToMarkdownOptions::default(),
+  );
+}

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -1548,3 +1548,20 @@ fn streaming_matches_one_shot_across_blockquote_quoting() {
     HTMLToMarkdownOptions::default(),
   );
 }
+
+// A trim takes the marker's own trailing space, which leaves the marker's
+// recorded end past where the item's content now starts, so the element that
+// opens the item -- a code span's backtick, or an emphasis marker -- reads as
+// content. Streaming resolves the marker as content arrives and settled the
+// question on it; one-shot only looks at the item's exit and never saw it, so
+// they disagreed on the blank line that keeps an empty item from continuing the
+// paragraph above.
+#[test]
+fn streaming_keeps_an_empty_items_blank_line_across_a_code_span() {
+  assert_stream_matches_every_split("a a<li><p><code>", HTMLToMarkdownOptions::default());
+}
+
+#[test]
+fn streaming_keeps_an_empty_items_blank_line_across_an_inline_marker() {
+  assert_stream_matches_every_split("a a<li><html><strong>", HTMLToMarkdownOptions::default());
+}

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -1584,6 +1584,35 @@ fn streaming_defers_the_blockquote_flush_while_a_fence_is_open() {
   }
 }
 
+// A code span or fence opened after completed quote lines only owns the output
+// from its delimiter onward. The earlier quote prefix can be finalized and
+// yielded before recording those buffer offsets.
+#[test]
+fn streaming_releases_a_completed_blockquote_prefix_before_open_code() {
+  for container in ["<blockquote>", "<ul><li><blockquote>"] {
+    for open_code in ["<code>x", "<pre>x"] {
+      let html = format!(
+        "{container}{}{open_code}",
+        "<p>quoted line</p>".repeat(1024)
+      );
+      let expected = html_to_markdown(&html, HTMLToMarkdownOptions::default());
+      let mut stream = MarkdownStreamProcessor::new(HTMLToMarkdownOptions::default());
+      let first = stream.process_chunk(&html);
+
+      assert!(
+        first.contains("> quoted line"),
+        "completed quote prefix held behind {open_code:?}"
+      );
+      let mut actual = first;
+      actual.push_str(&stream.finish());
+      assert_eq!(
+        actual, expected,
+        "container={container:?} open_code={open_code:?}"
+      );
+    }
+  }
+}
+
 // A `<p>` inside a list item or blockquote separates itself from the text before
 // it, and asks the buffer's last byte what that text ended with. An empty buffer
 // means the start of the document to that question, but streaming empties the

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -1583,3 +1583,27 @@ fn streaming_defers_the_blockquote_flush_while_a_fence_is_open() {
     );
   }
 }
+
+// A `<p>` inside a list item or blockquote separates itself from the text before
+// it, and asks the buffer's last byte what that text ended with. An empty buffer
+// means the start of the document to that question, but streaming empties the
+// buffer whenever it yields, so the paragraph read a mid-document position as
+// the first thing written and skipped the blank line one-shot writes.
+#[test]
+fn streaming_separates_a_paragraph_from_text_it_has_already_yielded() {
+  let html = "<li><pre>a<!>              <!><h3><h3><p>a";
+  let expected =
+    html_to_format_result(html, HTMLToMarkdownOptions::default(), OutputFormat::Text).markdown;
+  for chunk in 1..=html.len() {
+    let mut p = MarkdownStreamProcessor::new_with_format(
+      HTMLToMarkdownOptions::default(),
+      OutputFormat::Text,
+    );
+    let mut actual = String::new();
+    for c in html.as_bytes().chunks(chunk) {
+      actual.push_str(&p.process_chunk(std::str::from_utf8(c).unwrap()));
+    }
+    actual.push_str(&p.finish());
+    assert_eq!(actual, expected, "chunk={chunk}");
+  }
+}

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -1565,3 +1565,21 @@ fn streaming_keeps_an_empty_items_blank_line_across_a_code_span() {
 fn streaming_keeps_an_empty_items_blank_line_across_an_inline_marker() {
   assert_stream_matches_every_split("a a<li><html><strong>", HTMLToMarkdownOptions::default());
 }
+
+// A code span or fence measures and rewrites itself through buffer offsets, and
+// quoting moves the bytes under them. The drain already holds at the open one,
+// so flushing past it releases nothing and leaves the fence pointing into the
+// quote prefix -- mid-codepoint, where finalizing it panics. Long enough to
+// cross the flush threshold while the fence is still open.
+#[test]
+fn streaming_defers_the_blockquote_flush_while_a_fence_is_open() {
+  let html = format!("<blockquote><pre>{}", "\u{e9}\n<br>".repeat(3000));
+  let expected = html_to_markdown(&html, HTMLToMarkdownOptions::default());
+  for chunk in [512, 4096] {
+    assert_eq!(
+      stream_chars(&html, chunk, HTMLToMarkdownOptions::default()),
+      expected,
+      "chunk={chunk}"
+    );
+  }
+}


### PR DESCRIPTION
A follow-up to #207, found the same way: differential fuzzing of the streaming
writer against the one-shot converter. Each commit is an independent fix with a
regression test that fails without it.

- **Rebuild the cached line start after quoting a blockquote.** Quoting moved the
  buffer without invalidating the cached line start, so `line_opens_raw_html_block`
  read a stale multi-line "line" and dropped escaping on a later line.
- **Shrink a marker's recorded end when a trim takes its space.** `empty_item_len`
  went stale once a trim reclaimed the marker's trailing space, so the element
  opening the item read as content and the empty item lost its blank line.
- **Hold the blockquote flush while a code span or fence is open.** A fence
  measures itself through buffer offsets that quoting moves, which panicked
  `finalize_code_fence` on a character boundary.
- **Separate a text paragraph from output already yielded.** The paragraph looked
  at the buffer instead of the last byte actually emitted, so it missed a
  separator once the drain had cut.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown blockquote conversion, including correct escaping of HTML-like text, entities, and backticks.
  * Fixed streaming output across split points, open code fences, and inline markers.
  * Corrected spacing between paragraphs and empty list items.
  * Improved list-marker handling when trimming formatted output.

* **Tests**
  * Added regression coverage for blockquote escaping and streaming conversion edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->