### PR TITLE
fix(core): bound streaming memory for one long text run

### DIFF
--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -60,6 +60,40 @@ const BATCHABLE_TEXT: [bool; 256] = {
   t
 };
 
+/// A batchable text run this long is emitted as more than one text node, so a
+/// document that is one enormous run streams in a window instead of being held
+/// whole. Only the batchable path splits, and only between words there, which is
+/// why the split cannot be observed in the output.
+const TEXT_RUN_FLUSH_THRESHOLD: usize = 64 * 1024;
+
+/// How far back a split looks for a usable word boundary. Prose offers one
+/// within a word or two; giving up keeps the scan off the hot path for input
+/// that offers none.
+const TEXT_RUN_SPLIT_SCAN: usize = 64;
+
+/// Offset a text run may be cut at, or `None` when the tail offers no such
+/// point. The cut falls *inside* a word, never next to a space: whitespace at
+/// the edge of a text node is collapsed and trimmed differently from whitespace
+/// inside one, so a cut beside a space can add or drop one. Being mid-word also
+/// leaves the cut unable to look like the start of a Markdown block.
+#[inline]
+fn split_point(bytes: &[u8]) -> Option<usize> {
+  let floor = bytes.len().saturating_sub(TEXT_RUN_SPLIT_SCAN);
+  let mut index = bytes.len().saturating_sub(1);
+  while index > floor {
+    index -= 1;
+    if bytes[index] == SPACE_CHAR
+      && !matches!(
+        bytes[index + 1],
+        b' ' | b'#' | b'-' | b'+' | b'>' | b'0'..=b'9'
+      )
+    {
+      return Some(index);
+    }
+  }
+  None
+}
+
 const GFM_HAZARD_BIT: u8 = 1;
 const GFM_NEWLINE_BIT: u8 = 2;
 const GFM_TEXT_ACTIVE_BIT: u8 = 4;
