### PR TITLE
fix(core): two more streaming/one-shot divergences

### DIFF
--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -1564,6 +1564,10 @@ impl ConvertState {
     let bytes = self.buffer.as_bytes();
     self.flushed_tail = if drain_end >= 2 {
       [bytes[drain_end - 2], bytes[drain_end - 1]]
+    } else if self.cut_line_lead == CutLineLead::Uncut {
+      // Nothing precedes a first cut this small: shifting the document-start
+      // sentinel in would invent a newline that cancels a real block separator.
+      [0, bytes[0]]
     } else {
       [self.flushed_tail[1], bytes[0]]
     };

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -348,8 +348,10 @@ impl ConvertState {
       ];
     }
 
+    self.scan_before_requote(content_end);
     self.buffer.truncate(frame.content_start);
     self.buffer.push_str(&quoted);
+    self.shift_raw_html_scan(content_end, quoted_end);
     self.last_content_cache_len = quoted.len();
     self.blockquote_scratch = quoted;
     // Quoting inserted a `> ` and a newline per line, so a line the scan had
@@ -414,8 +416,11 @@ impl ConvertState {
         }
         quoted.push('\n');
       }
+      self.scan_before_requote(flush_end);
       self.buffer.replace_range(shared_start..flush_end, &quoted);
-      flush_end = shared_start + quoted.len();
+      let quoted_end = shared_start + quoted.len();
+      self.shift_raw_html_scan(flush_end, quoted_end);
+      flush_end = quoted_end;
       self.blockquote_scratch = quoted;
       for frame in &mut self.blockquotes {
         frame.content_start = flush_end;
@@ -425,6 +430,10 @@ impl ConvertState {
       return;
     }
 
+    // Every frame re-quotes the same region, so only the first pass sees the
+    // bytes unquoted; the rest just move them further.
+    let unquoted_end = flush_end;
+    self.scan_before_requote(unquoted_end);
     // Taken once for the whole walk: every frame rewrites the same region again,
     // so without this each nesting level allocates its own copy of it per flush.
     let mut quoted = core::mem::take(&mut self.blockquote_scratch);
@@ -453,6 +462,7 @@ impl ConvertState {
       flush_end = frame.content_start + quoted.len();
     }
     self.blockquote_scratch = quoted;
+    self.shift_raw_html_scan(unquoted_end, flush_end);
 
     for frame in &mut self.blockquotes {
       frame.content_start = flush_end;
@@ -2025,6 +2035,26 @@ impl ConvertState {
       self.clamp_item_marker_end(trimmed_len);
       self.buffer.truncate(trimmed_len);
     }
+  }
+
+  // The blank-line scan holds an absolute buffer offset, so quoting has to scan
+  // the bytes it is about to move while they still read the way one-shot sees
+  // them. Call before the rewrite, `shift_raw_html_scan` after it.
+  fn scan_before_requote(&mut self, old_end: usize) {
+    if self.raw_html_scanned_to < old_end && self.in_raw_html_block() {
+      self.track_raw_html_markdown_context(old_end);
+    }
+  }
+
+  // Quoting `[_, old_end)` into `[_, new_end)` moves every byte after it.
+  fn shift_raw_html_scan(&mut self, old_end: usize, new_end: usize) {
+    self.raw_html_scanned_to = if self.raw_html_scanned_to < old_end {
+      // A blank line among the quoted bytes is a `>` line now, which the scan
+      // would not match, and the cursor is rebased before it is next read.
+      new_end
+    } else {
+      self.raw_html_scanned_to + new_end - old_end
+    };
   }
 
   #[inline]

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -1661,3 +1661,27 @@ fn streaming_keeps_the_raw_html_blank_line_scan_aligned_across_quoting() {
     );
   }
 }
