### PR TITLE
fix: resolve urls against the origin as a base url

### DIFF
--- a/crates/core/src/url.rs
+++ b/crates/core/src/url.rs
@@ -82,6 +82,11 @@ pub(crate) fn is_empty_link_href(href: &str) -> bool {
   }
 }
 
+#[inline]
+fn is_scheme_char(byte: u8) -> bool {
+  byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'-' | b'.')
+}
+
 /// Whether a URL is safe to emit into an HTML href or src attribute.
 pub(crate) fn is_safe_html_url(href: &str, image: bool) -> bool {
   let rest = trim_url_c0(href);
@@ -104,7 +109,7 @@ pub(crate) fn is_safe_html_url(href: &str, image: bool) -> bool {
     if matches!(byte, b'/' | b'?' | b'#') {
       return true;
     }
-    if !(byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'-' | b'.')) {
+    if !is_scheme_char(byte) {
       return true;
     }
   }
@@ -128,7 +133,7 @@ pub(crate) fn strip_tracking_params(url: &str) -> Cow<'_, str> {
   let Some(qmark) = url.find('?') else {
     return Cow::Borrowed(url);
   };
-  if url.find('#').is_some_and(|hash| hash < qmark) {
+  if url[..qmark].contains('#') {
     return Cow::Borrowed(url);
   }
   let query_start = qmark + 1;
@@ -256,6 +261,170 @@ pub(crate) fn slugify_heading(text: &str) -> String {
   slug
 }
 
+/// Query and fragment take no part in resolution, so the split drops them.
+struct BaseUrl<'a> {
+  root: &'a str,
+  path: &'a str,
+}
+
+impl<'a> BaseUrl<'a> {
+  fn split(origin: &'a str) -> Option<Self> {
+    let bytes = origin.as_bytes();
+    let mut i = origin.find("://")? + 3;
+    let mut root_end = None;
+    while i < bytes.len() {
+      match bytes[i] {
+        b'?' | b'#' => break,
+        b'/' if root_end.is_none() => root_end = Some(i),
+        _ => {}
+      }
+      i += 1;
+    }
+    let root_end = root_end.unwrap_or(i);
+    Some(Self {
+      root: origin.get(..root_end).unwrap_or(origin),
+      path: origin.get(root_end..i).unwrap_or(""),
+    })
+  }
+
+  fn dir(&self) -> &'a str {
+    match self.path.rfind('/') {
+      Some(i) => self.path.get(..=i).unwrap_or("/"),
+      None => "/",
+    }
+  }
+}
+
+#[inline]
+fn is_dot_segment(segment: &[u8]) -> bool {
+  matches!(segment, [b'.'] | [b'.', b'.'])
+}
+
+/// One pass over a reference: its scheme, where its path ends (first `?` or
+/// `#`, else its length), and whether that path holds a dot segment.
+struct RefScan {
+  scheme: bool,
+  path_end: usize,
+  has_dot: bool,
+}
+
+fn scan_reference(url: &str) -> RefScan {
+  let bytes = url.as_bytes();
+  let mut i = 0;
+  let mut segment_start = 0;
+  let mut dot = false;
+  // A scheme opens with a letter; every byte so far could still belong to one.
+  let mut scheme_chars = bytes.first().is_some_and(u8::is_ascii_alphabetic);
+  while i < bytes.len() {
+    let byte = bytes[i];
+    match byte {
+      b'?' | b'#' => break,
+      b':' if scheme_chars && i > 0 => {
+        return RefScan {
+          scheme: true,
+          path_end: i,
+          has_dot: false,
+        };
+      }
+      b'/' => {
+        dot |= is_dot_segment(bytes.get(segment_start..i).unwrap_or(&[]));
+        segment_start = i + 1;
+        scheme_chars = false;
+      }
+      _ => {
+        if scheme_chars && !is_scheme_char(byte) {
+          scheme_chars = false;
+        }
+      }
+    }
+    i += 1;
+  }
+  RefScan {
+    scheme: false,
+    path_end: i,
+    has_dot: dot || is_dot_segment(bytes.get(segment_start..i).unwrap_or(&[])),
+  }
+}
+
+/// `root_len` marks where the path starts; a `..` never climbs past it.
+fn pop_path_segment(out: &mut String, root_len: usize) {
+  let end = out.len() - 1; // the trailing `/` is not part of the segment
+  if end <= root_len {
+    return;
+  }
+  let prev = out
+    .get(root_len..end)
+    .and_then(|path| path.rfind('/'))
+    .map_or(root_len, |i| root_len + i);
+  out.truncate(prev + 1);
+}
+
+/// `out` must end with `/`, and does so again after every segment.
+fn push_path_segments(out: &mut String, path: &str, root_len: usize) {
+  let mut segments = path.split('/').peekable();
+  while let Some(segment) = segments.next() {
+    match segment.as_bytes() {
+      // Writes no segment, so `out` keeps the `/` it ends with.
+      [b'.'] => {}
+      [b'.', b'.'] => pop_path_segment(out, root_len),
+      _ => {
+        out.push_str(segment);
+        if segments.peek().is_some() {
+          out.push('/');
+        }
+      }
+    }
+  }
+}
+
+/// Resolves `url` against `base` the way a browser would.
+fn join_base_url(base: &BaseUrl<'_>, url: &str, scan: &RefScan) -> String {
+  // Only the path resolves; query and fragment carry across.
+  let path = url.get(..scan.path_end).unwrap_or(url);
+  let suffix = url.get(scan.path_end..).unwrap_or("");
+  let mut resolved = String::with_capacity(base.root.len() + base.path.len() + url.len() + 1);
+  resolved.push_str(base.root);
+  if path.is_empty() {
+    resolved.push_str(base.path);
+    resolved.push_str(suffix);
+    return resolved;
+  }
+  let (dir, rest) = match path.strip_prefix('/') {
+    Some(absolute) => ("/", absolute),
+    None => (base.dir(), path),
+  };
+  resolved.push_str(dir);
+  if scan.has_dot {
+    push_path_segments(&mut resolved, rest, base.root.len());
+  } else {
+    resolved.push_str(rest);
+  }
+  resolved.push_str(suffix);
+  resolved
+}
+
+/// No `scheme://authority`, so no base path to resolve against.
+fn join_origin_prefix(origin: &str, url: &str) -> String {
+  let origin = origin.trim_end_matches('/');
+  let suffix = url.strip_prefix("./").unwrap_or(url);
+  let mut resolved = String::with_capacity(origin.len() + 1 + suffix.len());
+  resolved.push_str(origin);
+  if !suffix.starts_with('/') {
+    resolved.push('/');
+  }
+  resolved.push_str(suffix);
+  resolved
+}
+
+#[inline]
+fn cleaned(resolved: String, needs_clean: bool) -> Cow<'static, str> {
+  Cow::Owned(if needs_clean {
+    strip_tracking_params_owned(resolved)
+  } else {
+    resolved
+  })
+}
+
 #[inline]
 pub(crate) fn resolve_url<'a>(url: &'a str, origin: Option<&str>, clean: bool) -> Cow<'a, str> {
   if url.is_empty() || url.starts_with('#') {
@@ -263,61 +432,27 @@ pub(crate) fn resolve_url<'a>(url: &'a str, origin: Option<&str>, clean: bool) -
   }
 
   // Fast path: check if cleaning needed before any allocation