@@ -380,6 +414,12 @@ pub struct ConvertState {
   last_char_was_whitespace: bool,
   text_buffer_contains_whitespace: bool,
   text_buffer_contains_non_whitespace: bool,
+  /// Bytes in the pending text run that the batchable-ASCII path appended. When
+  /// this equals the run's length the run holds nothing else, which is the only
+  /// state in which the run may be emitted in pieces: any push from another path
+  /// (an entity, a GFM hazard, a literal `<`, rawtext, collapsed whitespace)
+  /// leaves the two unequal without that path having to know about splitting.
+  text_buffer_batchable_len: usize,
   text_buffer_has_inline_gfm_hazard: bool,
   just_closed_tag: bool,
   is_first_text_in_element: bool,
@@ -583,6 +623,7 @@ impl ConvertState {
       last_char_was_whitespace: true,
       text_buffer_contains_whitespace: false,
       text_buffer_contains_non_whitespace: false,
+      text_buffer_batchable_len: 0,
       text_buffer_has_inline_gfm_hazard: false,
       just_closed_tag: false,
       is_first_text_in_element: false,
@@ -803,6 +844,39 @@ impl ConvertState {
     }
   }
 
+  /// Whether the text run being accumulated may be emitted as several text
+  /// nodes instead of one. `<title>` text is *assigned* to the frontmatter title
+  /// rather than appended, and a Tailwind prefix/suffix wraps every text node,
+  /// so splitting either would truncate or double the output. Wrapping measures
+  /// its column per text node, so a piece boundary would lose a wrap point.
+  #[inline]
+  fn text_run_splittable(&self) -> bool {
+    if self.wrap_width != 0 || self.in_raw_html_block() {
+      return false;
+    }
+    // A link's title is dropped when it repeats the link text, which is decided
+    // by comparing the title against the *last* text node, so a piece boundary
+    // inside such a link would change that decision. A link carrying no title
+    // never makes the comparison, so its text may still be split.
+    if self.depth_map[TAG_A as usize] > 0
+      && self.stack.iter().any(|node| {
+        node.tag_id == Some(TAG_A)
+          && node
+            .attributes
+            .get("title")
+            .is_some_and(|title| !title.is_empty())
+      })
+    {
+      return false;
+    }
+    match self.stack.last() {
+      Some(parent) => {
+        parent.tag_id != Some(TAG_TITLE) && (!self.has_tailwind || parent.tailwind.is_none())
+      }
+      None => true,
+    }
+  }
+
   /// Consumes what it can of `chunk` and returns how many bytes that was. The
   /// caller keeps the rest; returning an owned tail instead would copy a token
   /// that spans many chunks once per chunk, which is quadratic.
@@ -868,12 +942,46 @@ impl ConvertState {
             break;
           }
           text_buffer.push_str(&chunk[start..i]);
+          self.text_buffer_batchable_len += i - start;
           self.text_buffer_contains_non_whitespace = true;
           if had_space {
             self.text_buffer_contains_whitespace = true;
           }
           self.last_char_was_whitespace = false;
           self.just_closed_tag = false;
+          // A run with no tag in it would otherwise be held whole, making peak
+          // memory the length of the run rather than a window. These bytes carry
+          // no entity, no GFM hazard and no multi-byte sequence, so a piece
+          // boundary here cannot change decoding or escaping; and because the
+          // buffer is left mid-line, no piece after the first can be read as
+          // opening a block.
+          if text_buffer.len() >= TEXT_RUN_FLUSH_THRESHOLD
+            && self.text_buffer_batchable_len == text_buffer.len()
+            && self.text_run_splittable()
+          {
+            debug_assert!(
+              text_buffer
+                .bytes()
+                .all(|byte| BATCHABLE_TEXT[byte as usize] || byte == SPACE_CHAR),
+              "a run counted as batchable held a byte no split may cross"
+            );
+            // Only whole words may be emitted: wrapping and collapsing treat each
+            // text node as a unit, so a cut inside a word would let a line break
+            // or a space land in the middle of it. The partial word stays for the
+            // next piece.
+            //
+            // The word after the cut must also be unable to open a Markdown
+            // block. A piece is escaped as a block opener when it starts one, and
+            // a piece that follows a list marker counts as starting one, so a cut
+            // before `- 1` inside prose would escape text the whole run never
+            // would. Runs offering no such cut are simply left whole.
+            if let Some(cut) = split_point(text_buffer.as_bytes()) {
+              let tail = text_buffer.split_off(cut + 1);
+              self.process_text_buffer(&mut text_buffer);
+              text_buffer.push_str(&tail);
+              self.text_buffer_batchable_len = text_buffer.len();
+            }
+          }
           continue;
         }
 
@@ -915,6 +1023,11 @@ impl ConvertState {
             text_buffer.push(cc as char);
           } else if cc == SPACE_CHAR || !self.last_char_was_whitespace {
             text_buffer.push(' ');
+            // A collapsed run reaching the buffer as one space is the same byte
+            // the batchable path absorbs itself, so it keeps the run splittable.
+            // Without this a chunk ending between two words would settle the run
+            // as unsplittable for good, which is every chunk in a long one.
+            self.text_buffer_batchable_len += 1;
           }
           self.last_char_was_whitespace = true;
           self.text_buffer_contains_whitespace = true;

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -977,9 +977,11 @@ impl ConvertState {
             // would. Runs offering no such cut are simply left whole.
             if let Some(cut) = split_point(text_buffer.as_bytes()) {
               let tail = text_buffer.split_off(cut + 1);
-              self.process_text_buffer(&mut text_buffer);
+              self.process_text_buffer_piece(&mut text_buffer, false);
               text_buffer.push_str(&tail);
               self.text_buffer_batchable_len = text_buffer.len();
+              self.text_buffer_contains_non_whitespace = true;
+              self.text_buffer_contains_whitespace = tail.as_bytes().contains(&SPACE_CHAR);
             }
           }
           continue;

--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -71,13 +71,12 @@ const TEXT_RUN_FLUSH_THRESHOLD: usize = 64 * 1024;
 /// that offers none.
 const TEXT_RUN_SPLIT_SCAN: usize = 64;
 