+
+// `flushed_tail` holds the two bytes before `buffer[0]`, so a block boundary can
+// count the newlines already separating it from the last block. A first cut that
+// takes a single byte has no byte two back, and shifting the document-start
+// sentinel into that slot claimed a newline there, cancelling a separator
+// one-shot writes -- joining two list items onto one line.
+#[test]
+fn streaming_does_not_invent_a_newline_behind_a_single_byte_cut() {
+  let html = "<li><pre>x<x>              <x><li>x";
+  let opts = HTMLToMarkdownOptions::default();
+  let expected = html_to_format_result(html, opts.clone(), OutputFormat::Text).markdown;
+  for chunk in 1..=html.len() {
+    let mut p = MarkdownStreamProcessor::new_with_format(opts.clone(), OutputFormat::Text);
+    let mut actual = String::new();
+    let mut start = 0;
+    while start < html.len() {
+      let end = (start + chunk).min(html.len());
+      actual.push_str(&p.process_chunk(&html[start..end]));
+      start = end;
+    }
+    actual.push_str(&p.finish());
+    assert_eq!(actual, expected, "chunk={chunk}");
+  }
+}

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -1639,3 +1639,25 @@ fn streaming_separates_a_paragraph_from_text_it_has_already_yielded() {
     assert_eq!(actual, expected, "chunk={chunk}");
   }
 }
+
+// A blank line breaks an open raw-HTML region, which the escape gate reads off a
+// scan cursor holding an absolute buffer offset. Quoting a large blockquote's
+// completed lines in place grows that region, moving every byte after it, so the
+// cursor pointed short of where it had scanned to and the window reached back to
+// a blank line from before the region opened -- escaping a `[` one-shot passes
+// through. The text run crosses the flush threshold before `<dl>` opens.
+#[test]
+fn streaming_keeps_the_raw_html_blank_line_scan_aligned_across_quoting() {
+  let html = format!(
+    "{}<blockquote>xxxxxxxx>xxxxxxxxxxxxxxxxxx>xxxxxxxxxxxxxxxx>xxx>xxx>xxx<h3>xx><h3><h3><h3><dl>xxxxxxxx><x>[",
+    "x".repeat(8100)
+  );
+  let expected = html_to_markdown(&html, HTMLToMarkdownOptions::default());
+  for chunk in [512, 4096] {
+    assert_eq!(
+      stream_chars(&html, chunk, HTMLToMarkdownOptions::default()),
+      expected,
+      "chunk={chunk}"
+    );
+  }
+}


### PR DESCRIPTION
Two streaming/one-shot divergences found by differential fuzzing, each a case of the drain
yielding bytes a later rewrite would have changed. Both are pre-existing, independent, and
fixed separately with a regression test that fails without its fix.

- `fix(core): keep the raw-HTML blank-line scan aligned across quoting` — quoting a large
  blockquote in place moves every byte after it, but `raw_html_scanned_to` (an absolute
  offset) was not shifted, so the rescan reached back to a blank line from before the
  raw-HTML region opened and escaped a `[` one-shot passes through. The same rewrite
  already remaps `fragment_links`, `code_spans` and `code_fence`.
- `fix(core): stop a single-byte drain inventing a newline behind itself` — a first drain
  cutting one byte filled `flushed_tail[1]` by shifting the document-start sentinel in,
  claiming a newline before the first output byte and cancelling a block separator, so two
  list items were joined onto one line.

No behaviour change to one-shot conversion: over 239,366 corpus inputs the one-shot output
hash is identical for all three output formats.

Cost is unchanged — peak memory, allocation volume and allocation count are identical on
six blockquote workloads including a 4 MB `<blockquote><dl>` document. Streaming stays
O(window); notably, deferring the flush to fix the first bug instead would take peak from
87 KB to 12.3 MB on that document.

Separately, streamed `OutputFormat::Html` diverges from one-shot on a large share of the
corpus — one systematic rule (one-shot keeps a whitespace byte streaming drops, e.g.
`<hr>\r` → `"<hr> "` vs `"<hr>"`). Not touched here: Markdown and Text are unaffected, and
one-shot looks like the wrong side for the document-end cases, so which side is correct
needs deciding first. Html has no streaming test or fuzz target today.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed streaming Markdown output when content is split at very short buffer boundaries.
  - Corrected preservation of trailing bytes during incremental processing.
  - Fixed raw HTML handling within blockquotes, including nested and streamed blockquotes.
  - Prevented incorrect blank lines or invented newlines from appearing in rendered output.

- **Tests**
  - Added regression coverage for blockquote raw HTML scanning and single-byte streaming splits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->