### PR TITLE
fix(core): preserve discarded comment state

### DIFF
--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -1,9 +1,9 @@
 use crate::consts::*;
 use crate::entities::{decode_html_entities, decode_html_entities_for_markdown};
 use crate::scan::{
-  DiscardedCloseTag, PendingTagScan, discarded_cdata_end, discarded_close_tag_end,
-  discarded_comment_end, discarded_gt, is_whitespace, process_comment_or_doctype,
-  process_tag_attributes, tag_is_complete,
+  DiscardedCloseTag, DiscardedCommentState, PendingTagScan, discarded_cdata_end,
+  discarded_close_tag_end, discarded_comment_end, discarded_gt, is_whitespace,
+  process_comment_or_doctype, process_tag_attributes, tag_is_complete,
 };
 use crate::selector::{ParsedSelectorList, matches_selector_list, parse_css_selector_list};
 use crate::tags::get_tag_handler;
@@ -1249,6 +1249,9 @@ impl ConvertState {
         }
         let result = process_comment_or_doctype(chunk, i);
         if result.complete {
+          if max_node_bytes != 0 && result.new_position - i > max_node_bytes {
+            self.truncated = true;
+          }
           i = result.new_position;
         } else {
           carry = true;
@@ -1402,7 +1405,12 @@ impl ConvertState {
     // run is kept in `text_buffer` instead, so it is parsed once however many
     // chunks it spans.
     let consumed = if carry {
-      if max_node_bytes != 0 && chunk_length - run_start > max_node_bytes {
+      let carried = &chunk[run_start..];
+      // Keep an ambiguous markup-declaration opener until it can be classified.
+      // Both prefixes are fixed-size, so this retains at most eight bytes.
+      let partial_declaration = (carried.len() < "<!--".len() && "<!--".starts_with(carried))
+        || (carried.len() < "<![CDATA[".len() && "<![CDATA[".starts_with(carried));
+      if max_node_bytes != 0 && chunk_length - run_start > max_node_bytes && !partial_declaration {
         self.start_discard(chunk, run_start);
         chunk_length
       } else {
@@ -1431,9 +1439,9 @@ impl ConvertState {
     // in another. Picking the owning one here is what keeps a dropped token
     // ending where an uncapped parse ends it, so the document resumes in step.
     self.discard = if let Some(body) = rest.strip_prefix("<!--") {
-      let mut dashes = 0;
-      discarded_comment_end(body, &mut dashes);
-      Discard::Comment(dashes)
+      let mut state = DiscardedCommentState::new();
+      discarded_comment_end(body, &mut state);
+      Discard::Comment(state)
     } else if let Some(body) = rest.strip_prefix("<![CDATA[") {
       let mut brackets = 0;
       discarded_cdata_end(body, &mut brackets);
@@ -1941,8 +1949,8 @@ enum Discard {
   No,
   /// Quote-aware resume for the `>` ending a dropped start tag.
   Tag(PendingTagScan),
-  /// Trailing dash-run state for the `-->` or `--!>` ending a dropped comment.
-  Comment(u8),
+  /// Tokenizer state for the end of a dropped comment.
+  Comment(DiscardedCommentState),
   /// Name and quote state for the `>` ending a dropped end tag, which the
   /// end-tag tokenizer quotes differently from a start tag's.
   CloseTag(DiscardedCloseTag),

--- a/crates/core/src/scan.rs
+++ b/crates/core/src/scan.rs
@@ -123,31 +123,61 @@ impl PendingTagScan {
   }
 }
 
-/// State after the `!` in `--!`, where only `>` still closes the comment. Held in
-/// the same byte as the dash run, which counts 0, 1, or 2-or-more.
-const COMMENT_BANG: u8 = 3;
+#[derive(Clone, Copy)]
+#[repr(u8)]
+pub(crate) enum DiscardedCommentState {
+  Start,
+  StartDash,
+  Comment,
+  EndDash,
+  End,
+  EndBang,
+}
+
+impl DiscardedCommentState {
+  #[inline]
+  pub(crate) fn new() -> Self {
+    Self::Start
+  }
+}
 
 /// Find the end of a comment whose earlier bytes have been dropped, resuming from
-/// `dashes` (the trailing dash-run state). Only `-->` and `--!>` can still close
-/// one this far in, so no bytes need retaining. Returns the index after the `>`.
-///
-/// A second `!` leaves the comment end bang state, and a `-` after it starts a
-/// fresh dash run, so `--!!>` and `--!->` do not close. Diverging here would let
-/// a dropped comment end at a byte the full scan runs past, which resumes the
-/// document inside the comment.
-pub(crate) fn discarded_comment_end(chunk: &str, dashes: &mut u8) -> Option<usize> {
+/// its tokenizer state. Returns the index after the `>` without retaining bytes.
+pub(crate) fn discarded_comment_end(
+  chunk: &str,
+  state: &mut DiscardedCommentState,
+) -> Option<usize> {
   for (index, &c) in chunk.as_bytes().iter().enumerate() {
-    match c {
-      DASH_CHAR => {
-        *dashes = if *dashes == COMMENT_BANG {
-          1
-        } else {
-          (*dashes + 1).min(2)
-        };
-      }
-      GT_CHAR if *dashes >= 2 => return Some(index + 1),
-      EXCLAMATION_CHAR if *dashes == 2 => *dashes = COMMENT_BANG,
-      _ => *dashes = 0,
+    *state = match *state {
+      DiscardedCommentState::Start => match c {
+        GT_CHAR => return Some(index + 1),
+        DASH_CHAR => DiscardedCommentState::StartDash,
+        _ => DiscardedCommentState::Comment,
+      },
+      DiscardedCommentState::StartDash => match c {
+        GT_CHAR => return Some(index + 1),
+        DASH_CHAR => DiscardedCommentState::End,
+        _ => DiscardedCommentState::Comment,
+      },
+      DiscardedCommentState::Comment => match c {
+        DASH_CHAR => DiscardedCommentState::EndDash,
+        _ => DiscardedCommentState::Comment,
+      },
+      DiscardedCommentState::EndDash => match c {
+        DASH_CHAR => DiscardedCommentState::End,
+        _ => DiscardedCommentState::Comment,
+      },
+      DiscardedCommentState::End => match c {
+        GT_CHAR => return Some(index + 1),
+        EXCLAMATION_CHAR => DiscardedCommentState::EndBang,
+        DASH_CHAR => DiscardedCommentState::End,
+        _ => DiscardedCommentState::Comment,
+      },
+      DiscardedCommentState::EndBang => match c {
+        GT_CHAR => return Some(index + 1),
+        DASH_CHAR => DiscardedCommentState::EndDash,
+        _ => DiscardedCommentState::Comment,
+      },
     }
   }
   None
@@ -882,8 +912,7 @@ mod tests {
   }
 
   // A dropped comment ends where the full scan ends it, or the document resumes
-  // inside the comment. `discarded_comment_end` starts where the cap cut, which is
-  // the spec's comment state, so the reference is prefixed by one ordinary byte.
+  // inside the comment. Check every carried state by splitting each short input.
   #[test]
   fn the_discarded_comment_scan_matches_the_spec_state_machine() {
     const ALPHABET: [u8; 5] = *b"-!>x<";
@@ -896,13 +925,14 @@ mod tests {
           rest /= ALPHABET.len();
         }
         tail.push('Z');
-        let mut dashes = 0;
-        let reference = spec_comment_end(format!("x{tail}").as_bytes(), 0).map(|end| end - 1);
-        assert_eq!(
-          discarded_comment_end(&tail, &mut dashes),
-          reference,
-          "tail={tail:?}"
-        );
+        let reference = spec_comment_end(tail.as_bytes(), 0);
+        for split in 0..=tail.len() {
+          let mut state = DiscardedCommentState::new();
+          let first = discarded_comment_end(&tail[..split], &mut state);
+          let actual = first
+            .or_else(|| discarded_comment_end(&tail[split..], &mut state).map(|end| split + end));
+          assert_eq!(actual, reference, "tail={tail:?} split={split}");
+        }
       }
     }
   }

--- a/crates/core/src/scan.rs
+++ b/crates/core/src/scan.rs
@@ -148,36 +148,31 @@ pub(crate) fn discarded_comment_end(
   state: &mut DiscardedCommentState,
 ) -> Option<usize> {
   for (index, &c) in chunk.as_bytes().iter().enumerate() {
-    *state = match *state {
-      DiscardedCommentState::Start => match c {
-        GT_CHAR => return Some(index + 1),
-        DASH_CHAR => DiscardedCommentState::StartDash,
-        _ => DiscardedCommentState::Comment,
+    if c == GT_CHAR
+      && matches!(
+        *state,
+        DiscardedCommentState::Start
+          | DiscardedCommentState::StartDash
+          | DiscardedCommentState::End
+          | DiscardedCommentState::EndBang
+      )
+    {
+      return Some(index + 1);
+    }
+    *state = match c {
+      DASH_CHAR => match *state {
+        DiscardedCommentState::Start => DiscardedCommentState::StartDash,
+        DiscardedCommentState::StartDash
+        | DiscardedCommentState::EndDash
+        | DiscardedCommentState::End => DiscardedCommentState::End,
+        DiscardedCommentState::Comment | DiscardedCommentState::EndBang => {
+          DiscardedCommentState::EndDash
+        }
       },
-      DiscardedCommentState::StartDash => match c {
-        GT_CHAR => return Some(index + 1),
-        DASH_CHAR => DiscardedCommentState::End,
-        _ => DiscardedCommentState::Comment,
-      },
-      DiscardedCommentState::Comment => match c {
-        DASH_CHAR => DiscardedCommentState::EndDash,
-        _ => DiscardedCommentState::Comment,
-      },
-      DiscardedCommentState::EndDash => match c {
-        DASH_CHAR => DiscardedCommentState::End,
-        _ => DiscardedCommentState::Comment,
-      },
-      DiscardedCommentState::End => match c {
-        GT_CHAR => return Some(index + 1),
-        EXCLAMATION_CHAR => DiscardedCommentState::EndBang,
-        DASH_CHAR => DiscardedCommentState::End,
-        _ => DiscardedCommentState::Comment,
-      },
-      DiscardedCommentState::EndBang => match c {
-        GT_CHAR => return Some(index + 1),
-        DASH_CHAR => DiscardedCommentState::EndDash,
-        _ => DiscardedCommentState::Comment,
-      },
+      EXCLAMATION_CHAR if matches!(*state, DiscardedCommentState::End) => {
+        DiscardedCommentState::EndBang
+      }
+      _ => DiscardedCommentState::Comment,
     }
   }
   None

--- a/crates/core/tests/max_node_bytes.rs
+++ b/crates/core/tests/max_node_bytes.rs
@@ -277,6 +277,75 @@ fn dropping_a_token_keeps_the_surrounding_document() {
   }
 }
 
+#[test]
+fn an_oversized_complete_comment_reports_truncation() {
+  for html in ["<!-->x", "<!--->x", "<!--x-->x", "<!--x--!>x"] {
+    let result = html_to_markdown_result(html, options(3));
+    assert_eq!(result.markdown, "x", "html={html:?}");
+    assert!(result.truncated, "html={html:?}");
+
+    let exact = html_to_markdown_result(html, options(html.len() - 1));
+    assert_eq!(exact.markdown, "x", "html={html:?}");
+    assert!(!exact.truncated, "html={html:?}");
+  }
+}
+
+#[test]
+fn a_discarded_comment_preserves_its_start_state() {
+  for html in ["<!-->x", "<!--->x"] {
+    for split in 0..=html.len() {
+      let mut processor = MarkdownStreamProcessor::new(options(3));
+      let mut out = processor.process_chunk(&html[..split]);
+      out.push_str(&processor.process_chunk(&html[split..]));
+      out.push_str(&processor.finish());
+      assert_eq!(out, "x", "html={html:?} split={split}");
+      assert!(processor.truncated(), "html={html:?} split={split}");
+    }
+  }
+}
+
+#[test]
+fn a_partial_comment_opener_is_not_discarded_as_a_bogus_comment() {
+  let html = "<!--a>inside-->x";
+  for cap in 1..=3 {
+    for split in 0..=html.len() {
+      let mut processor = MarkdownStreamProcessor::new(options(cap));
+      let mut out = processor.process_chunk(&html[..split]);
+      out.push_str(&processor.process_chunk(&html[split..]));
+      out.push_str(&processor.finish());
+      assert_eq!(out, "x", "cap={cap} split={split}");
+      assert!(processor.truncated(), "cap={cap} split={split}");
+    }
+  }
+}
+
+#[test]
+fn an_oversized_complete_markup_declaration_reports_truncation() {
+  for html in ["<!x>x", "<!DOCTYPE html>x"] {
+    for cap in 1..=3 {
+      let result = html_to_markdown_result(html, options(cap));
+      assert_eq!(result.markdown, "x", "html={html:?} cap={cap}");
+      assert!(result.truncated, "html={html:?} cap={cap}");
+
+      for split in 0..=html.len() {
+        let mut processor = MarkdownStreamProcessor::new(options(cap));
+        let mut out = processor.process_chunk(&html[..split]);
+        out.push_str(&processor.process_chunk(&html[split..]));
+        out.push_str(&processor.finish());
+        assert_eq!(
+          out, result.markdown,
+          "html={html:?} cap={cap} split={split}"
+        );
+        assert_eq!(
+          processor.truncated(),
+          result.truncated,
+          "html={html:?} cap={cap} split={split}"
+        );
+      }
+    }
+  }
+}
+
 // Each kind of token is ended by its own scanner, and they disagree: a `>` inside
 // a quoted end-tag attribute closes a doctype but not an end tag, `--!!>` closes
 // nothing, and CDATA ends only at `]]>`. Dropping a token with the wrong scanner


### PR DESCRIPTION
Preserves the HTML tokenizer state when `max_node_bytes` starts discarding a comment, so abrupt `<!-->` and `<!--->` terminators cannot swallow following content across chunk boundaries. Complete oversized markup declarations now report truncation consistently; ambiguous declaration prefixes retain at most eight bytes until classification.

Behavior change: an oversized ignored comment, doctype, or bogus declaration conservatively sets `truncated = true` even when Markdown output is unchanged.

Validation:
- `cargo test --workspace --exclude mdream-edge`
- `cargo clippy --workspace --exclude mdream-edge --locked -- -D warnings -A clippy::pedantic -A clippy::nursery`
- `cargo check --workspace --locked`
- `cargo build -p mdream-edge --target wasm32-unknown-unknown`
- touched-file `rustfmt --check`

`pnpm typecheck` was blocked locally before execution by the workspace supply-chain policy rejecting missing registry metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of oversized comments and markup declarations by reporting them as truncated.
  * Preserved partial comment and CDATA markers when content arrives across multiple chunks.
  * Ensured discarded comments are removed correctly without affecting following content.
  * Improved consistency between one-shot and streaming processing.

* **Tests**
  * Added coverage for oversized and split comments, markup declarations, and streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->