### PR TITLE
chore(rust): resolve strict clippy warnings

### DIFF
--- a/crates/core/benches/convert_bench.rs
+++ b/crates/core/benches/convert_bench.rs
@@ -1,12 +1,16 @@
 use std::time::Instant;
 
+fn usize_as_f64(value: usize) -> f64 {
+  f64::from(u32::try_from(value).expect("benchmark value fits in u32"))
+}
+
 fn bench(
   label: &str,
   html: &str,
-  opts: mdream::types::HTMLToMarkdownOptions,
+  opts: &mdream::types::HTMLToMarkdownOptions,
   iterations: u32,
 ) -> f64 {
-  let size_kb = html.len() as f64 / 1024.0;
+  let size_kb = usize_as_f64(html.len()) / 1024.0;
   for _ in 0..50 {
     let _ = mdream::html_to_markdown(html, opts.clone());
   }
@@ -16,7 +20,7 @@ fn bench(
     for _ in 0..iterations {
       let _ = mdream::html_to_markdown(html, opts.clone());
     }
-    let us = start.elapsed().as_micros() as f64 / f64::from(iterations);
+    let us = start.elapsed().as_secs_f64() * 1_000_000.0 / f64::from(iterations);
     if us < best {
       best = us;
     }
@@ -43,8 +47,8 @@ fn utf8_chunks(s: &str, target: usize) -> Vec<&str> {
 }
 
 /// Stream `html` in `chunk`-sized pieces, discarding output like the wire.
-fn run_stream(html: &str, opts: mdream::types::HTMLToMarkdownOptions, chunk: usize) -> usize {
-  let mut p = mdream::MarkdownStreamProcessor::new(opts);
+fn run_stream(html: &str, opts: &mdream::types::HTMLToMarkdownOptions, chunk: usize) -> usize {
+  let mut p = mdream::MarkdownStreamProcessor::new(opts.clone());
   let mut produced = 0usize;
   for piece in utf8_chunks(html, chunk) {
     produced += p.process_chunk(piece).len();
@@ -55,21 +59,21 @@ fn run_stream(html: &str, opts: mdream::types::HTMLToMarkdownOptions, chunk: usi
 fn bench_stream(
   label: &str,
   html: &str,
-  opts: mdream::types::HTMLToMarkdownOptions,
+  opts: &mdream::types::HTMLToMarkdownOptions,
   chunk: usize,
   iterations: u32,
 ) {
-  let size_kb = html.len() as f64 / 1024.0;
+  let size_kb = usize_as_f64(html.len()) / 1024.0;
   for _ in 0..20 {
-    let _ = run_stream(html, opts.clone(), chunk);
+    let _ = run_stream(html, opts, chunk);
   }
   let mut best = f64::MAX;
   for _ in 0..3 {
     let start = Instant::now();
     for _ in 0..iterations {
-      let _ = run_stream(html, opts.clone(), chunk);
+      let _ = run_stream(html, opts, chunk);
     }
-    let us = start.elapsed().as_micros() as f64 / f64::from(iterations);
+    let us = start.elapsed().as_secs_f64() * 1_000_000.0 / f64::from(iterations);
     if us < best {
       best = us;
     }
@@ -145,13 +149,8 @@ fn main() {
   );
 
   for (label, html) in &fixtures {
-    let d = bench(
-      &format!("{label} default"),
-      html,
-      default_opts.clone(),
-      iters,
-    );
-    let c = bench(&format!("{label} clean"), html, clean_opts.clone(), iters);
+    let d = bench(&format!("{label} default"), html, &default_opts, iters);
+    let c = bench(&format!("{label} clean"), html, &clean_opts, iters);
     let overhead = ((c - d) / d) * 100.0;
     // Reprint as table row
     println!(
@@ -178,14 +177,14 @@ fn main() {
       bench_stream(
         &format!("{label} default @ {}KB", chunk / 1024),
         html,
-        default_opts.clone(),
+        &default_opts,
         chunk,
         iters,
       );
       bench_stream(
         &format!("{label} clean @ {}KB", chunk / 1024),
         html,
-        stream_clean_opts.clone(),
+        &stream_clean_opts,
         chunk,
         iters,
       );

--- a/crates/core/benches/token_cost.rs
+++ b/crates/core/benches/token_cost.rs
@@ -33,6 +33,10 @@ fn count_tokens_approx(text: &str) -> usize {
   tokens
 }
 
+fn usize_as_f64(value: usize) -> f64 {
+  f64::from(u32::try_from(value).expect("benchmark value fits in u32"))
+}
+
 fn make_clean() -> mdream::types::CleanConfig {
   mdream::types::CleanConfig {
     urls: true,
@@ -48,7 +52,7 @@ fn make_clean() -> mdream::types::CleanConfig {
 
 fn make_minimal_plugins() -> mdream::types::PluginConfig {
   mdream::types::PluginConfig {
-    isolate_main: Some(mdream::types::IsolateMainConfig {}),
+    isolate_main: Some(mdream::types::IsolateMainConfig),
     filter: Some(mdream::types::FilterConfig {
       exclude: Some(vec![
         "form".into(),
@@ -67,7 +71,7 @@ fn make_minimal_plugins() -> mdream::types::PluginConfig {
       include: None,
       process_children: None,
     }),
-    tailwind: Some(mdream::types::TailwindConfig {}),
+    tailwind: Some(mdream::types::TailwindConfig),
     frontmatter: Some(mdream::types::FrontmatterConfig {
       additional_fields: None,
       meta_fields: None,
@@ -78,7 +82,7 @@ fn make_minimal_plugins() -> mdream::types::PluginConfig {
 }
 
 fn analyze(label: &str, html: &str) {
-  let html_kb = html.len() as f64 / 1024.0;
+  let html_kb = usize_as_f64(html.len()) / 1024.0;
   let html_tokens = count_tokens_approx(html);
 
   let default_md = mdream::html_to_markdown(html, mdream::types::HTMLToMarkdownOptions::default());
@@ -94,10 +98,13 @@ fn analyze(label: &str, html: &str) {
   );
   let minimal_clean_tokens = count_tokens_approx(&minimal_clean_md);
 
+  let html_tokens_float = usize_as_f64(html_tokens);
+  let default_tokens_float = usize_as_f64(default_tokens);
+  let minimal_clean_tokens_float = usize_as_f64(minimal_clean_tokens);
   let html_reduction =
-    ((html_tokens as f64 - minimal_clean_tokens as f64) / html_tokens as f64) * 100.0;
+    ((html_tokens_float - minimal_clean_tokens_float) / html_tokens_float) * 100.0;
   let default_reduction =
-    ((default_tokens as f64 - minimal_clean_tokens as f64) / default_tokens as f64) * 100.0;
+    ((default_tokens_float - minimal_clean_tokens_float) / default_tokens_float) * 100.0;
 
   println!(
     "| {label:28} | {html_kb:>8.0} KB | {html_tokens:>8} | {default_tokens:>8} | {minimal_clean_tokens:>8} | {html_reduction:>5.0}% | {default_reduction:>5.0}% |",

--- a/crates/core/src/bin.rs
+++ b/crates/core/src/bin.rs
@@ -100,6 +100,7 @@ fn main() -> io::Result<()> {
       carry.drain(..valid_up_to);
     }
   }
+  drop(input);
 
   if !carry.is_empty() {
     return Err(io::Error::new(

--- a/crates/core/src/convert/html_output.rs
+++ b/crates/core/src/convert/html_output.rs
@@ -384,7 +384,7 @@ mod tests {
 
     for (tag_id, name) in TAG_NAMES.iter().enumerate() {
       assert_eq!(
-        html_tag_name(tag_id as u8).is_some(),
+        html_tag_name(u8::try_from(tag_id).expect("tag ID fits in u8")).is_some(),
         ALLOWED.contains(name),
         "tag={name}",
       );

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -160,7 +160,7 @@ impl ConvertState {
 
   #[cold]
   #[inline(never)]
-  fn finalize_code_span(&mut self, span: CodeSpanState) -> String {
+  fn finalize_code_span(&mut self, span: &CodeSpanState) -> String {
     // A pipe splits the row even inside a code span; `\|` is GFM's escape and is
     // honoured there. Content sits at the buffer tail, so this shifts no offset.
     if self.depth_map[TAG_TABLE as usize] > 0 && self.buffer[span.content_start..].contains('|') {
@@ -281,10 +281,10 @@ impl ConvertState {
       }
       quoted.push_str(&frame.list_indent);
       quoted.push('>');
-      let unindented = if !frame.list_indent.is_empty() {
-        line.strip_prefix(&frame.list_indent).unwrap_or(line)
-      } else {
+      let unindented = if frame.list_indent.is_empty() {
         line
+      } else {
+        line.strip_prefix(&frame.list_indent).unwrap_or(line)
       };
       if !unindented.is_empty() {
         quoted.push(' ');
@@ -420,10 +420,10 @@ impl ConvertState {
         let line = line.strip_suffix('\n').unwrap_or(line);
         quoted.push_str(&frame.list_indent);
         quoted.push('>');
-        let unindented = if !frame.list_indent.is_empty() {
-          line.strip_prefix(&frame.list_indent).unwrap_or(line)
-        } else {
+        let unindented = if frame.list_indent.is_empty() {
           line
+        } else {
+          line.strip_prefix(&frame.list_indent).unwrap_or(line)
         };
         if !unindented.is_empty() {
           quoted.push(' ');
@@ -1109,7 +1109,7 @@ impl ConvertState {
     }
 
     if let Some(span) = closing_code_span {
-      output = Some(Cow::Owned(self.finalize_code_span(span)));
+      output = Some(Cow::Owned(self.finalize_code_span(&span)));
     }
     if !has_override
       && closes_own_pre_fence
@@ -3187,7 +3187,7 @@ impl ConvertState {
       .get("start")
       .and_then(|value| parse_bounded_u32(value, MAX_ORDERED_START))
       .unwrap_or(1)
-      .saturating_add(index as u32)
+      .saturating_add(u32::try_from(index).unwrap_or(u32::MAX))
       .min(MAX_ORDERED_START)
   }
 }

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -556,8 +556,8 @@ impl ConvertState {
       if tw.hidden {
         excludes_text_nodes = true;
       } else if !excludes_text_nodes {
-        tailwind_prefix = tw.prefix.clone();
-        tailwind_suffix = tw.suffix.clone();
+        tailwind_prefix.clone_from(&tw.prefix);
+        tailwind_suffix.clone_from(&tw.suffix);
       }
     }
 

--- a/crates/core/src/convert/plugins.rs
+++ b/crates/core/src/convert/plugins.rs
@@ -20,18 +20,6 @@ where
   }
 }
 
-#[cfg(test)]
-mod tests {
-  use super::sort_fields_by_key;
-
-  #[test]
-  fn field_sort_is_ordered_and_stable() {
-    let mut fields = [("b", 0), ("a", 1), ("a", 2), ("c", 3)];
-    sort_fields_by_key(&mut fields, |(key, _)| key);
-    assert_eq!(fields, [("a", 1), ("a", 2), ("b", 0), ("c", 3)]);
-  }
-}
-
 impl ConvertState {
   pub(crate) fn generate_frontmatter_yaml(&mut self) {
     if self.format != OutputFormat::Markdown {
@@ -116,5 +104,17 @@ impl ConvertState {
       }
     }
     Some(entries)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::sort_fields_by_key;
+
+  #[test]
+  fn field_sort_is_ordered_and_stable() {
+    let mut fields = [("b", 0), ("a", 1), ("a", 2), ("c", 3)];
+    sort_fields_by_key(&mut fields, |(key, _)| key);
+    assert_eq!(fields, [("a", 1), ("a", 2), ("b", 0), ("c", 3)]);
   }
 }

--- a/crates/core/src/scan.rs
+++ b/crates/core/src/scan.rs
@@ -237,13 +237,11 @@ fn scan_tag<const EXTRACT: bool>(
 
     if EXTRACT {
       scan.step(html_chunk, c, i);
+    } else if state == State::BeforeValue && (c == QUOTE_CHAR || c == APOS_CHAR) {
+      inside_quote = true;
+      quote_char = c;
     } else {
-      if state == State::BeforeValue && (c == QUOTE_CHAR || c == APOS_CHAR) {
-        inside_quote = true;
-        quote_char = c;
-      } else {
-        state = state.step_without_extraction(c);
-      }
+      state = state.step_without_extraction(c);
     }
     i += 1;
   }
@@ -797,7 +795,10 @@ mod tests {
     const ALPHABET: &[u8] = b"a ='\".>/";
     const WIDTH: usize = 6;
 
-    for case in 0..ALPHABET.len().pow(WIDTH as u32) {
+    for case in 0..ALPHABET
+      .len()
+      .pow(u32::try_from(WIDTH).expect("test width fits in u32"))
+    {
       let mut encoded = case;
       let mut input = [b'a'; WIDTH];
       for byte in &mut input {

--- a/crates/core/src/tailwind.rs
+++ b/crates/core/src/tailwind.rs
@@ -2,10 +2,10 @@
 
 #[inline]
 fn extract_base_class(class: &str) -> (&str, u8) {
-  let breakpoints = ["sm:", "md:", "lg:", "xl:", "2xl:"];
-  for (index, bp) in breakpoints.into_iter().enumerate() {
+  let breakpoints = [("sm:", 1), ("md:", 2), ("lg:", 3), ("xl:", 4), ("2xl:", 5)];
+  for (bp, priority) in breakpoints {
     if let Some(rest) = class.strip_prefix(bp) {
-      return (rest, index as u8 + 1);
+      return (rest, priority);
     }
   }
   (class, 0)
@@ -133,11 +133,7 @@ mod tests {
 
   #[test]
   fn decoration_modifiers_do_not_enable_strikethrough() {
-    for classes in [
-      "underline-offset-4",
-      "no-underline",
-      "decoration-underline",
-    ] {
+    for classes in ["underline-offset-4", "no-underline", "decoration-underline"] {
       let (prefix, suffix, _) = process_tailwind_classes(classes);
       assert!(prefix.is_none(), "{classes}");
       assert!(suffix.is_none(), "{classes}");
@@ -146,8 +142,16 @@ mod tests {
 
   #[test]
   fn decoration_resets_follow_breakpoint_priority() {
-    assert!(process_tailwind_classes("line-through no-underline").0.is_none());
-    assert!(process_tailwind_classes("no-underline line-through").0.is_some());
+    assert!(
+      process_tailwind_classes("line-through no-underline")
+        .0
+        .is_none()
+    );
+    assert!(
+      process_tailwind_classes("no-underline line-through")
+        .0
+        .is_some()
+    );
     assert!(
       process_tailwind_classes("md:line-through no-underline")
         .0

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use mdream::types::{
   ExtractionConfig, FilterConfig, FrontmatterConfig, HTMLToMarkdownOptions, IsolateMainConfig,
   OutputFormat, PluginConfig, TagOverrideConfig,
@@ -397,11 +399,11 @@ fn link_with_title() {
 #[test]
 fn gfm_links_have_reparsable_destinations_and_titles() {
   for (html, expected) in [
-    (r#"<a href="">text</a>"#, r#"[text]()"#),
-    (r#"<a href="docs/a b">text</a>"#, r#"[text](<docs/a b>)"#),
+    (r#"<a href="">text</a>"#, r"[text]()"),
+    (r#"<a href="docs/a b">text</a>"#, r"[text](<docs/a b>)"),
     (
       r#"<a href="docs/(a)\file">text</a>"#,
-      r#"[text](<docs/(a)\\file>)"#,
+      r"[text](<docs/(a)\\file>)",
     ),
     (
       r#"<a href="/x" title="say &quot;hi&quot; \ path">text</a>"#,
@@ -1190,7 +1192,7 @@ fn loose_ordered_list_with_code_block_renders_as_commonmark_loose_list() {
   // The user's reproducer from issue #77. With 3-space indent the markdown
   // renders in CommonMark as a 2-item list with nested code block; with the
   // old 2-space indent the code block fell outside the list entirely.
-  let html = r#"
+  let html = r"
 <ol>
 <li>
 <p>text</p>
@@ -1201,7 +1203,7 @@ fn loose_ordered_list_with_code_block_renders_as_commonmark_loose_list() {
 <p>text</p>
 </li>
 </ol>
-"#;
+";
   assert_eq!(
     convert(html),
     "1. text\n\n   ```\n   text\n   ```\n\n   text\n2. text"
@@ -1211,7 +1213,7 @@ fn loose_ordered_list_with_code_block_renders_as_commonmark_loose_list() {
 // https://github.com/harlan-zw/mdream/issues/81
 #[test]
 fn multiple_paragraphs_in_list_item_separated_by_blank_lines() {
-  let html = r#"
+  let html = r"
 <ol>
     <li>
         <p><strong>text</strong>:</p>
@@ -1220,7 +1222,7 @@ fn multiple_paragraphs_in_list_item_separated_by_blank_lines() {
         <pre><code>text</code></pre>
     </li>
 </ol>
-"#;
+";
   assert_eq!(
     convert(html),
     "1. **text**:\n\n   text\n\n   text\n\n   ```\n   text\n   ```"
@@ -1527,6 +1529,7 @@ fn strips_script() {
 }
 
 #[test]
+#[allow(clippy::literal_string_with_formatting_args)]
 fn strips_style() {
   assert_eq!(
     convert("<p>Before</p><style>.x{color:red}</style><p>After</p>"),
@@ -1715,13 +1718,13 @@ fn streaming_empty() {
 fn large_table() {
   let mut html = String::from("<table><tr>");
   for i in 0..10 {
-    html.push_str(&format!("<th>Col{i}</th>"));
+    write!(html, "<th>Col{i}</th>").expect("writing to a String cannot fail");
   }
   html.push_str("</tr>");
   for _ in 0..100 {
     html.push_str("<tr>");
     for i in 0..10 {
-      html.push_str(&format!("<td>Val{i}</td>"));
+      write!(html, "<td>Val{i}</td>").expect("writing to a String cannot fail");
     }
     html.push_str("</tr>");
   }
@@ -2226,7 +2229,7 @@ fn filter_exclude_empty_link_title_in_footer() {
           exclude: Some(vec!["footer".to_string()]),
           ..Default::default()
         }),
-        isolate_main: Some(IsolateMainConfig::default()),
+        isolate_main: Some(IsolateMainConfig),
         ..Default::default()
       }),
       ..Default::default()

--- a/crates/core/tests/depth_limit.rs
+++ b/crates/core/tests/depth_limit.rs
@@ -1,6 +1,6 @@
 use mdream::{
   FilterConfig, HTMLToMarkdownOptions, MarkdownStreamProcessor, PluginConfig, TagOverrideConfig,
-  html_to_markdown,
+  TailwindConfig, html_to_markdown,
 };
 
 const LIMIT: usize = 512;
@@ -302,7 +302,7 @@ fn output_neutral_plugins_keep_visible_overflow_content() {
       ..Default::default()
     },
     PluginConfig {
-      tailwind: Some(Default::default()),
+      tailwind: Some(TailwindConfig),
       ..Default::default()
     },
   ] {
@@ -360,7 +360,7 @@ fn hidden_raw_overflow_root_scans_as_raw_text() {
       ..Default::default()
     },
     PluginConfig {
-      tailwind: Some(Default::default()),
+      tailwind: Some(TailwindConfig),
       ..Default::default()
     },
   ] {
@@ -388,7 +388,7 @@ fn only_plugin_hidden_subtrees_start_opaque_overflow() {
       ..Default::default()
     },
     PluginConfig {
-      tailwind: Some(Default::default()),
+      tailwind: Some(TailwindConfig),
       ..Default::default()
     },
   ] {

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -3,6 +3,7 @@
 
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::cell::Cell;
+use std::fmt::Write as _;
 
 use mdream::MarkdownStreamProcessor;
 use mdream::types::{
@@ -168,6 +169,8 @@ fn streamed_output_matches_one_shot() {
 
 // Streaming must equal one-shot for these parse-layer cases (drain-transparent).
 // Each asserts across chunk sizes so a boundary landing anywhere is covered.
+// Owned options keep the many test call sites concise while this helper clones them.
+#[allow(clippy::needless_pass_by_value)]
 fn assert_stream_matches(html: &str, opts: HTMLToMarkdownOptions) {
   let expected = html_to_markdown(html, opts.clone());
   for chunk in 1..=html.len().max(1) {
@@ -179,6 +182,8 @@ fn assert_stream_matches(html: &str, opts: HTMLToMarkdownOptions) {
   }
 }
 
+// Owned options keep the many test call sites concise while this helper clones them.
+#[allow(clippy::needless_pass_by_value)]
 fn assert_stream_matches_every_split(html: &str, opts: HTMLToMarkdownOptions) {
   let expected = html_to_markdown(html, opts.clone());
   for split in (0..=html.len()).filter(|&split| html.is_char_boundary(split)) {
@@ -613,9 +618,8 @@ fn streaming_keeps_trailing_nbsp_before_sibling() {
 fn streaming_keeps_raw_block_close_after_drain() {
   let mut html = String::from("<article>");
   for i in 0..400 {
-    html.push_str(&format!(
-      "<p>Filler paragraph number {i} with some words.</p>"
-    ));
+    write!(html, "<p>Filler paragraph number {i} with some words.</p>")
+      .expect("writing to a String cannot fail");
   }
   html.push_str(
     "<dl><dt>MPN:</dt><dd>D100-V36-PBO-1WZ</dd>\
@@ -640,9 +644,8 @@ fn streaming_keeps_raw_block_close_after_drain() {
 fn drain_filler() -> String {
   let mut s = String::new();
   for i in 0..400 {
-    s.push_str(&format!(
-      "<p>Filler paragraph number {i} with some words.</p>"
-    ));
+    write!(s, "<p>Filler paragraph number {i} with some words.</p>")
+      .expect("writing to a String cannot fail");
   }
   s
 }

--- a/crates/core/tests/streaming_scaling.rs
+++ b/crates/core/tests/streaming_scaling.rs
@@ -75,7 +75,9 @@ fn allocation_per_byte(html: &str) -> f64 {
   let before = TOTAL.load(Ordering::Relaxed);
   black_box(stream(html));
   let allocated = TOTAL.load(Ordering::Relaxed).saturating_sub(before);
-  allocated as f64 / html.len() as f64
+  let allocated = f64::from(u32::try_from(allocated).expect("allocation count fits in u32"));
+  let input = f64::from(u32::try_from(html.len()).expect("test input length fits in u32"));
+  allocated / input
 }
 
 fn repeat_to(prefix: &str, unit: &str, target: usize, suffix: &str) -> String {


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Running `cargo clippy --workspace --exclude mdream-edge --all-targets --locked -- -D warnings` failed on library, test, and benchmark targets. Checked conversions and borrowed benchmark options clear the failures without changing converter output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved streaming and one-shot conversion efficiency by reducing unnecessary option copying.
  * Refined benchmark timing and size calculations for more accurate results.

* **Reliability**
  * Added safer numeric conversions in conversion, scanning, and benchmark calculations.
  * Improved CLI streaming cleanup before final output is written.

* **Maintenance**
  * Simplified internal formatting, configuration setup, and test organization without changing expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->