### PR TITLE
fix(core): bound aggregate inline code spans

### DIFF
--- a/crates/core/src/convert/mod.rs
+++ b/crates/core/src/convert/mod.rs
@@ -127,6 +127,8 @@ const GFM_BYTE_FLAGS: [u8; 256] = {
 struct CodeSpanState {
   output_start: usize,
   content_start: usize,
+  opener_emitted: bool,
+  exhausted: bool,
 }
 
 struct CodeFenceState {

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -143,6 +143,67 @@ impl ConvertState {
     max
   }
 
+  /// Append content retained behind the outermost inline-code delimiter. Tag
+  /// output is atomic so a cap cannot leave half a Markdown marker; text may be
+  /// cut at a UTF-8 boundary. Once an append cannot fit, later content is never
+  /// allowed to refill the spare bytes.
+  #[inline(always)]
+  fn push_code_span_content(&mut self, value: &str, atomic: bool) -> usize {
+    if value.is_empty() {
+      return 0;
+    }
+    let cap = self.options.max_node_bytes;
+    if cap == 0 || self.code_spans.is_empty() {
+      self.buffer.push_str(value);
+      return value.len();
+    }
+
+    self.push_capped_code_span_content(value, atomic, cap)
+  }
+
+  #[cold]
+  #[inline(never)]
+  fn push_capped_code_span_content(&mut self, value: &str, atomic: bool, cap: usize) -> usize {
+    let span = &self.code_spans[0];
+    if !span.opener_emitted || span.exhausted {
+      self.truncated = true;
+      return 0;
+    }
+    let room = cap.saturating_sub(self.buffer.len().saturating_sub(span.content_start));
+    let kept = if atomic && value.len() > room {
+      ""
+    } else {
+      clamp_to_char_boundary(value, room)
+    };
+    if kept.len() != value.len() {
+      self.code_spans[0].exhausted = true;
+      self.truncated = true;
+    }
+    self.buffer.push_str(kept);
+    kept.len()
+  }
+
+  /// Replace already-accounted inline-code bytes. Growth is atomic because the
+  /// replacement is structural Markdown; shrinking rewrites are always safe.
+  #[inline]
+  fn replace_code_span_content(&mut self, range: std::ops::Range<usize>, value: &str) -> bool {
+    let cap = self.options.max_node_bytes;
+    if cap != 0
+      && let Some(span) = self.code_spans.first()
+      && range.start >= span.content_start
+      && value.len() > range.len()
+    {
+      let held = self.buffer.len().saturating_sub(span.content_start);
+      if span.exhausted || held - range.len() + value.len() > cap {
+        self.code_spans[0].exhausted = true;
+        self.truncated = true;
+        return false;
+      }
+    }
+    self.buffer.replace_range(range, value);
+    true
+  }
+
   fn max_line_leading_run(value: &str, marker: u8, indent: &str) -> usize {
     value
       .split('\n')
@@ -166,11 +227,31 @@ impl ConvertState {
   #[inline(never)]
   fn finalize_code_span(&mut self, span: &CodeSpanState) -> String {
     // A pipe splits the row even inside a code span; `\|` is GFM's escape and is
-    // honoured there. Content sits at the buffer tail, so this shifts no offset.
+    // honoured there. Its expanded form still has to fit the aggregate budget.
     if self.depth_map[TAG_TABLE as usize] > 0 && self.buffer[span.content_start..].contains('|') {
-      let escaped = self.buffer[span.content_start..].replace('|', "\\|");
-      self.buffer.truncate(span.content_start);
-      self.buffer.push_str(&escaped);
+      let content = &self.buffer[span.content_start..];
+      let escaped_cap = if self.options.max_node_bytes == 0 {
+        usize::MAX
+      } else if let Some(outer) = self.code_spans.first() {
+        let held = self.buffer.len().saturating_sub(outer.content_start);
+        content.len() + self.options.max_node_bytes.saturating_sub(held)
+      } else {
+        self.options.max_node_bytes
+      };
+      let mut escaped = String::with_capacity(content.len().min(escaped_cap));
+      for ch in content.chars() {
+        let addition = if ch == '|' { 2 } else { ch.len_utf8() };
+        if escaped.len() + addition > escaped_cap {
+          self.truncated = true;
+          break;
+        }
+        if ch == '|' {
+          escaped.push('\\');
+        }
+        escaped.push(ch);
+      }
+      let content_end = self.buffer.len();
+      self.replace_code_span_content(span.content_start..content_end, &escaped);
     }
     let max_run = Self::max_backtick_run(&self.buffer[span.content_start..]);
     let delimiter = "`".repeat((max_run + 1).max(1));
@@ -184,9 +265,7 @@ impl ConvertState {
     if padded {
       opening.push(' ');
     }
-    self
-      .buffer
-      .replace_range(span.output_start..span.content_start, &opening);
+    self.replace_code_span_content(span.output_start..span.content_start, &opening);
     if padded {
       format!(" {delimiter}")
     } else {
@@ -228,7 +307,7 @@ impl ConvertState {
       Self::max_line_leading_run(&self.buffer[fence.content_start..], marker, &fence.indent);
     let delimiter = (marker as char).to_string().repeat((max_run + 1).max(3));
     let marker_start = fence.output_start + fence.marker_offset;
-    self.buffer.replace_range(
+    self.replace_code_span_content(
       marker_start..marker_start + MARKDOWN_CODE_BLOCK.len(),
       &delimiter,
     );
@@ -296,6 +375,20 @@ impl ConvertState {
       if !unindented.is_empty() {
         quoted.push(' ');
         quoted.push_str(unindented);
+      }
+    }
+
+    if self.options.max_node_bytes != 0
+      && let Some(span) = self.code_spans.first()
+      && frame.content_start >= span.content_start
+      && quoted.len() > content.len()
+    {
+      let held = self.buffer.len().saturating_sub(span.content_start);
+      if span.exhausted || held - content.len() + quoted.len() > self.options.max_node_bytes {
+        self.code_spans[0].exhausted = true;
+        self.truncated = true;
+        self.blockquote_scratch = quoted;
+        return;
       }
     }
 
@@ -741,14 +834,24 @@ impl ConvertState {
         if !self.in_raw_html_block()
           && let Some(emitted) = output.as_deref()
         {
+          let opener_emitted = self.buffer.len() > output_start && self.buffer.ends_with(emitted);
+          let content_start = self.buffer.len();
           self.code_spans.push(CodeSpanState {
-            output_start: self.buffer.len() - emitted.len(),
-            content_start: self.buffer.len(),
+            output_start: if opener_emitted {
+              content_start - emitted.len()
+            } else {
+              content_start
+            },
+            content_start,
+            opener_emitted,
+            exhausted: false,
           });
         }
       } else if !self.pre_fence_open
         && !self.in_table_cell()
         && let Some(emitted) = output.as_deref()
+        && self.buffer.len() > output_start
+        && self.buffer.ends_with(emitted)
       {
         let output_start = self.buffer.len() - emitted.len();
         let language =
@@ -776,6 +879,7 @@ impl ConvertState {
       self.link_bracket_pos = if output
         .as_deref()
         .is_some_and(|o| o.as_bytes().last() == Some(&b'['))
+        && self.buffer.len() > output_start
       {
         buf_len - 1
       } else {
@@ -789,6 +893,8 @@ impl ConvertState {
       && let Some(inline_marker_type) = Self::inline_marker_type(id)
       && let Some(emitted) = output.as_deref()
       && !emitted.is_empty()
+      && self.buffer.len() > output_start
+      && self.buffer.ends_with(emitted)
     {
       self.open_markers.push((
         inline_marker_type,
@@ -1093,6 +1199,7 @@ impl ConvertState {
       self.write_output(false, is_inline, configured_new_lines, None, false);
       // Write link close directly
       if let Some(href) = node.attributes.get("href") {
+        let capped_code_span = self.options.max_node_bytes != 0 && !self.code_spans.is_empty();
         let resolved = resolve_url(
           href,
           self.options.origin.as_deref(),
@@ -1120,21 +1227,38 @@ impl ConvertState {
           let bp = self.link_bracket_pos;
           let buf_bytes = self.buffer.as_bytes();
           if bp < buf_bytes.len() && buf_bytes[bp] == b'[' && &self.buffer[bp + 1..] == resolved {
-            self.buffer.truncate(bp);
-            self.buffer.push('<');
-            self.buffer.push_str(resolved);
-            self.buffer.push('>');
-            self.last_content_cache_len = self.buffer.len() - bp;
-            self.last_node_is_inline = is_inline;
-            return;
+            if capped_code_span {
+              let replacement = format!("<{resolved}>");
+              let end = self.buffer.len();
+              if self.replace_code_span_content(bp..end, &replacement) {
+                self.last_content_cache_len = replacement.len();
+                self.last_node_is_inline = is_inline;
+                return;
+              }
+            } else {
+              self.buffer.truncate(bp);
+              self.buffer.push('<');
+              self.buffer.push_str(resolved);
+              self.buffer.push('>');
+              self.last_content_cache_len = self.buffer.len() - bp;
+              self.last_node_is_inline = is_inline;
+              return;
+            }
           }
         }
-        self.buffer.push(']');
-        write_markdown_resource(
-          &mut self.buffer,
-          resolved,
-          (!title.is_empty()).then_some(title),
-        );
+        if capped_code_span {
+          let mut close = String::with_capacity(resolved.len() + title.len() + 6);
+          close.push(']');
+          write_markdown_resource(&mut close, resolved, (!title.is_empty()).then_some(title));
+          self.push_code_span_content(&close, true);
+        } else {
+          self.buffer.push(']');
+          write_markdown_resource(
+            &mut self.buffer,
+            resolved,
+            (!title.is_empty()).then_some(title),
+          );
+        }
         // The cache is a length, not an offset: the link starts at its `[`.
         // Saturating because `link_bracket_pos` is `buffer.len()` when no `[`
         // was emitted.
@@ -1194,7 +1318,14 @@ impl ConvertState {
     }
 
     if let Some(span) = closing_code_span {
-      output = Some(Cow::Owned(self.finalize_code_span(&span)));
+      if span.opener_emitted && span.exhausted && self.buffer.len() == span.content_start {
+        self.buffer.truncate(span.output_start);
+        output = None;
+      } else if span.opener_emitted {
+        output = Some(Cow::Owned(self.finalize_code_span(&span)));
+      } else {
+        output = None;
+      }
     }
     if !has_override
       && closes_own_pre_fence
@@ -1275,8 +1406,11 @@ impl ConvertState {
       format!("```{}\n", self.pre_fence_lang)
     };
     let output_start = self.buffer.len();
-    self.last_content_cache_len = fence.len();
-    self.buffer.push_str(&fence);
+    self.last_content_cache_len = self.push_code_span_content(&fence, true);
+    if self.last_content_cache_len != fence.len() {
+      self.pre_fence_open = false;
+      return;
+    }
     self.start_code_fence(
       output_start,
       self.buffer.len(),
@@ -1363,7 +1497,7 @@ impl ConvertState {
       let last = self.last_output_byte();
       let first = text.as_bytes()[0];
       if !matches!(last, Some(b' ' | b'\n' | b'\t') | None) && !is_whitespace(first) {
-        self.buffer.push(' ');
+        self.push_code_span_content(" ", true);
       }
       self.pending_inline_whitespace = false;
     }
@@ -1537,12 +1671,19 @@ impl ConvertState {
     } else if !(self.plain_text && self.depth_map[TAG_PRE as usize] > 0)
       && self.should_add_spacing_before_text(last_char, text)
     {
-      self.buffer.push(' ');
-      self.last_content_cache_len = text.len() + 1;
-      self.buffer.push_str(text);
-    } else {
+      if self.options.max_node_bytes == 0 {
+        self.buffer.push(' ');
+        self.last_content_cache_len = text.len() + 1;
+        self.buffer.push_str(text);
+      } else {
+        let written = self.push_code_span_content(" ", true);
+        self.last_content_cache_len = written + self.push_code_span_content(text, false);
+      }
+    } else if self.options.max_node_bytes == 0 {
       self.last_content_cache_len = text.len();
       self.buffer.push_str(text);
+    } else {
+      self.last_content_cache_len = self.push_code_span_content(text, false);
     }
 
     if !self.open_markers.is_empty() && text.as_bytes().iter().any(|&b| !is_whitespace(b)) {
@@ -1721,7 +1862,7 @@ impl ConvertState {
       run -= 1;
     }
     if run < end && (run == start || matches!(bytes[run - 1], b' ' | b'\t')) {
-      self.buffer.insert(run, '\\');
+      self.replace_code_span_content(run..run, "\\");
     }
   }
 
@@ -1830,7 +1971,10 @@ impl ConvertState {
       return;
     }
     self.empty_item_hazard = false;
-    self.buffer.insert(self.empty_item_line_start, '\n');
+    if !self.replace_code_span_content(self.empty_item_line_start..self.empty_item_line_start, "\n")
+    {
+      return;
+    }
     // The insertion moves cached offsets at or past the line: an inline marker
     // still open across it measures emptiness from `content_start`, so left
     // unshifted it stops looking empty and streaming leaks markers one-shot drops.
@@ -2324,10 +2468,15 @@ impl ConvertState {
 
   fn flush_list_rule(&mut self) {
     let prefix = self.continuation_prefix();
-    self.buffer.reserve(2 + prefix.len());
-    self.buffer.push_str("\n\n");
-    self.buffer.push_str(&prefix);
-    self.last_content_cache_len = 2 + prefix.len();
+    if self.options.max_node_bytes == 0 || self.code_spans.is_empty() {
+      self.buffer.reserve(2 + prefix.len());
+      self.buffer.push_str("\n\n");
+      self.buffer.push_str(&prefix);
+      self.last_content_cache_len = 2 + prefix.len();
+    } else {
+      let output = format!("\n\n{prefix}");
+      self.last_content_cache_len = self.push_code_span_content(&output, true);
+    }
     self.list_rule_pending = false;
   }
 
@@ -2359,14 +2508,14 @@ impl ConvertState {
       let need_space = if first { first_needs_space } else { true };
 
       if need_space && col > prefix_len && col + 1 + word_len > width {
-        self.buffer.push('\n');
-        self.buffer.push_str(&prefix);
+        self.push_code_span_content("\n", true);
+        self.push_code_span_content(&prefix, true);
         col = prefix_len;
       } else if need_space {
-        self.buffer.push(' ');
+        self.push_code_span_content(" ", true);
         col += 1;
       }
-      self.buffer.push_str(word);
+      self.push_code_span_content(word, false);
       col += word_len;
       first = false;
     }
@@ -2374,7 +2523,7 @@ impl ConvertState {
     // Preserve a trailing separator space (unless we emitted nothing or the
     // line already ends in whitespace) so the next inline run stays separated.
     if trailing_space && !matches!(self.buffer.as_bytes().last(), Some(b' ' | b'\n') | None) {
-      self.buffer.push(' ');
+      self.push_code_span_content(" ", true);
     }
     self.last_content_cache_len = self.buffer.len() - buf_start;
   }
@@ -2382,8 +2531,7 @@ impl ConvertState {
   /// Emit frontmatter content.
   pub(crate) fn emit_frontmatter(&mut self, content: &str) {
     if self.format == OutputFormat::Markdown && !content.is_empty() {
-      self.last_content_cache_len = content.len();
-      self.buffer.push_str(content);
+      self.last_content_cache_len = self.push_code_span_content(content, true);
     }
   }
 
@@ -2962,7 +3110,7 @@ impl ConvertState {
       } else if let Some(first) = first_output {
         let last = self.last_output_byte();
         if !matches!(last, Some(b' ' | b'\n' | b'\t') | None) && !is_whitespace(first) {
-          self.buffer.push(' ');
+          self.push_code_span_content(" ", true);
         }
         self.pending_inline_whitespace = false;
       }
@@ -3040,8 +3188,7 @@ impl ConvertState {
       // which never drains, keeps).
       if self.buffer.is_empty() && !self.has_streamed_output {
         if !output_str.is_empty() {
-          self.last_content_cache_len = output_str.len();
-          self.buffer.push_str(output_str);
+          self.last_content_cache_len = self.push_code_span_content(output_str, true);
         }
         self.last_node_is_inline = is_inline;
         return;
@@ -3057,19 +3204,17 @@ impl ConvertState {
 
       if is_enter {
         for _ in 0..new_lines {
-          self.buffer.push('\n');
+          self.push_code_span_content("\n", true);
         }
         if !output_str.is_empty() {
-          self.last_content_cache_len = output_str.len();
-          self.buffer.push_str(output_str);
+          self.last_content_cache_len = self.push_code_span_content(output_str, true);
         }
       } else {
         if !output_str.is_empty() {
-          self.last_content_cache_len = output_str.len();
-          self.buffer.push_str(output_str);
+          self.last_content_cache_len = self.push_code_span_content(output_str, true);
         }
         for _ in 0..new_lines {
-          self.buffer.push('\n');
+          self.push_code_span_content("\n", true);
         }
       }
     } else {
@@ -3130,13 +3275,11 @@ impl ConvertState {
         && last_char != 0
         && self.needs_spacing(last_char, output_str.as_bytes()[0])
       {
-        self.buffer.push(' ');
-        self.last_content_cache_len = 1;
+        self.last_content_cache_len = self.push_code_span_content(" ", true);
       }
 
       if !output_str.is_empty() {
-        self.last_content_cache_len = output_str.len();
-        self.buffer.push_str(output_str);
+        self.last_content_cache_len = self.push_code_span_content(output_str, true);
       }
     }
     self.last_node_is_inline = is_inline;

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -1230,10 +1230,10 @@ impl ConvertState {
           let buf_bytes = self.buffer.as_bytes();
           if bp < buf_bytes.len() && buf_bytes[bp] == b'[' && &self.buffer[bp + 1..] == resolved {
             if capped_code_span {
-              let replacement = format!("<{resolved}>");
               let end = self.buffer.len();
-              if self.replace_code_span_content(bp..end, &replacement) {
-                self.last_content_cache_len = replacement.len();
+              if self.replace_code_span_content(end..end, ">") {
+                self.buffer.replace_range(bp..bp + 1, "<");
+                self.last_content_cache_len = self.buffer.len() - bp;
                 self.last_node_is_inline = is_inline;
                 return;
               }

--- a/crates/core/src/convert/output.rs
+++ b/crates/core/src/convert/output.rs
@@ -1029,8 +1029,10 @@ impl ConvertState {
         output = self.get_exit_output(node, cell_span);
       }
     }
-    let closing_code_span = if !has_override
-      && tag_id == Some(TAG_CODE)
+    // Pop for every inline <code> exit that could have pushed: the enter push
+    // ignores overrides, so an exit-only override that skipped the pop leaked
+    // the span, whose exhausted flag then capped the rest of the document.
+    let closing_code_span = if tag_id == Some(TAG_CODE)
       && self.depth_map[TAG_PRE as usize] == 0
       && !self.in_raw_html_block()
     {
@@ -1318,13 +1320,17 @@ impl ConvertState {
     }
 
     if let Some(span) = closing_code_span {
-      if span.opener_emitted && span.exhausted && self.buffer.len() == span.content_start {
-        self.buffer.truncate(span.output_start);
-        output = None;
-      } else if span.opener_emitted {
-        output = Some(Cow::Owned(self.finalize_code_span(&span)));
-      } else {
-        output = None;
+      // An explicit exit override replaces the default closing delimiter, but
+      // the span state is still popped and discarded above.
+      if !has_override {
+        if span.opener_emitted && span.exhausted && self.buffer.len() == span.content_start {
+          self.buffer.truncate(span.output_start);
+          output = None;
+        } else if span.opener_emitted {
+          output = Some(Cow::Owned(self.finalize_code_span(&span)));
+        } else {
+          output = None;
+        }
       }
     }
     if !has_override

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -520,12 +520,12 @@ pub struct HTMLToMarkdownOptions {
   /// wrapped.
   pub wrap_width: usize,
   /// Cap on the bytes one construct may buffer — a text node, a tag, a comment, an
-  /// open code block, a table row's columns, or the script text an extraction
-  /// reads; `0` (the default) is unlimited. Content past the cap is **dropped**,
-  /// bounding memory on adversarial input at the cost of that content, an over-long
-  /// tag entirely (attributes included), and a row's extra columns. A tag is
-  /// measured by its own length, so the result does not depend on chunking, and the
-  /// cap applies to one-shot conversion as well as streaming.
+  /// open code block or inline code span, a table row's columns, or the script text
+  /// an extraction reads; `0` (the default) is unlimited. Content past the cap is
+  /// **dropped**, bounding memory on adversarial input at the cost of that content,
+  /// an over-long tag entirely (attributes included), and a row's extra columns. A
+  /// tag is measured by its own length, so the result does not depend on chunking,
+  /// and the cap applies to one-shot conversion as well as streaming.
   /// [`MdreamResult::truncated`] reports whether it fired.
   pub max_node_bytes: usize,
 }
@@ -597,8 +597,8 @@ impl HTMLToMarkdownOptions {
     self
   }
 
-  /// Drop content past `bytes` in one node, token, or code block, bounding
-  /// streaming memory.
+  /// Drop content past `bytes` in one buffered construct, including a text node,
+  /// token, code block, or inline code span. Applies to one-shot and streaming conversion.
   ///
   /// ```rust
   /// use mdream::HTMLToMarkdownOptions;

--- a/crates/core/tests/max_node_bytes.rs
+++ b/crates/core/tests/max_node_bytes.rs
@@ -494,6 +494,32 @@ fn override_output_consumes_the_inline_code_span_cap() {
   );
 }
 
+// An exit-only override still pushes the span on enter, so skipping the pop on
+// exit leaked the span: its exhausted flag then capped every byte after the
+// first inline code element, and streaming held its output at the leaked span.
+#[test]
+fn an_exit_only_override_still_pops_the_inline_code_span() {
+  let opts = HTMLToMarkdownOptions {
+    plugins: Some(PluginConfig {
+      tag_overrides: Some(vec![(
+        "code".to_string(),
+        TagOverrideConfig {
+          exit: Some("X".to_string()),
+          ..Default::default()
+        },
+      )]),
+      ..Default::default()
+    }),
+    ..options(8)
+  };
+  assert_capped_inline_code_with_options(
+    "<code>abcdefgh</code><p>ij</p><p>kl</p>",
+    opts,
+    "`abcdefghX\n\nij\n\nkl",
+    false,
+  );
+}
+
 #[test]
 fn frontmatter_output_cannot_escape_an_inline_code_span_cap() {
   let opts = HTMLToMarkdownOptions {

--- a/crates/core/tests/max_node_bytes.rs
+++ b/crates/core/tests/max_node_bytes.rs
@@ -6,8 +6,8 @@
 //! text buffered for one text node (~5x its size in peak heap), and the raw bytes
 //! of a tag or comment the parser cannot consume yet (~3x).
 //!
-//! Three more grow with a whole element rather than one node: an open code fence
-//! pins the output buffer until its delimiter is known (~0.9x the block), a row's
+//! Four more grow with a whole element rather than one node: open code fences and
+//! inline code spans pin the output buffer until their delimiter is known, a row's
 //! width forces a delimiter row of 7 bytes a column, and script text is retained
 //! whole for an extraction that reads it (~4x).
 //!
@@ -17,7 +17,7 @@
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::cell::Cell;
 
-use mdream::types::{ExtractionConfig, HTMLToMarkdownOptions, PluginConfig};
+use mdream::types::{ExtractionConfig, HTMLToMarkdownOptions, PluginConfig, TagOverrideConfig};
 use mdream::{MarkdownStreamProcessor, html_to_markdown_result};
 
 // Peak-allocation tracker, per-thread so parallel tests do not pollute each other.
@@ -85,6 +85,36 @@ fn stream(html: &str, chunk: usize, cap: usize) -> String {
   }
   out.push_str(&p.finish());
   out
+}
+
+fn stream_parts_with_options(parts: &[&str], options: HTMLToMarkdownOptions) -> (String, bool) {
+  let mut p = MarkdownStreamProcessor::new(options);
+  let mut out = String::new();
+  for part in parts {
+    out.push_str(&p.process_chunk(part));
+  }
+  out.push_str(&p.finish());
+  (out, p.truncated())
+}
+
+fn assert_capped_inline_code(html: &str, cap: usize, expected: &str, truncated: bool) {
+  assert_capped_inline_code_with_options(html, options(cap), expected, truncated);
+}
+
+fn assert_capped_inline_code_with_options(
+  html: &str,
+  options: HTMLToMarkdownOptions,
+  expected: &str,
+  truncated: bool,
+) {
+  let result = html_to_markdown_result(html, options.clone());
+  assert_eq!(result.markdown, expected, "one-shot html={html:?}");
+  assert_eq!(result.truncated, truncated, "one-shot html={html:?}");
+
+  for split in (0..=html.len()).filter(|&split| html.is_char_boundary(split)) {
+    let actual = stream_parts_with_options(&[&html[..split], &html[split..]], options.clone());
+    assert_eq!(actual, (expected.to_string(), truncated), "split={split}");
+  }
 }
 
 fn extracting(cap: usize, selectors: &[&str]) -> HTMLToMarkdownOptions {
@@ -339,6 +369,178 @@ fn the_cut_point_does_not_depend_on_chunking_above_the_flush_threshold() {
   );
 }
 
+#[test]
+fn inline_code_cap_is_aggregate_and_chunk_invariant() {
+  assert_capped_inline_code(
+    "<code><span>ab</span><span>cd</span><span>ef</span><span>gh</span><span>ij</span></code><p>after</p>",
+    8,
+    "`abcdefgh`\n\nafter",
+    true,
+  );
+}
+
+#[test]
+fn inline_code_exhaustion_is_sticky_at_a_utf8_boundary() {
+  assert_capped_inline_code(
+    "<code><span>aaaaaaa</span><span>é</span><span>z</span></code>",
+    8,
+    "`aaaaaaa`",
+    true,
+  );
+}
+
+#[test]
+fn an_exact_utf8_inline_code_cap_does_not_report_truncation() {
+  assert_capped_inline_code(
+    "<code><span>aaaaaa</span><span>é</span></code>",
+    8,
+    "`aaaaaaé`",
+    false,
+  );
+}
+
+#[test]
+fn generated_inline_code_content_consumes_the_cap() {
+  assert_capped_inline_code(
+    "<code>a<br>b<br>c<br>d<br>e</code>",
+    8,
+    "`a\nb\nc\nd\n`",
+    true,
+  );
+}
+
+#[test]
+fn inline_markers_and_spacing_consume_the_code_span_cap() {
+  assert_capped_inline_code(
+    "<code><em>abcde</em><span>x</span><span>y</span></code>",
+    8,
+    "`*abcde*x`",
+    true,
+  );
+}
+
+#[test]
+fn a_rejected_inline_marker_cannot_remove_retained_code_content() {
+  assert_capped_inline_code(
+    "<code><span>abcdefgh</span><em>x</em></code>",
+    8,
+    "`abcdefgh`",
+    true,
+  );
+}
+
+#[test]
+fn inline_code_delimiter_growth_does_not_consume_content_budget() {
+  assert_capped_inline_code(
+    "<code><span>``abcdef</span><span>g</span></code>",
+    8,
+    "``` ``abcdef ```",
+    true,
+  );
+}
+
+#[test]
+fn an_exhausted_outer_span_keeps_nested_span_state_balanced() {
+  assert_capped_inline_code(
+    "<code><span>abcdefgh</span><code>x</code><span>y</span></code><p>after</p>",
+    8,
+    "`abcdefgh`\n\nafter",
+    true,
+  );
+}
+
+#[test]
+fn a_rejected_nested_code_fence_does_not_create_invalid_state() {
+  assert_capped_inline_code(
+    "<code>abcdefgh<pre><code>x</code></pre></code><p>after</p>",
+    8,
+    "`abcdefgh`\n\nafter",
+    true,
+  );
+}
+
+#[test]
+fn an_unclosed_inline_code_span_is_finalized_after_exhaustion() {
+  assert_capped_inline_code("<code><span>abcdefgh</span><span>ij", 8, "`abcdefgh`", true);
+}
+
+#[test]
+fn link_output_cannot_grow_an_inline_code_span_past_the_cap() {
+  assert_capped_inline_code(
+    "<code><a href=x>abcdefghijklmn</a><span>z</span></code>",
+    16,
+    "`[abcdefghijklmn`",
+    true,
+  );
+}
+
+#[test]
+fn override_output_consumes_the_inline_code_span_cap() {
+  let opts = HTMLToMarkdownOptions {
+    plugins: Some(PluginConfig {
+      tag_overrides: Some(vec![(
+        "x".to_string(),
+        TagOverrideConfig::wrap("12345", "67890"),
+      )]),
+      ..Default::default()
+    }),
+    ..options(8)
+  };
+  assert_capped_inline_code_with_options(
+    "<code><x></x><span>z</span></code>",
+    opts,
+    "`12345`",
+    true,
+  );
+}
+
+#[test]
+fn frontmatter_output_cannot_escape_an_inline_code_span_cap() {
+  let opts = HTMLToMarkdownOptions {
+    plugins: Some(PluginConfig::frontmatter()),
+    ..options(8)
+  };
+  assert_capped_inline_code_with_options(
+    "<code><head><title>a</title></head></code><p>after</p>",
+    opts,
+    "after",
+    true,
+  );
+}
+
+#[test]
+fn generated_spacing_consumes_the_inline_code_span_cap() {
+  assert_capped_inline_code("<code><em>a </em>bcdefgh</code>", 8, "`*a* bcde`", true);
+}
+
+#[test]
+fn a_growing_autolink_rewrite_can_exactly_fill_the_span_cap() {
+  assert_capped_inline_code(
+    "<code><span>12345678</span><a href=http://x>http://x</a></code>",
+    19,
+    "`12345678 <http://x>`",
+    false,
+  );
+}
+
+#[test]
+fn table_pipe_escaping_respects_the_inline_code_span_cap() {
+  assert_capped_inline_code(
+    "<table><tr><td><code>a|b|c|d</code></td></tr></table>",
+    8,
+    "| `a\\|b\\|c` |\n| --- |",
+    true,
+  );
+}
+
+#[test]
+fn inline_code_truncation_is_reported_before_finish() {
+  let mut p = MarkdownStreamProcessor::new(options(8));
+  let first = p.process_chunk("<code><span>abcdefgh</span><span>ij</span></code><p>after</p>");
+  assert!(p.truncated());
+  assert_eq!(first + &p.finish(), "`abcdefgh`\n\nafter");
+}
+
 // A code fence cannot be closed until the longest backtick run inside it is known,
 // so the block pins the buffer however small its text nodes are. The cap is
 // measured against the block, not the node.
@@ -485,6 +687,13 @@ fn truncating_fixtures() -> Vec<(&'static str, String)> {
       ),
     ),
     (
+      "inline code",
+      format!(
+        "<code>{}</code>",
+        repeat_to("<span>abcdefgh</span>", 256 * 1024)
+      ),
+    ),
+    (
       "table row",
       format!(
         "<table><tr>{}</tr></table>",
@@ -602,6 +811,38 @@ fn a_code_fence_holds_at_most_the_cap() {
       content.len()
     );
   }
+}
+
+#[test]
+fn inline_code_from_many_small_nodes_stays_bounded() {
+  let html = format!("<code>{}</code>", repeat_to("<span>abcdefgh</span>", HUGE));
+  let uncapped = peak(&html, 8 * 1024, 0);
+  let capped = peak(&html, 8 * 1024, CAP);
+  assert!(
+    uncapped > (HUGE / 4) as u64,
+    "fixture should retain aggregate code uncapped, got {uncapped}"
+  );
+  assert!(
+    capped < (HUGE / 4) as u64,
+    "capped peak {capped} should be a window, not the {} byte span",
+    html.len()
+  );
+}
+
+#[test]
+fn inline_code_from_many_breaks_stays_bounded() {
+  let html = format!("<code>{}</code>", repeat_to("a<br>", HUGE));
+  let uncapped = peak(&html, 8 * 1024, 0);
+  let capped = peak(&html, 8 * 1024, CAP);
+  assert!(
+    uncapped > (HUGE / 4) as u64,
+    "fixture should retain generated breaks uncapped, got {uncapped}"
+  );
+  assert!(
+    capped < (HUGE / 4) as u64,
+    "capped peak {capped} should be a window, not the {} byte span",
+    html.len()
+  );
 }
 
 // `colspan` used to be added whole after the count check, and a nonzero `align`


### PR DESCRIPTION
## Summary
- enforce `max_node_bytes` across aggregate inline-code content, including descendant text and generated output
- make exhaustion sticky while preserving UTF-8 boundaries, nested span/fence state, valid delimiters, and following siblings
- account for links, markers, spacing, overrides, frontmatter, table pipe escaping, and structural rewrites without changing the uncapped hot path
- add exhaustive split-boundary and peak-allocation regressions

## Testing
- `cargo test --workspace --exclude mdream-edge`
- `cargo clippy --workspace --exclude mdream-edge --locked -- -D warnings -A clippy::pedantic -A clippy::nursery`
- `cargo check --workspace --locked`
- `cargo build -p mdream-edge --target wasm32-unknown-unknown`
- `rustfmt --edition 2024 --check crates/core/src/convert/mod.rs crates/core/src/convert/output.rs crates/core/src/types.rs crates/core/tests/max_node_bytes.rs`
- interleaved benchmark: 1.6 MiB default `5.20 ms` upstream vs `5.21 ms` branch; 8 KiB streaming `5.41 ms` vs `5.42 ms`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline code spans now respect the configured maximum node-size limit.
  * Size limits apply consistently to one-shot and streaming conversions.
* **Bug Fixes**
  * Improved truncation handling across links, autolinks, blockquotes, tables, frontmatter, and generated content.
  * Preserved valid UTF-8 boundaries when truncating content.
* **Tests**
  * Added coverage for inline code limits, exact-fit behavior, and streaming consistency.
* **Documentation**
  * Clarified that inline code spans and extraction reads are included in capped content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->