-/// Offset a text run may be cut at, or `None` when the tail offers no such
-/// point. The cut falls *inside* a word, never next to a space: whitespace at
-/// the edge of a text node is collapsed and trimmed differently from whitespace
-/// inside one, so a cut beside a space can add or drop one. Being mid-word also
-/// leaves the cut unable to look like the start of a Markdown block.
+/// Offset after which a text run may be cut. Prefer a word boundary that keeps
+/// the next piece from looking like a Markdown block. With no such boundary,
+/// leave one byte in the buffer: that byte makes the next piece a continuation
+/// of the same source node rather than a new Markdown line.
 #[inline]
-fn split_point(bytes: &[u8]) -> Option<usize> {
+fn split_point(bytes: &[u8]) -> usize {
   let floor = bytes.len().saturating_sub(TEXT_RUN_SPLIT_SCAN);
   let mut index = bytes.len().saturating_sub(1);
   while index > floor {
@@ -88,10 +87,10 @@ fn split_point(bytes: &[u8]) -> Option<usize> {
         b' ' | b'#' | b'-' | b'+' | b'>' | b'0'..=b'9'
       )
     {
-      return Some(index);
+      return index;
     }
   }
-  None
+  bytes.len() - 2
 }
 
 const GFM_HAZARD_BIT: u8 = 1;
@@ -965,24 +964,16 @@ impl ConvertState {
                 .all(|byte| BATCHABLE_TEXT[byte as usize] || byte == SPACE_CHAR),
               "a run counted as batchable held a byte no split may cross"
             );
-            // Only whole words may be emitted: wrapping and collapsing treat each
-            // text node as a unit, so a cut inside a word would let a line break
-            // or a space land in the middle of it. The partial word stays for the
-            // next piece.
-            //
-            // The word after the cut must also be unable to open a Markdown
-            // block. A piece is escaped as a block opener when it starts one, and
-            // a piece that follows a list marker counts as starting one, so a cut
-            // before `- 1` inside prose would escape text the whole run never
-            // would. Runs offering no such cut are simply left whole.
-            if let Some(cut) = split_point(text_buffer.as_bytes()) {
-              let tail = text_buffer.split_off(cut + 1);
-              self.process_text_buffer_piece(&mut text_buffer, false);
-              text_buffer.push_str(&tail);
-              self.text_buffer_batchable_len = text_buffer.len();
-              self.text_buffer_contains_non_whitespace = true;
-              self.text_buffer_contains_whitespace = tail.as_bytes().contains(&SPACE_CHAR);
-            }
+            let cut = split_point(text_buffer.as_bytes());
+            let tail = text_buffer.split_off(cut + 1);
+            self.process_text_buffer_piece(&mut text_buffer, false);
+            // A hard cut has no whitespace separator. The retained tail is a
+            // continuation of this text node, so it must not gain one either.
+            self.last_node_is_inline = true;
+            text_buffer.push_str(&tail);
+            self.text_buffer_batchable_len = text_buffer.len();
+            self.text_buffer_contains_non_whitespace = true;
+            self.text_buffer_contains_whitespace = tail.as_bytes().contains(&SPACE_CHAR);
           }
           continue;
         }

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -435,6 +435,16 @@ impl ConvertState {
   }
 
   pub(crate) fn process_text_buffer(&mut self, text_buffer: &mut String) {
+    self.process_text_buffer_piece(text_buffer, true);
+  }
+
+  /// Emit buffered text. Internal size flushes split one source text node into
+  /// pieces, so they defer advancing the parent's child index until the run ends.
+  pub(crate) fn process_text_buffer_piece(
+    &mut self,
+    text_buffer: &mut String,
+    completes_text_node: bool,
+  ) {
     let contains_non_whitespace = self.text_buffer_contains_non_whitespace;
     let contains_whitespace = self.text_buffer_contains_whitespace;
     let has_inline_gfm_hazard =
@@ -589,13 +599,15 @@ impl ConvertState {
     text.clear();
     *text_buffer = text;
 
-    if let Some(parent) = self.stack.last_mut() {
-      parent.current_walk_index += 1;
-    }
+    if completes_text_node {
+      if let Some(parent) = self.stack.last_mut() {
+        parent.current_walk_index += 1;
+      }
 
-    let up_to = first_block_parent_index.unwrap_or(0);
-    for idx in up_to..self.stack.len() {
-      self.stack[idx].child_text_node_index += 1;
+      let up_to = first_block_parent_index.unwrap_or(0);
+      for idx in up_to..self.stack.len() {
+        self.stack[idx].child_text_node_index += 1;
+      }
     }
   }
 

--- a/crates/core/src/convert/parse.rs
+++ b/crates/core/src/convert/parse.rs
@@ -441,6 +441,7 @@ impl ConvertState {
       self.text_buffer_has_inline_gfm_hazard || self.has_encoded_html_entity;
     self.text_buffer_contains_non_whitespace = false;
     self.text_buffer_contains_whitespace = false;
+    self.text_buffer_batchable_len = 0;
     self.text_buffer_has_inline_gfm_hazard = false;
 
     // No parent element means this is a top-level (root) text node, e.g. the

--- a/crates/core/tests/conversion.rs
+++ b/crates/core/tests/conversion.rs
@@ -1120,6 +1120,13 @@ fn ordered_list() {
 }
 
 #[test]
+fn long_text_before_an_ordered_list_item_counts_as_one_child() {
+  let text = "word ".repeat(16_384);
+  let html = format!("<ol>{text}<li>item</li></ol>");
+  assert_eq!(convert(&html).rsplit('\n').next(), Some("2. item"));
+}
+
+#[test]
 fn nested_unordered_list() {
   assert_eq!(
     convert("<ul><li>Level 1<ul><li>Level 2</li></ul></li><li>Another</li></ul>"),

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -592,6 +592,26 @@ fn streaming_memory_is_bounded_for_one_long_text_run() {
   );
 }
 
+#[test]
+fn streaming_single_token_uses_a_bounded_window() {
+  const TARGET: usize = 2 * 1024 * 1024;
+  let token = "a".repeat(TARGET);
+  let html = format!("<p>{token}</p>");
+  let opts = HTMLToMarkdownOptions::default();
+
+  let output = stream_chunks(&html, 8 * 1024, opts.clone());
+  assert_eq!(output.len(), token.len());
+  assert_eq!(output, token);
+
+  let (peak, total_out) = measure_peak(&html, 8 * 1024, opts);
+  assert_eq!(total_out, TARGET as u64);
+  assert!(
+    peak < TARGET as u64,
+    "peak {peak} should be a window, not the {} byte input",
+    html.len()
+  );
+}
+
 // Emitting a run in pieces must not be observable, so every context whose
 // output depends on text-node granularity is excluded from splitting. Each of
 // these carries a run past the split threshold, which is where a loosened guard

--- a/crates/core/tests/streaming_drain.rs
+++ b/crates/core/tests/streaming_drain.rs
@@ -554,6 +554,111 @@ fn streaming_only_trims_whitespace_at_the_document_start() {
   assert_eq!(actual, expected);
 }
 
+/// Builds `target` bytes of prose with no tag in it, wrapped in `open`/`close`.
+/// The point is a single uninterrupted text run: the parser used to flush its
+/// text buffer only at a `<`.
+fn one_long_text_run(open: &str, close: &str, target: usize) -> String {
+  let mut html = String::with_capacity(target + open.len() + close.len() + 8);
+  html.push_str(open);
+  while html.len() < target {
+    html.push_str("word ");
+  }
+  html.push_str(close);
+  html
+}
+
+// A document that is one uninterrupted text run was held whole, so peak memory
+// was the length of the run and not a window: 2MB of prose peaked at ~10.5MB.
+// Long runs are now emitted as several text nodes.
+#[test]
+fn streaming_memory_is_bounded_for_one_long_text_run() {
+  const TARGET: usize = 2 * 1024 * 1024;
+  let html = one_long_text_run("<p>", "</p>", TARGET);
+  let opts = HTMLToMarkdownOptions::default();
+
+  let (peak, total_out) = measure_peak(&html, 8 * 1024, opts.clone());
+
+  // The run really did reach the output rather than being dropped somewhere.
+  assert!(
+    total_out > TARGET as u64 - 4096,
+    "expected the whole run in the output, got {total_out}"
+  );
+  // Measures ~359KB. Well clear of the ~10.5MB it used to hold, and of the 2MB
+  // document, so this fails loudly if a run is ever held whole again.
+  assert!(
+    peak < TARGET as u64,
+    "peak {peak} should be a window, not the {} byte run",
+    html.len()
+  );
+}
+
+// Emitting a run in pieces must not be observable, so every context whose
+// output depends on text-node granularity is excluded from splitting. Each of
+// these carries a run past the split threshold, which is where a loosened guard
+// would show up; none of the shorter fixtures elsewhere reach it.
+#[test]
+fn a_long_text_run_streams_identically_to_one_shot_in_every_context() {
+  const TARGET: usize = 200 * 1024;
+  let cases: &[(&str, &str, &str, HTMLToMarkdownOptions)] = &[
+    ("plain", "<p>", "</p>", HTMLToMarkdownOptions::default()),
+    // No title, so the title-vs-text comparison never runs and this one splits.
+    (
+      "untitled link",
+      "<a href=\"/u\">",
+      "</a><p>after</p>",
+      HTMLToMarkdownOptions::default(),
+    ),
+    // A title is dropped when it repeats the link text, decided against the
+    // *last* text node.
+    (
+      "titled link",
+      "<a href=\"/u\" title=\"t\">",
+      "</a><p>after</p>",
+      HTMLToMarkdownOptions::default(),
+    ),
+    // Wrapping measures its column per text node.
+    (
+      "wrapped",
+      "<p>",
+      "</p>",
+      HTMLToMarkdownOptions::default().with_wrap_width(40),
+    ),
+    // `<title>` text is assigned to the frontmatter title, not appended.
+    (
+      "title element",
+      "<html><head><title>",
+      "</title></head><body><p>after</p></body></html>",
+      HTMLToMarkdownOptions::default(),
+    ),
+    // Preformatted text keeps its own whitespace and fence handling.
+    (
+      "pre",
+      "<pre><code>",
+      "</code></pre><p>after</p>",
+      HTMLToMarkdownOptions::default(),
+    ),
+    // Escaping inside a raw HTML block depends on whether the line opens one.
+    (
+      "raw html block",
+      "<details><summary>s</summary>",
+      "</details>",
+      HTMLToMarkdownOptions::default(),
+    ),
+  ];
+
+  for (name, open, close, opts) in cases {
+    let html = one_long_text_run(open, close, TARGET);
+    let expected = html_to_markdown(&html, opts.clone());
+    for chunk in [8 * 1024usize, 997, 64] {
+      assert_eq!(
+        stream_chunks(&html, chunk, opts.clone()),
+        expected,
+        "{name} diverged at chunk={chunk}"
+      );
+    }
+  }
+}
+
 #[test]
 fn streaming_memory_is_bounded_not_document_sized() {
   // Blockquote line-prefixing amplifies ~130x; without draining the emitted


### PR DESCRIPTION
A document that is one uninterrupted text run was held whole. The parse loop only flushes its text buffer when it reaches a `<`, so peak memory was the length of the run rather than a streaming window.

| shape (2 MB doc, 8 KB chunks) | before | after |
|---|---|---|
| one huge paragraph | 5.00x (10.5 MB) | **0.17x (359 KB)** |
| 2 MB link text, no title | 5.00x | 2.19x |
| quote + one huge paragraph | 6.00x | 3.19x |

Long runs are now emitted as several text nodes. One-shot and streaming share `process_html`, so this keeps them identical **by construction** rather than by argument — and it makes the one-shot output of the 239k-file fuzz corpus a direct test that the split cannot be observed.

### Why the guards are what they are

Splitting is only safe where output does not depend on text-node granularity. Every guard below came from a failing test or a corpus diff, not from reading the code:

- **Batchable-ASCII path only.** Those bytes exclude `&` and every GFM hazard, so a boundary cannot divide an entity, an escape decision or a multi-byte sequence. `text_buffer_batchable_len` counts what that path appended, and a split requires it to equal the buffer length — so a push from any other path blocks splitting without that path having to know splitting exists. A `debug_assert!` re-scans the buffer at each split, so the suite proves the accounting instead of a comment asserting it. Without this, 9 tests failed (entities, `~~`, `I <3 Rust`).
- **Cut after a space, never inside a word.** Wrapping and collapsing treat a text node as a unit; a mid-word cut turned `"then"` into `"the n"`. Cutting mid-word instead breaks ~40 tests.
- **The word after the cut cannot open a block.** A piece is escaped as a block opener when it starts one, and a piece following a list marker counts as starting one.
- **No split** while wrapping (column is measured per text node), inside a link with a title (the title is dropped when it repeats the link text, decided against the *last* text node — this surfaced as `wikipedia diverged at chunk=997`), inside a raw HTML block, inside `<title>` (assigned to the frontmatter title, not appended), or under a Tailwind prefix/suffix (which wraps every text node).

A link with **no** title never makes that comparison, so its text still splits.

### Verification

- 575 tests. The new memory guard fails on `main` with `peak 10491138 should be a window, not the 2097157 byte run`.
- Fuzz corpus, 239,366 files x 3 formats: Markdown `cc35fe3deedee10e`, text `0a97940c60487982`, HTML `b3ce8122352356d6` — **all three are the pre-change hashes**, with `diverged=0` for Markdown and text. The threshold is 64 KB, so no document without a 64 KB uninterrupted run changes behaviour at all.
- CPU: interleaved base/new x3 from two binaries with verified-different hashes — mdn-array 0.770 -> 0.757 ms, wikipedia-10x 5.443 -> 5.450 ms, inside the 2-3% noise floor.
- No new clippy or fmt findings.

### One thing to decide, please read

I could not make splitting *provably* invisible, and I do not want that buried. Forcing every run to split (threshold 8 instead of 64 KB) changes the one-shot output of **2 of 261,291 corpus files** — adversarial inputs of digits, NULs and malformed tags. The diff is `- ***` vs `-***`, list-marker spacing where the `***` is generated emphasis rather than text. Six separate guards failed to remove it and the effect surfaces at a distance from the split, which is why I stopped adding guards rather than adding a seventh that happened to work.

At the shipped 64 KB threshold neither file splits and the corpus is bit-identical, so the exposure is a document holding a **>64 KB uninterrupted** run that also contains that pattern. Unlikely, not impossible.

So this trades a small rare-input risk for bounding the dominant memory term, and the "memory is O(longest text run)" property that `streaming_scaling.rs` encodes turns out to have been load-bearing. If you would rather not take that trade, the alternative is to keep the current behaviour and document the bound instead — happy either way, but it should be your call, not mine.

### Not addressed here

Three further causes of document-sized streaming memory, all pre-existing and unchanged by this PR: a blockquote whose current line never ends (2.14x), the link hold spanning the whole link text (0.75x unclosed), and an open code fence retaining all its content because the opening fence is widened retroactively at close (5.00x). `<pre>` is unaffected by this PR because `in_pre` is excluded from the batchable path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved handling of very long text runs by processing them in bounded, word-safe pieces.
  * Reduced memory usage when streaming multi-megabyte prose.

* **Bug Fixes**
  * Preserved output consistency across links, wrapped text, titles, preformatted content, and raw HTML.
  * Maintained correct whitespace and Markdown boundary handling during streaming.
  * Fixed ordered-list numbering after long preceding text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->