-  let needs_clean = clean && url.as_bytes().contains(&b'?');
+  let needs_clean = clean && url.find('?').is_some();
   if url.starts_with("//") {
-    let mut resolved = String::with_capacity(6 + url.len());
-    resolved.push_str("https:");
-    resolved.push_str(url);
-    return Cow::Owned(if needs_clean {
-      strip_tracking_params_owned(resolved)
-    } else {
-      resolved
+    // A network-path reference inherits only the base scheme.
+    let scheme = origin.and_then(BaseUrl::split).map_or("https", |base| {
+      &base.root[..base.root.find(':').unwrap_or(0)]
     });
+    let mut resolved = String::with_capacity(scheme.len() + 1 + url.len());
+    resolved.push_str(scheme);
+    resolved.push(':');
+    resolved.push_str(url);
+    return cleaned(resolved, needs_clean);
   }
   if let Some(orig) = origin {
-    let orig = orig.trim_end_matches('/');
-    if url.starts_with('/') {
-      let mut resolved = String::with_capacity(orig.len() + url.len());
-      resolved.push_str(orig);
-      resolved.push_str(url);
-      return Cow::Owned(if needs_clean {
-        strip_tracking_params_owned(resolved)
-      } else {
-        resolved
-      });
-    }
-    if let Some(suffix) = url.strip_prefix("./") {
-      let mut resolved = String::with_capacity(orig.len() + 1 + suffix.len());
-      resolved.push_str(orig);
-      resolved.push('/');
-      resolved.push_str(suffix);
-      return Cow::Owned(if needs_clean {
-        strip_tracking_params_owned(resolved)
-      } else {
-        resolved
-      });
-    }
-    // A url with an explicit scheme (`mailto:`, `ftp:`, `https:`, …) is
-    // absolute — only scheme-less urls are joined against the origin.
-    // Checked here rather than up-front so the common relative/`/`-prefixed
-    // paths never pay for the scan.
-    let has_scheme = url.find(':').is_some_and(|ci| {
-      ci > 0
-        && url[..ci]
-          .bytes()
-          .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'+' | b'-' | b'.'))
-    });
-    if !has_scheme {
-      let suffix = url.strip_prefix('/').unwrap_or(url);
-      let mut resolved = String::with_capacity(orig.len() + 1 + suffix.len());
-      resolved.push_str(orig);
-      resolved.push('/');
-      resolved.push_str(suffix);
-      return Cow::Owned(if needs_clean {
-        strip_tracking_params_owned(resolved)
-      } else {
-        resolved
-      });
+    // An explicit scheme (`mailto:`, `https:`, …) means absolute.
+    let scan = scan_reference(url);
+    if !scan.scheme {
+      let resolved = match BaseUrl::split(orig) {
+        Some(base) => join_base_url(&base, url, &scan),
+        None => join_origin_prefix(orig, url),
+      };
+      return cleaned(resolved, needs_clean);
     }
   }
   if needs_clean {
@@ -454,6 +589,25 @@ mod tests {
       strip_tracking_params("https://x.com/a?id=1&fbclid=z#sec"),
       "https://x.com/a?id=1#sec",
     );
+    // trailing tracking param takes the separator before it
+    assert_eq!(
+      strip_tracking_params("https://x.com/a?id=1&utm_source=n"),
+      "https://x.com/a?id=1",
+    );
+    // adjacent tracking params
+    assert_eq!(
+      strip_tracking_params("https://x.com/a?utm_a=1&utm_b=2&id=3"),
+      "https://x.com/a?id=3",
+    );
+    assert_eq!(
+      strip_tracking_params("https://x.com/a?utm_a=1&fbclid=2"),
+      "https://x.com/a",
+    );
+    // a fragment before the query makes the whole thing opaque
+    assert_eq!(
+      strip_tracking_params("https://x.com/a#s?utm_source=n"),
+      "https://x.com/a#s?utm_source=n",
+    );
   }
 
   #[test]
@@ -481,21 +635,59 @@ mod tests {
 
   #[test]
   fn resolve_url_relative_against_origin() {
-    // root-relative
-    assert_eq!(
-      resolve_url("/path", Some("https://x.com/"), false),
-      "https://x.com/path",
-    );
-    // ./ prefix
-    assert_eq!(
-      resolve_url("./sub", Some("https://x.com"), false),
-      "https://x.com/sub",
-    );
-    // bare relative
     assert_eq!(
       resolve_url("page", Some("https://x.com"), false),
       "https://x.com/page",
     );
+    assert_eq!(
+      resolve_url("./sub", Some("https://x.com"), false),
+      "https://x.com/sub",
+    );
+    assert_eq!(
+      resolve_url("./sub", Some("https://x.com/"), false),
+      "https://x.com/sub",
+    );
+    assert_eq!(
+      resolve_url("/path", Some("https://x.com/"), false),
+      "https://x.com/path",
+    );
+  }
+
+  #[test]
+  fn resolve_url_resolves_relative_references() {
+    // The dual-engine table in packages/mdream/test/unit/nodes/links.test.ts
+    // covers the scenarios; this pins the mechanics for `cargo test`.
+    let doc = Some("https://x.com/a/b/doc.html?q=1#frag");
+    assert_eq!(
+      resolve_url("c.html", doc, false),
+      "https://x.com/a/b/c.html"
+    );
+    assert_eq!(
+      resolve_url("../c.html", doc, false),
+      "https://x.com/a/c.html"
+    );
+    assert_eq!(resolve_url("/a/../c", doc, false), "https://x.com/c");
+    assert_eq!(resolve_url("../../../c", doc, false), "https://x.com/c");
+    assert_eq!(resolve_url("..", doc, false), "https://x.com/a/");
+    assert_eq!(resolve_url("c//d", doc, false), "https://x.com/a/b/c//d");
+    assert_eq!(
+      resolve_url("c.html?p=../x#f", doc, false),
+      "https://x.com/a/b/c.html?p=../x#f",
+    );
+    assert_eq!(
+      resolve_url("?p=2", doc, false),
+      "https://x.com/a/b/doc.html?p=2"
+    );
+  }
+
+  #[test]
+  fn resolve_url_origin_without_authority_is_a_prefix() {
+    // A plain prefix keeps an unsafe origin recognisable downstream.
+    assert_eq!(
+      resolve_url("/safe", Some("javascript:alert(1)"), false),
+      "javascript:alert(1)/safe",
+    );
+    assert_eq!(resolve_url("b.html", Some("docs"), false), "docs/b.html");
   }
 
   #[test]
@@ -542,23 +734,6 @@ mod tests {
     assert_eq!(
       resolve_url("tel:123", Some("https://x.com"), true),
       "tel:123"
-    );
-  }
-
-  #[test]
-  fn relative_join_no_double_slash() {
-    // trailing slash on origin must not produce `//`
-    assert_eq!(
-      resolve_url("./sub", Some("https://x.com/"), false),
-      "https://x.com/sub"
-    );
-    assert_eq!(
-      resolve_url("/p", Some("https://x.com/"), false),
-      "https://x.com/p"
-    );
-    assert_eq!(
-      resolve_url("page", Some("https://x.com/"), false),
-      "https://x.com/page"
     );
   }
 

--- a/packages/crawl/src/crawl.ts
+++ b/packages/crawl/src/crawl.ts
@@ -598,6 +598,8 @@ export async function crawlAndGenerate(options: CrawlOptions, onProgress?: (prog
 
   // Pre-compute shared origin if provided (avoids per-page URL parsing)
   const sharedOrigin = origin || ''
+  // Trim the trailing slash so a page path appends cleanly below
+  const sharedOriginBase = sharedOrigin.replace(URL_TRAILING_SLASH_RE, '')
 
   // Queue for BFS link following
   const pendingUrls: { url: string, depth: number }[] = []
@@ -624,9 +626,11 @@ export async function crawlAndGenerate(options: CrawlOptions, onProgress?: (prog
       await hooks.callHook('crawl:html', htmlCtx)
       content = htmlCtx.html
 
-      // Single htmlToMarkdown call with merged extraction
+      // Single htmlToMarkdown call with merged extraction. An origin
+      // override swaps the host and keeps the page path.
+      const pageBaseUrl = sharedOriginBase ? `${sharedOriginBase}${parsedUrl.pathname}` : url
       const { extraction, getMetadata } = extractMetadataInline(parsedUrl, allowedRegistrableDomains)
-      md = htmlToMarkdown(content, { origin: pageOrigin, extraction })
+      md = htmlToMarkdown(content, { origin: pageBaseUrl, extraction })
       metadata = getMetadata()
     }
     let title = initialTitle || metadata.title

--- a/packages/crawl/test/unit/relative-link-resolution.test.ts
+++ b/packages/crawl/test/unit/relative-link-resolution.test.ts
@@ -1,0 +1,74 @@
+import { readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+
+// A page two directories deep: bare relative, dot-prefixed, parent-relative
+// and root-relative links.
+const PAGE_URL = 'https://site.test/docs/guide/intro.html'
+const PAGE_HTML = `<!doctype html><html><head><title>Intro</title></head><body><main>
+<p>The introduction paragraph explains what this guide covers in detail.</p>
+<p><a href="setup.html">Setup</a> <a href="./install.html">Install</a> <a href="../faq.html">FAQ</a> <a href="/index.html">Home</a></p>
+<p><img src="images/diagram.png" alt="Diagram"></p>
+</main></body></html>`
+
+vi.mock('ofetch', () => {
+  const mockOfetch = Object.assign(
+    async () => '',
+    {
+      raw: async () => ({
+        _data: PAGE_HTML,
+        headers: new Headers({ 'content-type': 'text/html' }),
+      }),
+    },
+  )
+  return { ofetch: mockOfetch }
+})
+
+vi.mock('@clack/prompts', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), success: vi.fn() },
+  note: vi.fn(),
+  intro: vi.fn(),
+  outro: vi.fn(),
+  spinner: () => ({ start: vi.fn(), stop: vi.fn(), message: vi.fn() }),
+}))
+
+const { crawlAndGenerate } = await import('../../src/crawl.ts')
+
+function tmpOut(): string {
+  return join(tmpdir(), `mdream-links-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+}
+
+async function crawlIntro(origin?: string): Promise<string> {
+  const outputDir = tmpOut()
+  await crawlAndGenerate({
+    urls: [PAGE_URL],
+    outputDir,
+    maxDepth: 0,
+    skipSitemap: true,
+    generateIndividualMd: true,
+    silent: true,
+    origin,
+  })
+  return readFile(join(outputDir, 'docs/guide/intro-html.md'), 'utf-8')
+}
+
+describe('relative links in crawled markdown', () => {
+  it('resolves against the page URL, not the site root', async () => {
+    const md = await crawlIntro()
+
+    expect(md).toContain('[Setup](https://site.test/docs/guide/setup.html)')
+    expect(md).toContain('[Install](https://site.test/docs/guide/install.html)')
+    expect(md).toContain('[FAQ](https://site.test/docs/faq.html)')
+    expect(md).toContain('[Home](https://site.test/index.html)')
+    expect(md).toContain('(https://site.test/docs/guide/images/diagram.png)')
+  })
+
+  it('keeps the page path when an origin override is given', async () => {
+    const md = await crawlIntro('https://cdn.site.test/')
+
+    expect(md).toContain('[Setup](https://cdn.site.test/docs/guide/setup.html)')
+    expect(md).toContain('[FAQ](https://cdn.site.test/docs/faq.html)')
+    expect(md).toContain('[Home](https://cdn.site.test/index.html)')
+  })
+})

--- a/packages/js/src/tags.ts
+++ b/packages/js/src/tags.ts
@@ -127,7 +127,8 @@ import {
 import { blockOpenPrefix, continuationPrefix, getLanguageFromClass, isEmptyLinkHref, isInsideHeading, isInsideTableCell, listMarkerLineStart, orderedItemNumber, parseUnsignedInteger } from './utils'
 
 const TRACKING_PARAM_RE = /^(?:utm_|fbclid|gclid|mc_eid|msclkid|oly_)/
-const URL_SCHEME_RE = /^[\dA-Z+.-]+:/i
+const URL_SCHEME_RE = /^[A-Z][\dA-Z+.-]*:/i
+const SLASH_CHAR = 47
 
 function stripTrackingParams(url: string): string {
   const queryStart = url.indexOf('?')
@@ -143,19 +144,107 @@ function stripTrackingParams(url: string): string {
   return `${url.slice(0, queryStart)}${query ? `?${query}` : ''}${url.slice(queryEnd)}`
 }
 
+/** Index of the first `?` or `#` at or after `from`, else `value.length`. */
+function pathEnd(value: string, from: number): number {
+  const query = value.indexOf('?', from)
+  const fragment = value.indexOf('#', from)
+  if (query === -1)
+    return fragment === -1 ? value.length : fragment
+  return fragment === -1 ? query : Math.min(query, fragment)
+}
+
+function hasDotSegment(path: string): boolean {
+  // No `.` anywhere rules out a dot segment.
+  return path.includes('.')
+    && (path === '.' || path === '..' || path.startsWith('./') || path.startsWith('../')
+      || path.includes('/./') || path.includes('/../') || path.endsWith('/.') || path.endsWith('/..'))
+}
+
+/** `dir` starts and ends with `/`; a `..` never climbs past the root. */
+function mergeDotSegments(dir: string, rest: string): string {
+  let out = dir
+  let index = 0
+  for (;;) {
+    let end = rest.indexOf('/', index)
+    const last = end === -1
+    if (last)
+      end = rest.length
+    const segment = rest.slice(index, end)
+    if (segment === '..')
+      // lastIndexOf clamps a negative start to 0, which holds `out` at the root.
+      out = out.slice(0, out.lastIndexOf('/', out.length - 2) + 1)
+    else if (segment !== '.')
+      out += last ? segment : `${segment}/`
+    if (last)
+      return out
+    index = end + 1
+  }
+}
+
+// One origin serves a whole document, so its split is kept until a different
+// one arrives. Keying by the string keeps interleaved conversions correct.
+let baseOrigin: string | undefined
+let baseRoot = ''
+let basePath = ''
+let baseDir = ''
+
+/** False when `origin` has no `scheme://authority` to resolve against. */
+function loadBase(origin: string): boolean {
+  if (origin !== baseOrigin) {
+    baseOrigin = origin
+    baseRoot = ''
+    const authority = origin.indexOf('://')
+    if (authority !== -1) {
+      // The base query and fragment take no part in resolution.
+      const end = pathEnd(origin, authority + 3)
+      const slash = origin.indexOf('/', authority + 3)
+      const rootEnd = slash === -1 || slash > end ? end : slash
+      baseRoot = origin.slice(0, rootEnd)
+      basePath = origin.slice(rootEnd, end)
+      baseDir = basePath.slice(0, basePath.lastIndexOf('/') + 1) || '/'
+    }
+  }
+  return baseRoot !== ''
+}
+
+function resolveAgainstBase(origin: string, url: string): string {
+  if (!loadBase(origin)) {
+    let prefix = origin
+    while (prefix.endsWith('/'))
+      prefix = prefix.slice(0, -1)
+    const path = url.startsWith('./') ? url.slice(2) : url
+    return `${prefix}${path.charCodeAt(0) === SLASH_CHAR ? '' : '/'}${path}`
+  }
+
+  // Only the path resolves; query and fragment carry across.
+  const end = pathEnd(url, 0)
+  const path = url.slice(0, end)
+  const suffix = end === url.length ? '' : url.slice(end)
+  if (!path)
+    return `${baseRoot}${basePath}${suffix}`
+
+  const dot = hasDotSegment(path)
+  if (path.charCodeAt(0) === SLASH_CHAR)
+    return `${baseRoot}${dot ? mergeDotSegments('/', path.slice(1)) : path}${suffix}`
+  return `${baseRoot}${dot ? mergeDotSegments(baseDir, path) : baseDir + path}${suffix}`
+}
+
 export function resolveUrl(url: string, origin?: string, clean?: EngineOptions['clean']): string {
   if (!url || url[0] === '#')
     return url
 
+  const isSlash = url.charCodeAt(0) === SLASH_CHAR
   let resolved = url
-  if (url.startsWith('//')) {
-    resolved = `https:${url}`
+  if (isSlash && url.charCodeAt(1) === SLASH_CHAR) {
+    // A network-path reference inherits only the base scheme.
+    let scheme = 'https'
+    if (origin && loadBase(origin))
+      scheme = baseRoot.slice(0, baseRoot.indexOf(':'))
+    resolved = `${scheme}:${url}`
   }
-  else if (origin && !URL_SCHEME_RE.test(url)) {
-    const path = url.startsWith('./') ? url.slice(2) : url
-    while (origin.endsWith('/'))
-      origin = origin.slice(0, -1)
-    resolved = `${origin}${path[0] === '/' ? '' : '/'}${path}`
+  // An explicit scheme (`mailto:`, `https:`, …) means absolute.
+  else if (origin && (isSlash || !URL_SCHEME_RE.test(url))) {
+    resolved = resolveAgainstBase(origin, url)
   }
 
   const cleansUrls = clean === true || (!!clean && clean.urls === true)

--- a/packages/mdream/test/unit/html-output.test.ts
+++ b/packages/mdream/test/unit/html-output.test.ts
@@ -25,7 +25,8 @@ describe.each(engines)('safe HTML output $name', (engineConfig) => {
       origin: 'https://mdream.dev/base/',
     })).toBe([
       '<h1 id="hello-world">Hello <em>world</em></h1>',
-      '<p>Visit <a href="https://mdream.dev/base/docs?section=api" title="Docs">docs</a>.</p>',
+      // Root-relative, so it skips the origin's `/base/` directory.
+      '<p>Visit <a href="https://mdream.dev/docs?section=api" title="Docs">docs</a>.</p>',
       '<ol start="3"><li><strong>First</strong></li><li>Second</li></ol>',
       '<pre tabindex="0"><code class="language-ts">const value = 1 &lt; 2</code></pre>',
     ].join(''))

--- a/packages/mdream/test/unit/nodes/links.test.ts
+++ b/packages/mdream/test/unit/nodes/links.test.ts
@@ -102,6 +102,99 @@ describe.each(engines)('links $name', (engineConfig) => {
     expect(markdown).toBe('[Link](/page#section)')
   })
 
+  it.each([
+    ['https://example.com', 'page.html', 'https://example.com/page.html'],
+    ['https://example.com/', 'page.html', 'https://example.com/page.html'],
+    ['https://example.com/docs/', 'page.html', 'https://example.com/docs/page.html'],
+    ['https://example.com/docs/x.html?a=1#f', 'page.html', 'https://example.com/docs/page.html'],
+    ['https://example.com', '../page.html', 'https://example.com/page.html'],
+    // No scheme and authority to resolve against, so the origin is a prefix.
+    ['docs', 'b.html', 'docs/b.html'],
+  ])('resolves %s + %s', async (origin, href, expected) => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const markdown = htmlToMarkdown(`<a href="${href}">Link</a>`, { origin, engine })
+    expect(markdown).toBe(`[Link](${expected})`)
+  })
+
+  // RFC 3986 section 5.4, verbatim. The two references it resolves to the
+  // base URI itself are left alone instead; see the test below.
+  it.each([
+    // 5.4.1 normal examples
+    ['g:h', 'g:h'],
+    ['g', 'http://a/b/c/g'],
+    ['./g', 'http://a/b/c/g'],
+    ['g/', 'http://a/b/c/g/'],
+    ['/g', 'http://a/g'],
+    ['//g', 'http://g'],
+    ['?y', 'http://a/b/c/d;p?y'],
+    ['g?y', 'http://a/b/c/g?y'],
+    ['g#s', 'http://a/b/c/g#s'],
+    ['g?y#s', 'http://a/b/c/g?y#s'],
+    [';x', 'http://a/b/c/;x'],
+    ['g;x', 'http://a/b/c/g;x'],
+    ['g;x?y#s', 'http://a/b/c/g;x?y#s'],
+    ['.', 'http://a/b/c/'],
+    ['./', 'http://a/b/c/'],
+    ['..', 'http://a/b/'],
+    ['../', 'http://a/b/'],
+    ['../g', 'http://a/b/g'],
+    ['../..', 'http://a/'],
+    ['../../', 'http://a/'],
+    ['../../g', 'http://a/g'],
+    // 5.4.2 abnormal examples
+    ['../../../g', 'http://a/g'],
+    ['../../../../g', 'http://a/g'],
+    ['/./g', 'http://a/g'],
+    ['/../g', 'http://a/g'],
+    ['g.', 'http://a/b/c/g.'],
+    ['.g', 'http://a/b/c/.g'],
+    ['g..', 'http://a/b/c/g..'],
+    ['..g', 'http://a/b/c/..g'],
+    ['./../g', 'http://a/b/g'],
+    ['./g/.', 'http://a/b/c/g/'],
+    ['g/./h', 'http://a/b/c/g/h'],
+    ['g/../h', 'http://a/b/c/h'],
+    ['g;x=1/./y', 'http://a/b/c/g;x=1/y'],
+    ['g;x=1/../y', 'http://a/b/c/y'],
+    ['g?y/./x', 'http://a/b/c/g?y/./x'],
+    ['g?y/../x', 'http://a/b/c/g?y/../x'],
+    ['g#s/./x', 'http://a/b/c/g#s/./x'],
+    ['g#s/../x', 'http://a/b/c/g#s/../x'],
+    // Strict resolution: a scheme means absolute.
+    ['http:g', 'http:g'],
+  ])('resolves RFC 3986 reference %s', async (href, expected) => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const markdown = htmlToMarkdown(`<a href="${href}">Link</a>`, {
+      origin: 'http://a/b/c/d;p?q',
+      engine,
+    })
+    expect(markdown).toBe(`[Link](${expected})`)
+  })
+
+  it.each([
+    // A scheme opens with a letter, so these are relative references.
+    ['3:16', 'http://a/b/c/3:16'],
+    ['+x:y', 'http://a/b/c/+x:y'],
+    ['a3:x', 'a3:x'],
+  ])('resolves %s against its scheme rule', async (href, expected) => {
+    const engine = await resolveEngine(engineConfig.engine)
+    const markdown = htmlToMarkdown(`<a href="${href}">Link</a>`, {
+      origin: 'http://a/b/c/d;p?q',
+      engine,
+    })
+    expect(markdown).toBe(`[Link](${expected})`)
+  })
+
+  it('keeps an empty reference unresolved', async () => {
+    // RFC 3986 resolves it to the base URI; the href stays as it is.
+    const engine = await resolveEngine(engineConfig.engine)
+    const markdown = htmlToMarkdown('<a href="">Link</a>', {
+      origin: 'http://a/b/c/d;p?q',
+      engine,
+    })
+    expect(markdown).toBe('[Link]()')
+  })
+
   it('handles empty fragment', async () => {
     const engine = await resolveEngine(engineConfig.engine)
     const html = '<a href="#">Link</a>'


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #217

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`origin` was concatenated onto every relative href, so a base URL carrying a path never contributed its directory. With `https://gcc.gnu.org/onlinedocs/gcc/Invoking-GCC.html` as the origin:

| href | before | after |
|---|---|---|
| `Warning-Options.html` | `…/Invoking-GCC.html/Warning-Options.html` | `…/onlinedocs/gcc/Warning-Options.html` |
| `../foo.html` | `…/Invoking-GCC.html/../foo.html` | `https://gcc.gnu.org/onlinedocs/foo.html` |
| `/foo.html` | `…/Invoking-GCC.html/foo.html` | `https://gcc.gnu.org/foo.html` |
| `?q=1` | `…/Invoking-GCC.html/?q=1` | `…/Invoking-GCC.html?q=1` |

Pass the site root instead and the other half of the issue appears: every relative href lands at the root.

**What changed**

- `crates/core/src/url.rs`, `packages/js/src/tags.ts`: the origin splits into `scheme://authority` and a path, a relative reference merges into the document's directory, and dot segments are removed per RFC 3986 §5.4. The base's query and fragment take no part; the reference's carry across. `//host` inherits the base scheme instead of assuming `https`.
- An origin with no `scheme://authority` (`docs`, `javascript:alert(1)`) still concatenates. Nothing to resolve against, and keeping it verbatim is what leaves an unsafe origin recognisable to `is_safe_html_url`.
- `packages/crawl/src/crawl.ts`: pages were converted with the site origin, though link discovery already resolved hrefs with `new URL(href, url)` — the crawler followed `foo.html` correctly while writing the wrong link. Each page now converts against its own URL; an `--origin` override swaps the host and keeps the page path.

**Behaviour**

An origin without a path resolves as before for any href with no dot segment (`../x` against `https://x.com` was `https://x.com/../x`, now `https://x.com/x`). Two more:

- `/docs` against `https://mdream.dev/base/` now gives `https://mdream.dev/docs` — root-relative ignores the base directory, as in a browser. One `html-output.test.ts` expectation changed.
- `//cdn.example.com/a.js` on an `http://` page resolves to `http://`.

**Cost**

Baseline and current artifacts loaded in one process, A/B interleaved with the order swapped each rep, median of 15. The no-origin rows are controls.

| case | before | after |
|---|---|---|
| rust · html spec, 14.9 MB, 67k anchors | 96.3 ms | 95.7 ms (−0.6%) |
| rust · same, no origin | 95.6 ms | 95.2 ms (−0.4%) |
| rust · mdn-array.html, 230 KB, 510 anchors | 1.13 ms | 1.15 ms (+1.2%) |
| rust · same, no origin | 1.06 ms | 1.06 ms (+0.4%) |
| rust · 20k relative links, 1.4 MB | 9.44 ms | 10.05 ms (+6.5%) |
| js · html spec | 1857 ms | 1865 ms (+0.4%) |
| js · mdn-array.html | 6.67 ms | 6.52 ms (−2.3%) |
| js · 20k relative links | 71.2 ms | 73.3 ms (+2.9%) |

Resolution costs more than concatenation, so it runs in as few passes as possible: one scan of the reference yields its scheme, where its path ends and whether it holds a dot segment; the origin splits in one scan; the JS engine merges dot segments without an intermediate array and keeps the origin's split until a different origin arrives. Without that last one, the 20k-link document — every href relative, three of its seven shapes carrying dot segments — costs +12% in js instead of +3%.

Bundle cost is +355 B gzip on JavaScript Core (+1.8%) and +954 B on the WASM edge build (+1.2%), measured locally against `main`. Splitting the fused reference scan back into separate `find` calls costs 173 B more, and packing its result into an integer instead of a struct costs 29 B, so the fast shape is also the small one.

**Tests**

- `links.test.ts`: RFC 3986 §5.4's normal and abnormal tables verbatim, plus origin shapes (no path, trailing slash, base with query and fragment, no authority) — both engines via `describe.each(engines)`. The RFC resolves an empty reference and `#s` to the base URI; mdream leaves both alone, and the empty one has its own test.
- `packages/crawl/test/unit/relative-link-resolution.test.ts`: crawls a page two directories deep through the real converter with `ofetch` mocked, asserting the written markdown with and without an `origin` override.
- `url.rs`: resolution mechanics for `cargo test` alone, the authority-less prefix invariant the sanitizer makes unreachable end to end, and the separator handling the in-place stripper introduces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution of relative, root-relative, parent-relative, and absolute links in crawled pages.
  * Correctly handles dot-segments, queries, fragments, network-path references, and origins with paths.
  * Preserves page paths when applying a custom origin during crawling.
  * Improved tracking-parameter removal while preserving URL fragments and separators.
  * Correctly distinguishes URL schemes and preserves empty references when applicable.

* **Tests**
  * Added comprehensive coverage for URL resolution, generated Markdown links, images, and tracking-parameter edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->